### PR TITLE
fix(security): redact secret query params from req.url before log

### DIFF
--- a/app/middleware/redact-url.js
+++ b/app/middleware/redact-url.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * URL-redaction helper used by the pino-http request serializer.
+ *
+ * The authKey header is already covered by logger.js's redact paths
+ * (`req.headers.authkey`, etc.), but `req.url` is logged verbatim
+ * via the serializer and may still contain the raw token if an SDK
+ * mistakenly puts it in the query string (e.g.
+ * `GET /v1/customer/5?authKey=...`). This function strips a small
+ * allowlist of known-sensitive query params before the URL hits the
+ * structured log.
+ *
+ * Pattern matching is case-insensitive on the param name and
+ * preserves the rest of the URL (path, ordering, other params).
+ */
+
+const SENSITIVE_PARAM_NAMES = new Set([
+    'authkey',
+    'apikey',
+    'api_key',
+    'token',
+    'access_token',
+    'password',
+    'secret',
+]);
+
+function redactUrl(url) {
+    if (typeof url !== 'string' || url.length === 0) return url;
+    const qIdx = url.indexOf('?');
+    if (qIdx === -1) return url;
+
+    const path = url.slice(0, qIdx);
+    const qs = url.slice(qIdx + 1);
+
+    // Hand-roll the parse to avoid pulling in URL/URLSearchParams.
+    // URLSearchParams would also work but reorders / normalizes
+    // params which complicates log diffing.
+    const parts = qs.split('&');
+    const out = [];
+    for (const part of parts) {
+        if (part.length === 0) continue;
+        const eq = part.indexOf('=');
+        const rawName = eq === -1 ? part : part.slice(0, eq);
+        const name = decodeURIComponent(rawName).toLowerCase();
+        if (SENSITIVE_PARAM_NAMES.has(name)) {
+            out.push(`${rawName}=<REDACTED>`);
+        } else {
+            out.push(part);
+        }
+    }
+    return out.length > 0 ? `${path}?${out.join('&')}` : path;
+}
+
+module.exports = { redactUrl, SENSITIVE_PARAM_NAMES };

--- a/server.js
+++ b/server.js
@@ -57,10 +57,13 @@ app.use(pinoHttp({
     serializers: {
         req: (req) => ({
             method: req.method,
-            url: req.url,
+            // url is redacted at the serializer boundary — if an SDK
+            // mistakenly puts the authKey in the query string instead
+            // of the header, the raw value still doesn't land in the
+            // structured log. Header values are separately covered by
+            // logger.js's redact paths.
+            url: require('./app/middleware/redact-url.js').redactUrl(req.url),
             remoteAddress: req.remoteAddress,
-            // headers intentionally omitted — see logger.js redact paths
-            // for the authKey defense-in-depth.
         }),
     },
 }));

--- a/tests/unit/redact-url.test.js
+++ b/tests/unit/redact-url.test.js
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { redactUrl, SENSITIVE_PARAM_NAMES } from '../../app/middleware/redact-url.js';
+
+describe('redactUrl', () => {
+    test('returns the URL unchanged if there is no query string', () => {
+        expect(redactUrl('/v1/customer/1')).toBe('/v1/customer/1');
+    });
+
+    test('returns the URL unchanged if no sensitive param is present', () => {
+        expect(redactUrl('/v1/customer?limit=10&offset=0')).toBe('/v1/customer?limit=10&offset=0');
+    });
+
+    test('redacts authKey value but keeps the param name', () => {
+        const out = redactUrl('/v1/customer/1?authKey=abc-secret-token');
+        expect(out).toBe('/v1/customer/1?authKey=<REDACTED>');
+    });
+
+    test('redacts case-insensitively', () => {
+        expect(redactUrl('/x?AUTHKEY=abc')).toBe('/x?AUTHKEY=<REDACTED>');
+        expect(redactUrl('/x?authkey=abc')).toBe('/x?authkey=<REDACTED>');
+        expect(redactUrl('/x?AuthKey=abc')).toBe('/x?AuthKey=<REDACTED>');
+    });
+
+    test('redacts every sensitive alias', () => {
+        for (const name of SENSITIVE_PARAM_NAMES) {
+            const out = redactUrl(`/x?${name}=secretvalue`);
+            expect(out).not.toContain('secretvalue');
+            expect(out).toContain('<REDACTED>');
+        }
+    });
+
+    test('preserves non-sensitive params next to a sensitive one', () => {
+        const out = redactUrl('/v1/x?limit=10&authKey=abc&offset=0');
+        expect(out).toBe('/v1/x?limit=10&authKey=<REDACTED>&offset=0');
+    });
+
+    test('handles multiple sensitive params', () => {
+        const out = redactUrl('/x?token=t1&apiKey=t2&q=safe');
+        expect(out).toBe('/x?token=<REDACTED>&apiKey=<REDACTED>&q=safe');
+    });
+
+    test('handles param with empty value', () => {
+        expect(redactUrl('/x?authKey=')).toBe('/x?authKey=<REDACTED>');
+    });
+
+    test('handles bare param without =', () => {
+        // `?authKey` alone (no value) — still a leak vector? No, but
+        // we should normalize for predictability.
+        const out = redactUrl('/x?authKey');
+        // Either format is acceptable as long as the param name is
+        // detected. Our implementation appends =<REDACTED>.
+        expect(out).toBe('/x?authKey=<REDACTED>');
+    });
+
+    test('handles URL-encoded param names', () => {
+        // `authKey` could arrive percent-encoded; decode for matching.
+        // (We don't construct this URL ourselves but a client might.)
+        const out = redactUrl('/x?auth%4Bey=abc');  // 'authKey' with %4B (K) — case-y but valid
+        // Implementation decodeURIComponents the name; result depends.
+        // Just verify the raw secret doesn't appear in the output.
+        expect(out).not.toContain('abc');
+    });
+
+    test('non-string input returns input unchanged (defensive)', () => {
+        expect(redactUrl(undefined)).toBe(undefined);
+        expect(redactUrl(null)).toBe(null);
+        expect(redactUrl(42)).toBe(42);
+    });
+});


### PR DESCRIPTION
Closes #73 P1-C.

## Problem
logger.js redacts the `authKey` HTTP header but pino-http's `req` serializer logs `req.url` verbatim. An SDK that mistakenly sends `?authKey=...` in the URL leaks the raw token to the structured log stream + log shippers.

## Fix
New `app/middleware/redact-url.js` strips a sensitive-param allowlist (authKey, apiKey, api_key, token, access_token, password, secret) from the query string before the URL hits the logger. Path + ordering + non-sensitive params preserved for log analytics.

## Test plan
- [x] vitest: 291 + 4 integration skipped (was 280 + 4 skipped); 11 new redact-url cases
- [x] Case-insensitive match (`AuthKey`, `authkey`, `AUTHKEY`)
- [x] Every alias in the sensitive set
- [x] Mixed sensitive + non-sensitive params keep order

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/