### PR TITLE
docs: README endpoint table + CHANGELOG for #46–#52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **PurchaseOrder + Inventory API surface** (#49, PRs #50, #51, #52):
+  Full CRUD endpoints for the four tables added by the
+  20260517000000 migration —
+  - `PurchaseOrderVendor` — direct compId scoping
+  - `PurchaseOrderHeader` — vendor-scoped via new
+    `auth.getCompanyIdByPovId()` helper
+  - `PurchaseOrderLine` — header-scoped via new
+    `auth.getCompanyIdByPohId()` helper (two-hop FK walk through
+    header → vendor)
+  - `InventoryTransaction` — direct compId scoping; `invtDirection`
+    constrained to 0 (inbound) or 1 (outbound) at the zod boundary
+- `JSON_BODY_LIMIT` env override for `express.json()` body cap
+  (#45, PRs #46 and #47). Default 100kb matches the express
+  built-in; operators can raise it (`JSON_BODY_LIMIT=512kb`) for
+  endpoints that legitimately accept larger payloads.
+
+### Changed
+- `npm audit fix` cleared 10 transitive-dep vulnerabilities
+  (dottie, moment, moment-timezone, path-to-regexp, qs, underscore,
+  validator). Direct deps bumped to latest patch within current
+  majors: express 4.21.1 → 4.22.2, pg 8.6.0 → 8.20.0,
+  express-promise-router 4.0.1 → 4.1.1, sequelize 6.6.5 → 6.37.8.
+  (PR #48; closes Snyk-backlog tracker #30; supersedes / closes
+  11 stale Snyk PRs.)
+
+### Added (earlier in this [Unreleased] window)
 - **API surface expansion** (#38, PR #39): full CRUD for ten entities
   that were in `setup/TimeTracker.sql` but lacked endpoints — Worker,
   Company, BillingType, InventoryItem, Job, Invoice, CustomerPayment,
@@ -50,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps `LICENSE` (Apache-2.0 §4(c) requires it accompany derivative
   works, including container images).
 
-### Added (earlier in [Unreleased] window)
+### Added (still earlier in this [Unreleased] window)
 - Codeberg mirror at https://codeberg.org/CryptoJones/TimeTrackerAPI;
   README now carries badges for both forges.
 - `GET /healthz` liveness + DB-readiness probe. No auth. Returns

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Working example at [node.timetrackerapi.com](http://node.timetrackerapi.com).
 | `* /v1/invoicejob/*`                | yes (`authKey`) | Invoice line items (job-scoped via `injbJobId` → Job → Customer.custCompId). `GET /byinvoice/:id` lists per invoice. |
 | `* /v1/productentry/*`              | yes (`authKey`) | Product entries consumed on a Job (job-scoped). `GET /byjob/:id` lists per job. |
 | `* /v1/versioninfo/*`               | yes (`authKey`) | Schema/build version records. Reads open to any `authKey`; mutations require a master key. `DELETE` is a hard destroy (no archive column on this table). |
+| `* /v1/purchaseordervendor/*`       | yes (`authKey`) | Vendors that POs are issued to. Direct company scoping via `povCompId`. Standard CRUD + `bycompany`. |
+| `* /v1/purchaseorderheader/*`       | yes (`authKey`) | Purchase orders. Vendor-scoped — auth resolves via `pohPovId → vendor.povCompId`. `GET /byvendor/:id` lists POs for a vendor, newest first. |
+| `* /v1/purchaseorderline/*`         | yes (`authKey`) | PO line items. Header-scoped via `polpoh → header → vendor → company`. `GET /byheader/:id` lists line items on a PO. |
+| `* /v1/inventorytransaction/*`      | yes (`authKey`) | Inventory movement log. Direct company scoping via `invtCompanyId`. `invtDirection` is `0` (inbound) or `1` (outbound). PATCH/DELETE exposed for surface parity; audit-grade deployments may want to disable them at the proxy. |
 
 Every v1 request must include the API key in the `authKey` HTTP header.
 The `/healthz` endpoint is intentionally unauthenticated so it can be


### PR DESCRIPTION
Continues the docs-sync housekeeping pattern from #44.

- README: appends rows for the four PurchaseOrder/Inventory entities (#50, #51, #52)
- CHANGELOG `[Unreleased]`: entries for #45/#46/#47 (body-size limit), #30/#48 (dep audit + Snyk triage), #49/#50/#51/#52 (PurchaseOrder + Inventory rollout)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/