### PR TITLE
docs: integration-test bring-up flow + commit compose override

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,32 @@ The server listens on `http://0.0.0.0:3000` by default. No root required.
 
 ---
 
+## Testing
+
+```bash
+npm test          # unit + API suite (mocks the DB; no infra needed)
+npm test -- --watch    # vitest watch mode
+```
+
+For integration tests against a real Postgres — see
+[`tests/integration/README.md`](tests/integration/README.md).
+Short version:
+
+```bash
+cp .env.example .env   # set DB_PASSWORD
+sudo docker compose up -d postgres setup migrate
+DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker \
+    DB_USERNAME=timetracker DB_PASSWORD=$(grep ^DB_PASSWORD= .env | cut -d= -f2-) \
+    npx vitest run tests/integration
+sudo docker compose down -v   # cleanup
+```
+
+The committed `docker-compose.override.yml` exposes Postgres on
+`127.0.0.1:5432` for these host-side test runs; without it the
+postgres container is reachable only from other compose services.
+
+---
+
 ## Environment variables
 
 All configuration lives in environment variables (loaded from `.env`

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+# Local-only override for integration testing. Exposes Postgres on
+# 127.0.0.1:5432 so the host-side vitest integration suite can reach
+# it. NOT for production / shared environments — leaving 5432 open
+# on a public host is a credential-brute-force invitation.
+#
+# This file is local; do not commit. The .dockerignore already
+# excludes it from the runtime image build context.
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5432:5432"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -4,20 +4,54 @@ These tests hit a **real PostgreSQL database**, not the mocked one
 the unit/API tests use. They verify Sequelize models, the migration
 chain, and the full HTTP → DB round-trip that the mocks can't cover.
 
-## Running them
+## Quick bring-up (docker compose)
+
+The repo ships a `docker-compose.override.yml` that exposes
+Postgres on `127.0.0.1:5432` for host-side test runs. Without
+the override, the `postgres` service is reachable only from
+other compose services (deliberate hardening for production).
 
 ```bash
-# 1. Bring up a Postgres on localhost:5432 (any method).
-docker compose up -d postgres setup
+# 1. .env must define DB_PASSWORD. Copy from .env.example and set
+#    something. Any value is fine — this is a throwaway DB.
+cp .env.example .env
+# edit .env: set DB_PASSWORD=…
 
-# 2. Apply migrations on top of the SQL bootstrap.
-npm run migrate
+# 2. Bring up the stack. The override auto-applies because docker
+#    compose loads docker-compose.override.yml by default.
+sudo docker compose up -d postgres setup migrate
+sudo docker compose ps -a   # postgres: healthy, setup/migrate: Exited (0)
 
-# 3. Run the integration suite.
-DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker \
-    DB_USERNAME=timetracker DB_PASSWORD=... \
-    npx vitest run tests/integration
+# 3. Run the integration suite with DB vars set.
+export DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker DB_USERNAME=timetracker
+export DB_PASSWORD=$(grep '^DB_PASSWORD=' .env | cut -d= -f2-)
+npx vitest run tests/integration
+
+# 4. Tear down when done. `-v` removes the volume so the next
+#    bring-up starts from an empty schema (see "Known gotchas").
+sudo docker compose down -v
 ```
+
+## Known gotchas
+
+- **`setup` exits 3 on re-run against a populated volume.** The
+  `setup/TimeTracker.sql` script does an unconditional
+  `CREATE SCHEMA dbo` which fails if the schema already exists.
+  Workaround: `docker compose down -v` before re-running. (Tracker
+  for the idempotency fix is filed as a separate issue.)
+- **`docker-compose.override.yml` opens port 5432 on the host.**
+  Fine for local dev; do not push the override file's port
+  binding to a public host without firewall rules — Postgres on
+  the open internet is a credential-brute-force invitation.
+
+## Without docker
+
+Any reachable Postgres works — set the four `DB_*` env vars and
+make sure `setup/TimeTracker.sql` + `setup/TimeEntry.sql` + the
+migrations have been applied. The tests don't care how the DB
+got there.
+
+## Skip behavior
 
 Tests **automatically skip** when:
 - `DB_PASSWORD` is empty / unset, or
@@ -29,10 +63,10 @@ clean against the mock without needing a live database.
 ## Conventions
 
 - Every integration test must clean up rows it inserts. Use a
-  unique sentinel value (e.g. `_integ_test_${Date.now()}`) so a
+  unique sentinel value (e.g. `_integ_<pid>_<timestamp>`) so a
   bad cleanup doesn't poison subsequent runs.
 - Never run integration tests against a production database.
   The cleanup pattern is defensive but not bulletproof.
-- Tests are intentionally narrow — they verify the
-  bridge between Sequelize, the schema, and the HTTP layer.
+- Tests are intentionally narrow — they verify the bridge
+  between Sequelize, the schema, and the HTTP layer.
   Heavyweight behavior testing belongs in the mocked API tests.


### PR DESCRIPTION
Follow-up to #55, which shipped the harness but not the operational doc for actually running it. After driving the full bring-up against a live PG this session, three missing pieces became clear:

1. **`docker-compose.override.yml`** committed: exposes 127.0.0.1:5432 for host-side test runs. The base compose deliberately keeps PG internal; the override is opt-in for the test path.
2. **`down -v` step documented**: `setup/TimeTracker.sql`'s unconditional `CREATE SCHEMA dbo` blows up against a populated volume (exit 3). Workaround documented; a follow-up issue tracks the idempotency fix.
3. **Exact env-var shape** for the integration suite spelled out.

README gets a short Testing section. `tests/integration/README.md` rewritten end-to-end.

## Test plan
- [x] Override file rebuilds the compose graph correctly (verified via `docker compose config`)
- [x] Following the documented bring-up against a fresh volume: postgres healthy, setup Exited(0), migrate Exited(0), vitest integration suite 4/4 green this session
- [x] `npm test` (without DB env vars) still passes; the integration suite skips cleanly

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/