### PR TITLE
fix(setup): make TimeTracker.sql idempotent against an existing schema

### DIFF
--- a/setup/TimeTracker.sql
+++ b/setup/TimeTracker.sql
@@ -17,6 +17,26 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Idempotency guard. If the dbo schema already exists, treat this
+-- bootstrap script as a no-op rather than failing on CREATE SCHEMA.
+-- That makes \`docker compose up\` survive re-runs against a populated
+-- postgres-data volume without needing \`down -v\` first.
+--
+-- The rest of the file is pg_dump output that wasn't authored with
+-- idempotency in mind (CREATE TABLE without IF NOT EXISTS, ALTER
+-- TABLE ADD CONSTRAINT which has no IF NOT EXISTS form, etc.).
+-- Rather than retrofit IF NOT EXISTS to ~40 statements piecemeal,
+-- we gate the whole file on whether the schema is already present.
+--
+SELECT EXISTS (
+    SELECT 1 FROM information_schema.schemata WHERE schema_name = 'dbo'
+) AS dbo_exists \gset
+\if :dbo_exists
+\echo 'dbo schema already exists — setup/TimeTracker.sql is a no-op'
+\q
+\endif
+
+--
 -- Name: dbo; Type: SCHEMA; Schema: -; Owner: timetracker
 --
 


### PR DESCRIPTION
Fixes the `docker compose down -v` papercut documented in #56.

## The bug
`setup/TimeTracker.sql` is pg_dump output that does an unconditional `CREATE SCHEMA dbo` at line 23. Against a populated postgres volume (the common case on re-runs), psql exits 3 — and because the compose `migrate` service `depends_on` setup completing successfully, the entire bring-up chain breaks.

## The fix
Gate the file with a psql `\if` check on `information_schema.schemata`. If the dbo schema already exists, print "no-op" and `\q` (exit 0). Otherwise, the rest of the pg_dump body runs exactly as before.

Picked over the alternative of retrofitting `IF NOT EXISTS` to every statement because `ALTER TABLE ADD CONSTRAINT` has no `IF NOT EXISTS` form — the file would still fail mid-way through.

## Test plan
- [x] Against live PG with dbo schema present: psql exits 0 with the "no-op" message
- [x] Against live PG after `DROP SCHEMA dbo CASCADE`: fresh bootstrap runs to completion, 14 tables created
- [x] Immediate re-run after fresh bootstrap: no-op, exit 0
- [x] Doesn't disturb the migrate service that runs after — that's a separate Sequelize-CLI invocation

After this lands, the `down -v` step in the integration-test docs can be removed.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/