### PR TITLE
feat(models): defaultScope filters archived rows on every soft-deletable model (P2-E)

### DIFF
--- a/app/models/apikey.model.js
+++ b/app/models/apikey.model.js
@@ -30,7 +30,8 @@ module.exports = (sequelize, Sequelize) => {
     },
         {
             tableName: 'ApiKey',
-            timestamps: false
+            timestamps: false,
+            defaultScope: { where: { akArchive: false } }
         }
     );
     return ApiKey;

--- a/app/models/apimaster.model.js
+++ b/app/models/apimaster.model.js
@@ -25,7 +25,8 @@ module.exports = (sequelize, Sequelize) => {
     },
         {
             tableName: 'ApiMaster',
-            timestamps: false
+            timestamps: false,
+            defaultScope: { where: { amArchive: false } }
         }
     );
 

--- a/app/models/billingtype.model.js
+++ b/app/models/billingtype.model.js
@@ -38,6 +38,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'BillingType',
         timestamps: false,
+        defaultScope: { where: { btArch: false } }
     });
 
     return BillingType;

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -38,6 +38,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'Company',
         timestamps: false,
+        defaultScope: { where: { compArch: false } }
     });
 
     return Company;

--- a/app/models/customer.model.js
+++ b/app/models/customer.model.js
@@ -66,7 +66,8 @@ module.exports = (sequelize, Sequelize) => {
     },
         {
             tableName: 'Customer',
-            timestamps: false
+            timestamps: false,
+            defaultScope: { where: { custArch: false } }
         }
     );
 

--- a/app/models/customerpayment.model.js
+++ b/app/models/customerpayment.model.js
@@ -42,6 +42,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'CustomerPayment',
         timestamps: false,
+        defaultScope: { where: { cpayArch: false } }
     });
 
     return CustomerPayment;

--- a/app/models/inventoryitem.model.js
+++ b/app/models/inventoryitem.model.js
@@ -40,6 +40,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'InventoryItem',
         timestamps: false,
+        defaultScope: { where: { invitArch: false } }
     });
 
     return InventoryItem;

--- a/app/models/inventorytransaction.model.js
+++ b/app/models/inventorytransaction.model.js
@@ -27,6 +27,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'InventoryTransactions',
         timestamps: false,
+        defaultScope: { where: { invtArch: false } }
     });
 
     return InventoryTransaction;

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -46,6 +46,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'Invoice',
         timestamps: false,
+        defaultScope: { where: { invArch: false } }
     });
 
     return Invoice;

--- a/app/models/invoicejob.model.js
+++ b/app/models/invoicejob.model.js
@@ -42,6 +42,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'InvoiceJob',
         timestamps: false,
+        defaultScope: { where: { injbArch: false } }
     });
 
     return InvoiceJob;

--- a/app/models/job.model.js
+++ b/app/models/job.model.js
@@ -40,6 +40,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'Job',
         timestamps: false,
+        defaultScope: { where: { jobArch: false } }
     });
 
     return Job;

--- a/app/models/productentry.model.js
+++ b/app/models/productentry.model.js
@@ -46,6 +46,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'ProductEntry',
         timestamps: false,
+        defaultScope: { where: { penArch: false } }
     });
 
     return ProductEntry;

--- a/app/models/purchaseorderheader.model.js
+++ b/app/models/purchaseorderheader.model.js
@@ -23,6 +23,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'PurchaseOrderHeaders',
         timestamps: false,
+        defaultScope: { where: { pohArch: false } }
     });
 
     return PurchaseOrderHeader;

--- a/app/models/purchaseorderline.model.js
+++ b/app/models/purchaseorderline.model.js
@@ -29,6 +29,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'PurchaseOrderLines',
         timestamps: false,
+        defaultScope: { where: { polArch: false } }
     });
 
     return PurchaseOrderLine;

--- a/app/models/purchaseordervendor.model.js
+++ b/app/models/purchaseordervendor.model.js
@@ -36,6 +36,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'PurchaseOrderVendors',
         timestamps: false,
+        defaultScope: { where: { povArch: false } }
     });
 
     return PurchaseOrderVendor;

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -66,6 +66,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'TimeEntry',
         timestamps: false,
+        defaultScope: { where: { teArch: false } }
     });
 
     return TimeEntry;

--- a/app/models/worker.model.js
+++ b/app/models/worker.model.js
@@ -55,6 +55,7 @@ module.exports = (sequelize, Sequelize) => {
     }, {
         tableName: 'Worker',
         timestamps: false,
+        defaultScope: { where: { workerArch: false } }
     });
 
     return Worker;

--- a/tests/unit/default-scope.test.js
+++ b/tests/unit/default-scope.test.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Verifies every soft-deletable model carries a defaultScope that
+// filters out archived rows. The scope is the load-bearing piece of
+// the P2-E refactor — without it the per-controller `<arch>: false`
+// filters are no longer the single source of truth, and any future
+// query that forgets the filter would silently include archived rows.
+
+import { describe, test, expect } from 'vitest';
+
+const db = require('../../app/config/db.config.js');
+
+// Model → archive column. VersionInfo is intentionally excluded — it
+// has no soft-delete semantics (it's a single-row schema-version row).
+const ARCHIVE_COLUMNS = {
+    ApiKey:               'akArchive',
+    ApiMaster:            'amArchive',
+    BillingType:          'btArch',
+    Company:              'compArch',
+    Customer:             'custArch',
+    CustomerPayment:      'cpayArch',
+    InventoryItem:        'invitArch',
+    InventoryTransaction: 'invtArch',
+    InvoiceJob:           'injbArch',
+    Invoice:              'invArch',
+    Job:                  'jobArch',
+    ProductEntry:         'penArch',
+    PurchaseOrderHeader:  'pohArch',
+    PurchaseOrderLine:    'polArch',
+    PurchaseOrderVendor:  'povArch',
+    TimeEntry:            'teArch',
+    Worker:               'workerArch',
+};
+
+describe('defaultScope: every soft-deletable model filters archived rows by default', () => {
+    test.each(Object.entries(ARCHIVE_COLUMNS))(
+        '%s carries defaultScope filtering %s = false',
+        (modelName, archCol) => {
+            const model = db[modelName];
+            expect(model, `${modelName} should be defined`).toBeDefined();
+
+            // Sequelize stores the resolved default scope on
+            // `model.options.defaultScope` (and also exposes it via the
+            // private `_scope` after a fresh model load).
+            const ds = model.options && model.options.defaultScope;
+            expect(ds, `${modelName} should have a defaultScope`).toBeDefined();
+            expect(ds.where, `${modelName}.defaultScope.where should be set`).toBeDefined();
+            expect(ds.where[archCol]).toBe(false);
+        },
+    );
+
+    test('VersionInfo has no defaultScope (no soft-delete column)', () => {
+        const ds = db.VersionInfo
+            && db.VersionInfo.options
+            && db.VersionInfo.options.defaultScope;
+        // Either undefined or an empty object — both are fine. The
+        // intent of this test is to document that VersionInfo is
+        // deliberately not soft-deletable, not to enforce a specific
+        // shape for "no scope."
+        if (ds && Object.keys(ds).length > 0) {
+            expect(ds.where).toEqual({});
+        } else {
+            expect(ds || {}).toEqual({});
+        }
+    });
+});


### PR DESCRIPTION
Part of architect audit issue #73 — iteration P2-E.

## Summary

- Every soft-deletable model now carries `defaultScope: { where: { <arch>: false } }`, so future queries that forget the filter cannot silently return tombstoned rows.
- 17 models touched. `VersionInfo` excluded (no soft-delete semantics).
- Existing per-controller `<arch>: false` filters become redundant (Sequelize merges via AND). Cleanup is a follow-up.
- Archive ops unchanged. Re-archiving an already-archived row now 404s at fetch time — matches the explicit guard every controller already had.

## Test plan

- [x] New `tests/unit/default-scope.test.js` (18 cases) asserts each model carries the expected scope.
- [x] Full suite: 309 pass / 4 skip (was 291/4).
- [ ] Follow-up: drop the redundant `<arch>: false` from controller WHERE clauses.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/