### PR TITLE
feat(deploy): optional Caddy TLS reverse-proxy compose layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,20 @@ HOST=0.0.0.0
 #   CORS_ORIGIN=https://app.example.com,https://admin.example.com
 CORS_ORIGIN=
 
+# ---- TLS reverse proxy (optional, docker-compose.tls.yml) ----
+
+# Domain Caddy provisions a Let's Encrypt cert for. Set to your real
+# FQDN in production, or 'localhost' for a self-signed cert (Caddy's
+# built-in CA — your browser will warn, but the wiring is identical
+# for HSTS / cookie-secure testing).
+#
+# Required if you bring up docker-compose.tls.yml; ignored otherwise.
+# TLS_DOMAIN=node.timetrackerapi.com
+
+# Email forwarded to Let's Encrypt for cert-expiry notices. Optional
+# but recommended in production.
+# TLS_EMAIL=ops@example.com
+
 # ---- PostgreSQL ----
 
 DB_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ npm start
 
 The server listens on `http://0.0.0.0:3000` by default. No root required.
 
+### Behind TLS (production)
+
+The repo ships an opt-in TLS reverse-proxy layer using Caddy in
+`docker-compose.tls.yml`. Caddy handles automatic Let's Encrypt
+provisioning + renewal, HTTP→HTTPS redirect, and HTTP/2 +
+HTTP/3 on :443. The api service is rebound off the host port so
+Caddy is the only thing the public reaches.
+
+```bash
+# In .env: set DB_PASSWORD, TLS_DOMAIN (your FQDN), and TLS_EMAIL.
+sudo docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.tls.yml \
+    up -d
+```
+
+For local TLS testing set `TLS_DOMAIN=localhost`; Caddy uses its
+built-in CA (self-signed) instead of ACME. Don't combine
+`docker-compose.tls.yml` with `docker-compose.override.yml` on a
+public host — the override exposes Postgres on :5432.
+
 ---
 
 ## Testing

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
+#
+# Caddy v2 configuration for TimeTrackerAPI's TLS reverse-proxy
+# layer. Loaded by the `caddy` service in docker-compose.tls.yml.
+#
+# Behavior:
+#   - {$TLS_DOMAIN} interpolates from the env (must be set).
+#   - {$TLS_EMAIL} is forwarded to Let's Encrypt for renewal notices.
+#   - HTTP traffic on :80 redirects to HTTPS (Caddy default behavior).
+#   - HTTPS terminates here; backend api at api:3000 is plain HTTP
+#     inside the compose network.
+#   - HSTS is on by default in Caddy (max-age=31536000) — kept.
+#   - Access logs go to stdout for `docker compose logs`.
+#
+# Local-dev / self-signed mode: set TLS_DOMAIN=localhost. Caddy will
+# use its built-in CA, no ACME calls, and the browser will warn on
+# first visit. Fine for testing the wiring.
+
+{
+    # Global options.
+    email {$TLS_EMAIL}
+    # Uncomment for staging cert during cutover testing — limits
+    # ACME rate-limit pain if something is misconfigured.
+    # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+}
+
+{$TLS_DOMAIN} {
+    reverse_proxy api:3000 {
+        # Standard X-Forwarded-* headers so the app's TRUST_PROXY
+        # path can identify the real client IP for rate-limiting.
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up Host {host}
+    }
+
+    # Compress responses. Skip for /openapi.json since it's already
+    # small and aggressive compression on JSON adds a few ms.
+    encode gzip
+
+    # Structured access logs to stdout.
+    log {
+        output stdout
+        format console
+    }
+}

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
+#
+# Optional TLS reverse-proxy layer. Puts Caddy in front of the api
+# service so production deployments get:
+#   - automatic Let's Encrypt cert provisioning + renewal (ACME)
+#   - HTTP → HTTPS redirect on :80
+#   - HTTP/2 + HTTPS on :443
+#   - rate-limit-friendly logging
+#
+# Usage (production):
+#
+#   cp .env.example .env
+#   # edit .env: set DB_PASSWORD + TLS_DOMAIN + TLS_EMAIL
+#   sudo docker compose \
+#       -f docker-compose.yml \
+#       -f docker-compose.tls.yml \
+#       up -d
+#
+# The api service is rebound to localhost-only inside the compose
+# network — Caddy is the only thing the public hits. Don't combine
+# this file with docker-compose.override.yml (which exposes Postgres
+# on 5432) on a public host.
+#
+# For local TLS (self-signed cert), set TLS_DOMAIN=localhost. Caddy
+# will skip ACME and use its internal CA — your browser will warn,
+# but the wiring is identical to the prod path. Useful for testing
+# HSTS / cookie-secure / SameSite behavior end-to-end.
+
+services:
+  # Remove the host port binding from api — Caddy reaches it via
+  # the compose network. Removes the api as a directly-reachable
+  # service from outside the box.
+  api:
+    ports: !reset []
+    environment:
+      # Tell the app it's behind a proxy so X-Forwarded-For
+      # propagation works for rate-limit + access logs.
+      TRUST_PROXY: "true"
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"   # HTTP/3
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data         # ACME certs + state
+      - caddy-config:/config
+    environment:
+      TLS_DOMAIN: ${TLS_DOMAIN:?TLS_DOMAIN must be set (FQDN or 'localhost')}
+      TLS_EMAIL:  ${TLS_EMAIL:-}
+    healthcheck:
+      # Hit Caddy's admin endpoint to verify it's up. Bound to
+      # localhost inside the container; not exposed externally.
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:2019/config/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  caddy-data:
+  caddy-config:


### PR DESCRIPTION
## Summary
Adds opt-in `docker-compose.tls.yml` + `caddy/Caddyfile` so production deployments can terminate TLS without manual cert wrangling. Caddy handles ACME, redirect, HSTS, X-Forwarded-* headers, and gzip out of the box.

```bash
sudo docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
```

`.env.example` gets `TLS_DOMAIN` + `TLS_EMAIL` documented. README gets a "Behind TLS (production)" subsection.

For local TLS dev (HSTS, secure-cookie testing): set `TLS_DOMAIN=localhost` and Caddy uses its built-in self-signed CA — no ACME.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.tls.yml config` validates clean
- [x] `api` rebinds off the host port when layered with tls.yml (verified in `config` output)
- [ ] Live ACME bring-up against a real FQDN (not run — no test domain pointing at this host)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/