### PR TITLE
fix(router): timeentry/export.csv must come before /:id

### DIFF
--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -101,6 +101,13 @@ router.post(
     v.body(timeEntrySchemas.createTimeEntryBody),
     timeEntry.create,
 );
+// Literal paths declared BEFORE /:id so express doesn't try to
+// parse "export.csv" / "bycompany" as a customer id.
+router.get(
+    '/v1/timeentry/export.csv',
+    v.query(timeEntrySchemas.exportCsvQuery),
+    timeEntry.exportCsv,
+);
 router.get(
     '/v1/timeentry/bycompany/:id',
     v.params(timeEntrySchemas.intIdParam),
@@ -122,11 +129,6 @@ router.delete(
     '/v1/timeentry/:id',
     v.params(timeEntrySchemas.intIdParam),
     timeEntry.remove,
-);
-router.get(
-    '/v1/timeentry/export.csv',
-    v.query(timeEntrySchemas.exportCsvQuery),
-    timeEntry.exportCsv,
 );
 
 // v1 worker routes.


### PR DESCRIPTION
Hot follow-up to #68. The new `/v1/timeentry/export.csv` route was placed AFTER the existing `/v1/timeentry/:id` block, so express matched `:id`-with-"export.csv" first, intIdParam failed coercion to a number, and the export handler was never reached. The 403-on-missing-authKey test was failing as a result.

Reorders so the literal path wins, matching the `search-before-:id` convention already used for `/v1/customer/search` (#64).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/