### PR TITLE
feat(api): RFC 5988 Link header on all 15 list endpoints (P3-F)

### DIFF
--- a/app/controllers/billingtypecontroller.js
+++ b/app/controllers/billingtypecontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const BillingType = db.BillingType;
 
 const IsMaster = auth.isMaster;
@@ -131,6 +132,9 @@ exports.listByCompany = async (req, res) => {
             offset,
             order: [['btId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved billing types with CompanyId " + targetCompanyId,
             count,

--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -17,6 +17,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const Company = db.Company;
 
 const IsMaster = auth.isMaster;
@@ -107,6 +108,9 @@ exports.list = async (req, res) => {
             offset,
             order: [['compId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved companies",
             count,

--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -568,6 +568,9 @@ exports.search = async (req, res) => {
             offset,
             order: [['custId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: `Found ${count} customer(s) matching ${JSON.stringify(q)} in company ${effectiveCompanyId}`,
             q,

--- a/app/controllers/customerpaymentcontroller.js
+++ b/app/controllers/customerpaymentcontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const CustomerPayment = db.CustomerPayment;
 
 const IsMaster = auth.isMaster;
@@ -117,6 +118,9 @@ exports.listByCustomer = async (req, res) => {
             limit, offset,
             order: [['cpayDate', 'DESC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved customer payments for CustomerId " + targetCustomerId,
             count, limit, offset, customerPayments: rows,

--- a/app/controllers/inventoryitemcontroller.js
+++ b/app/controllers/inventoryitemcontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const InventoryItem = db.InventoryItem;
 
 const IsMaster = auth.isMaster;
@@ -131,6 +132,9 @@ exports.listByCompany = async (req, res) => {
             offset,
             order: [['invitId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved inventory items with CompanyId " + targetCompanyId,
             count,

--- a/app/controllers/inventorytransactioncontroller.js
+++ b/app/controllers/inventorytransactioncontroller.js
@@ -13,6 +13,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const InventoryTransaction = db.InventoryTransaction;
 
 const IsMaster = auth.isMaster;
@@ -130,6 +131,9 @@ exports.listByCompany = async (req, res) => {
             limit, offset,
             order: [['invtId', 'DESC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved inventory transactions with CompanyId " + targetCompanyId,
             count, limit, offset, inventoryTransactions: rows,

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const Invoice = db.Invoice;
 
 const IsMaster = auth.isMaster;
@@ -118,6 +119,9 @@ exports.listByCustomer = async (req, res) => {
             limit, offset,
             order: [['invId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved invoices for CustomerId " + targetCustomerId,
             count, limit, offset, invoices: rows,

--- a/app/controllers/invoicejobcontroller.js
+++ b/app/controllers/invoicejobcontroller.js
@@ -10,6 +10,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const InvoiceJob = db.InvoiceJob;
 
 const IsMaster = auth.isMaster;
@@ -136,6 +137,9 @@ exports.listByInvoice = async (req, res) => {
             limit, offset,
             order: [['injbId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved invoice lines for InvoiceId " + targetInvoiceId,
             count, limit, offset, invoiceJobs: rows,

--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -12,6 +12,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const Job = db.Job;
 
 const IsMaster = auth.isMaster;
@@ -126,6 +127,9 @@ exports.listByCustomer = async (req, res) => {
             offset,
             order: [['jobId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved jobs for CustomerId " + targetCustomerId,
             count, limit, offset, jobs: rows,

--- a/app/controllers/productentrycontroller.js
+++ b/app/controllers/productentrycontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const ProductEntry = db.ProductEntry;
 
 const IsMaster = auth.isMaster;
@@ -114,6 +115,9 @@ exports.listByJob = async (req, res) => {
             limit, offset,
             order: [['pentId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved product entries for JobId " + targetJobId,
             count, limit, offset, productEntries: rows,

--- a/app/controllers/purchaseorderheadercontroller.js
+++ b/app/controllers/purchaseorderheadercontroller.js
@@ -10,6 +10,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const PurchaseOrderHeader = db.PurchaseOrderHeader;
 
 const IsMaster = auth.isMaster;
@@ -117,6 +118,9 @@ exports.listByVendor = async (req, res) => {
             limit, offset,
             order: [['pohDate', 'DESC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved purchase orders for VendorId " + targetVendorId,
             count, limit, offset, purchaseOrderHeaders: rows,

--- a/app/controllers/purchaseorderlinecontroller.js
+++ b/app/controllers/purchaseorderlinecontroller.js
@@ -10,6 +10,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const PurchaseOrderLine = db.PurchaseOrderLine;
 
 const IsMaster = auth.isMaster;
@@ -117,6 +118,9 @@ exports.listByHeader = async (req, res) => {
             limit, offset,
             order: [['polId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved PO lines for HeaderId " + targetHeaderId,
             count, limit, offset, purchaseOrderLines: rows,

--- a/app/controllers/purchaseordervendorcontroller.js
+++ b/app/controllers/purchaseordervendorcontroller.js
@@ -10,6 +10,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const PurchaseOrderVendor = db.PurchaseOrderVendor;
 
 const IsMaster = auth.isMaster;
@@ -145,6 +146,9 @@ exports.listByCompany = async (req, res) => {
             limit, offset,
             order: [['povId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved PO vendors with CompanyId " + targetCompanyId,
             count, limit, offset, purchaseOrderVendors: rows,

--- a/app/controllers/versioninfocontroller.js
+++ b/app/controllers/versioninfocontroller.js
@@ -13,6 +13,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const VersionInfo = db.VersionInfo;
 
 const IsMaster = auth.isMaster;
@@ -85,6 +86,9 @@ exports.list = async (req, res) => {
             limit, offset,
             order: [['viDate', 'DESC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved version info",
             count, limit, offset, versionInfos: rows,

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -5,6 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
 const Worker = db.Worker;
 
 const IsMaster = auth.isMaster;
@@ -157,6 +158,9 @@ exports.listByCompany = async (req, res) => {
             offset,
             order: [['workerId', 'ASC']],
         });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        res.setHeader('Access-Control-Expose-Headers', 'Link');
         return res.status(200).json({
             message: "Successfully retrieved workers with CompanyId " + targetCompanyId,
             count,


### PR DESCRIPTION
Part of architect audit issue #73 — iteration P3-F.

## Summary

- Every paginated list endpoint now emits a `Link` header with `rel="next"`, `rel="prev"`, `rel="first"`, `rel="last"` per RFC 5988.
- 15 controllers updated (customer/bycompany already had it; this PR covers the remaining 14, plus the customer/search endpoint).
- Each site also sets `Access-Control-Expose-Headers: Link` so browser JS clients can read it off cross-origin responses.

## Test plan

- [x] `tests/unit/pagination.test.js` pins the builder's RFC 5988 semantics.
- [x] Full suite: 309 pass / 4 skip — no regressions.
- [ ] Manual: `curl -i -H 'authKey: ...' http://localhost:3000/v1/worker/bycompany/1?limit=10` should now include a `Link: <...>; rel="next", ...` response header on large result sets.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/