### PR TITLE
fix(tests): replace brittle '.not.toBe(404)' with body-shape assertion

### DIFF
--- a/tests/api/billingtype.test.js
+++ b/tests/api/billingtype.test.js
@@ -62,7 +62,8 @@ describe('BillingType auth contract', () => {
 describe('BillingType route mounting', () => {
     test('routes are mounted (not 404)', async () => {
         const res = await request(app).get('/v1/billingtype/1').set('authKey', 'any');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/company.test.js
+++ b/tests/api/company.test.js
@@ -66,11 +66,13 @@ describe('Company auth contract', () => {
 describe('Company route mounting', () => {
     test('GET /v1/company/:id mounted (not 404)', async () => {
         const res = await request(app).get('/v1/company/1').set('authKey', 'any');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
     test('GET /v1/company mounted', async () => {
         const res = await request(app).get('/v1/company').set('authKey', 'any');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/customer-bycompany.test.js
+++ b/tests/api/customer-bycompany.test.js
@@ -44,7 +44,8 @@ describe('GET /v1/customer/bycompany/:id', () => {
         const res = await request(app)
             .get('/v1/customer/bycompany/1')
             .set('authKey', 'anything');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     // Regression for #3. Previously this endpoint had no auth check and

--- a/tests/api/customer-create.test.js
+++ b/tests/api/customer-create.test.js
@@ -50,7 +50,8 @@ describe('POST /v1/customer', () => {
             .post('/v1/customer')
             .set('authKey', 'anything')
             .send({});
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
         expect(res.status).not.toBe(405);
     });
 

--- a/tests/api/customer.test.js
+++ b/tests/api/customer.test.js
@@ -52,7 +52,8 @@ describe('GET /v1/customer/:id', () => {
         const res = await request(app)
             .get('/v1/customer/123')
             .set('authKey', 'anything');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     // Regression: previously the master-key branch sent a response inside

--- a/tests/api/customerpayment.test.js
+++ b/tests/api/customerpayment.test.js
@@ -40,7 +40,9 @@ describe('CustomerPayment auth contract', () => {
 
 describe('CustomerPayment route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/customerpayment/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/customerpayment/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/inventoryitem.test.js
+++ b/tests/api/inventoryitem.test.js
@@ -55,7 +55,8 @@ describe('InventoryItem auth contract', () => {
 describe('InventoryItem route mounting', () => {
     test('routes mounted (not 404)', async () => {
         const res = await request(app).get('/v1/inventoryitem/1').set('authKey', 'any');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/inventorytransaction.test.js
+++ b/tests/api/inventorytransaction.test.js
@@ -43,7 +43,9 @@ describe('InventoryTransaction auth contract', () => {
 
 describe('InventoryTransaction route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/inventorytransaction/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/inventorytransaction/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/invoice.test.js
+++ b/tests/api/invoice.test.js
@@ -41,7 +41,9 @@ describe('Invoice auth contract', () => {
 
 describe('Invoice route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/invoice/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/invoice/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/invoicejob.test.js
+++ b/tests/api/invoicejob.test.js
@@ -43,7 +43,9 @@ describe('InvoiceJob auth contract', () => {
 
 describe('InvoiceJob route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/invoicejob/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/invoicejob/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/job.test.js
+++ b/tests/api/job.test.js
@@ -41,7 +41,9 @@ describe('Job auth contract', () => {
 
 describe('Job route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/job/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/job/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/productentry.test.js
+++ b/tests/api/productentry.test.js
@@ -41,7 +41,9 @@ describe('ProductEntry auth contract', () => {
 
 describe('ProductEntry route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/productentry/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/productentry/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/purchaseorderheader.test.js
+++ b/tests/api/purchaseorderheader.test.js
@@ -46,7 +46,9 @@ describe('PurchaseOrderHeader auth contract', () => {
 
 describe('PurchaseOrderHeader route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/purchaseorderheader/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/purchaseorderheader/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/purchaseorderline.test.js
+++ b/tests/api/purchaseorderline.test.js
@@ -45,7 +45,9 @@ describe('PurchaseOrderLine auth contract', () => {
 
 describe('PurchaseOrderLine route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/purchaseorderline/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/purchaseorderline/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/purchaseordervendor.test.js
+++ b/tests/api/purchaseordervendor.test.js
@@ -44,7 +44,9 @@ describe('PurchaseOrderVendor auth contract', () => {
 
 describe('PurchaseOrderVendor route mounting', () => {
     test('routes mounted', async () => {
-        expect((await request(app).get('/v1/purchaseordervendor/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/purchaseordervendor/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/timeentry.test.js
+++ b/tests/api/timeentry.test.js
@@ -37,27 +37,32 @@ beforeAll(async () => {
 describe('/v1/timeentry routing', () => {
     test('POST /v1/timeentry route is mounted', async () => {
         const res = await request(app).post('/v1/timeentry').send({});
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('GET /v1/timeentry/:id route is mounted', async () => {
         const res = await request(app).get('/v1/timeentry/1');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('GET /v1/timeentry/bycompany/:id route is mounted', async () => {
         const res = await request(app).get('/v1/timeentry/bycompany/1');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('PATCH /v1/timeentry/:id route is mounted', async () => {
         const res = await request(app).patch('/v1/timeentry/1').send({});
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('DELETE /v1/timeentry/:id route is mounted', async () => {
         const res = await request(app).delete('/v1/timeentry/1');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/versioninfo.test.js
+++ b/tests/api/versioninfo.test.js
@@ -53,10 +53,14 @@ describe('VersionInfo auth contract', () => {
 
 describe('VersionInfo route mounting', () => {
     test('GET /v1/versioninfo/:id mounted', async () => {
-        expect((await request(app).get('/v1/versioninfo/1').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/versioninfo/1').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
     test('GET /v1/versioninfo mounted', async () => {
-        expect((await request(app).get('/v1/versioninfo').set('authKey', 'any')).status).not.toBe(404);
+        const _r = await request(app).get('/v1/versioninfo').set('authKey', 'any');
+        expect(_r.body).toBeTypeOf('object');
+        expect(_r.body.message).toBeDefined();
     });
 });
 

--- a/tests/api/worker.test.js
+++ b/tests/api/worker.test.js
@@ -79,7 +79,8 @@ describe('Worker route mounting (regression)', () => {
         const res = await request(app)
             .get('/v1/worker/1')
             .set('authKey', 'any');
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('POST /v1/worker is mounted', async () => {
@@ -93,7 +94,8 @@ describe('Worker route mounting (regression)', () => {
                 workerDefaultBillType: 1,
                 workerCompId: 1,
             });
-        expect(res.status).not.toBe(404);
+        expect(res.body).toBeTypeOf('object');
+        expect(res.body.message).toBeDefined();
     });
 
     test('controller exits with a single well-formed response', async () => {


### PR DESCRIPTION
## The bug
The "routes mounted" tests in 18 API test files asserted `res.status !== 404` — which passed for the wrong reason. The `vi.mock` on `db.config.js` never actually intercepted the nested CJS `require()` chain inside the controllers, so the controllers' real Sequelize call hit either:
- **no DB env vars** → SCRAM error → controller's try/catch → 500 → `500 !== 404` → green-but-meaningless
- **DB env vars set + reachable PG** → real query returns no row → controller's 404 path → `404 === 404` → red

So the tests had always been pseudo-passing, and an actual DB connection surfaced the brittleness.

## The fix
Stop depending on the mock for these tests. Switch from "status isn't 404" to "body came from our handler" (JSON with a `.message` field). Express's default 404 is HTML, so this still distinguishes "route mounted" from "express fall-through."

```js
const _r = await request(app).get('/v1/foo/1').set('authKey', 'any');
expect(_r.body).toBeTypeOf('object');
expect(_r.body.message).toBeDefined();
```

`healthz.test.js` is left alone — its response shape is different (`status: 'ok'`, no `message`) and its handler doesn't hit Sequelize.

## Test plan
- [x] vitest with no DB env: 29 passed | 1 skipped (integration), 223+4 tests
- [x] vitest with DB env pointing at the running compose postgres: 30 passed, 227 tests
- [x] No more "expected 404 not to be 404" flake when env vars are set

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/