### PR TITLE
refactor(auth): injectable DB seam unlocks unit-level success-path tests (P5-M)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`app/middleware/auth.js` is now testable end-to-end** (P5-M).
+  Two changes:
+  1. Every DB hit now goes through the Sequelize model layer
+     (`ApiMaster.findOne`, `Customer.findByPk`, etc.) instead of raw
+     `sequelize.query` calls — fewer hand-rolled SQL strings, and the
+     archive-filter relies on the P2-E defaultScope rather than a
+     repeated `<arch>: false` WHERE clause.
+  2. A test-only `_setDbForTesting(stub)` seam lets unit tests
+     substitute model fixtures directly. vitest's `vi.mock` does not
+     intercept this codebase's CJS `require()` reliably; the explicit
+     setter is the smallest practical injection point. Production
+     code MUST NOT call it.
+  Auth helpers gain 19 new unit-level cases including the previously
+  un-mockable "row found → returns the value" success paths.
+
 ### Added
 - **ESLint flat config + CI gate** (P5-L). New `eslint.config.js`
   with rules tuned for high-signal bug catching rather than style

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -28,9 +28,34 @@
  */
 
 const crypto = require('crypto');
-const { sequelize } = require('../config/db.config.js');
-const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
+
+/**
+ * Late-bound + injectable DB accessor. Returns the db.config module
+ * on every call, or a test-supplied substitute set via
+ * `_setDbForTesting(stub)`. P5-M.
+ *
+ * Why injection: vitest's `vi.mock()` does not intercept CJS
+ * `require()` in this codebase (the model files use CJS via
+ * sequelize-cli's conventions, and vitest's mock layer only patches
+ * ESM imports reliably here). Tests that want to drive the
+ * "row found" success paths therefore need a way to *explicitly*
+ * substitute the db. The setter is hidden behind a leading-underscore
+ * name to make it clear it's a test-only seam; production code
+ * never calls it.
+ *
+ * Production performance: Node caches the require by path, so the
+ * accessor is effectively a property read on `require.cache` after
+ * the first call.
+ */
+let _dbOverride = null;
+function getDb() {
+    return _dbOverride || require('../config/db.config.js');
+}
+function _setDbForTesting(db) {
+    // Pass `null` (or omit) to restore the production lookup.
+    _dbOverride = db || null;
+}
 
 /**
  * Hash an authKey for lookup. Migration 20260518000000 converted
@@ -48,15 +73,35 @@ function hashKey(rawKey) {
     return crypto.createHash('sha256').update(String(rawKey)).digest('hex');
 }
 
+/**
+ * Why model calls instead of raw `sequelize.query`:
+ *
+ * P5-M reworked this module to route every DB hit through the
+ * Sequelize model layer (`ApiMaster.findOne`, `Customer.findByPk`,
+ * etc.) for testability. `vi.mock('../config/db.config.js', ...)`
+ * intercepts the module export; the raw `db.sequelize.query` path
+ * had a nested CJS-require interplay that often slipped past the
+ * mock, leaving tests exercising the real (unreachable in tests) DB.
+ * Going through the models means every code path here is testable
+ * with the same model-stub fixtures the rest of the api tests use.
+ *
+ * Performance is no worse — these are single-row primary-key
+ * lookups; Sequelize's per-row instantiation overhead is in the
+ * sub-millisecond range and dwarfed by the network round-trip.
+ *
+ * The archive filter (`<arch>: false`) is no longer hand-rolled in
+ * the WHERE clause. P2-E added `defaultScope` to every model with
+ * an archive column, so the soft-delete filter is implicit.
+ */
+
 async function isMaster(authKey) {
     if (!authKey || authKey.length === 0) return false;
     try {
-        const r = await db.sequelize.query(
-            'SELECT * FROM "dbo"."ApiMaster" WHERE "amKEY" = ? AND "ApiMaster"."amArchive" = false;',
-            { replacements: [hashKey(authKey)], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return false;
-        return typeof r[0].amId === 'number' && r[0].amId > 0;
+        const row = await getDb().ApiMaster.findOne({
+            where: { amKEY: hashKey(authKey) },
+            attributes: ['amId'],
+        });
+        return !!(row && typeof row.amId === 'number' && row.amId > 0);
     } catch (error) {
         log.error({ err: error }, 'auth.isMaster query failed');
         return false;
@@ -66,12 +111,12 @@ async function isMaster(authKey) {
 async function getCompanyId(authKey) {
     if (!authKey || authKey.length === 0) return -1;
     try {
-        const r = await db.sequelize.query(
-            'SELECT * FROM "dbo"."ApiKey" WHERE "akKEY" = ? AND "ApiKey"."akArchive" = false;',
-            { replacements: [hashKey(authKey)], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return -1;
-        const cid = r[0].akCompanyId;
+        const row = await getDb().ApiKey.findOne({
+            where: { akKEY: hashKey(authKey) },
+            attributes: ['akCompanyId'],
+        });
+        if (!row) return -1;
+        const cid = row.akCompanyId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
         log.error({ err: error }, 'auth.getCompanyId query failed');
@@ -91,12 +136,11 @@ async function getCompanyIdByCustomerId(customerId) {
     const idStr = customerId == null ? '' : String(customerId);
     if (idStr.length === 0 || idStr === '0') return -1;
     try {
-        const r = await db.sequelize.query(
-            'SELECT "custCompId" FROM "dbo"."Customer" WHERE "custId" = ? AND "custArch" = false;',
-            { replacements: [customerId], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return -1;
-        const cid = r[0].custCompId;
+        const row = await getDb().Customer.findByPk(customerId, {
+            attributes: ['custCompId'],
+        });
+        if (!row) return -1;
+        const cid = row.custCompId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
         log.error({ err: error }, 'auth.getCompanyIdByCustomerId query failed');
@@ -113,12 +157,11 @@ async function getCompanyIdByPovId(povId) {
     const idStr = povId == null ? '' : String(povId);
     if (idStr.length === 0 || idStr === '0') return -1;
     try {
-        const r = await db.sequelize.query(
-            'SELECT "povCompId" FROM "dbo"."PurchaseOrderVendors" WHERE "povId" = ? AND "povArch" = false;',
-            { replacements: [povId], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return -1;
-        const cid = r[0].povCompId;
+        const row = await getDb().PurchaseOrderVendor.findByPk(povId, {
+            attributes: ['povCompId'],
+        });
+        if (!row) return -1;
+        const cid = row.povCompId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
         log.error({ err: error }, 'auth.getCompanyIdByPovId query failed');
@@ -130,21 +173,28 @@ async function getCompanyIdByPovId(povId) {
  * Resolve a PO header id to its owning company id. Used by
  * PurchaseOrderLine — lines reference a header (polpoh), and the
  * header references a vendor (pohPovId), and the vendor's povCompId
- * is the auth boundary. Single query via JOIN keeps the lookup cheap.
+ * is the auth boundary. Eager-loaded via the PurchaseOrderHeader →
+ * PurchaseOrderVendor association so this stays one round-trip.
  */
 async function getCompanyIdByPohId(pohId) {
     const idStr = pohId == null ? '' : String(pohId);
     if (idStr.length === 0 || idStr === '0') return -1;
     try {
-        const r = await db.sequelize.query(
-            `SELECT v."povCompId"
-             FROM "dbo"."PurchaseOrderHeaders" h
-             JOIN "dbo"."PurchaseOrderVendors" v ON v."povId" = h."pohPovId"
-             WHERE h."pohId" = ? AND h."pohArch" = false AND v."povArch" = false;`,
-            { replacements: [pohId], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return -1;
-        const cid = r[0].povCompId;
+        const row = await getDb().PurchaseOrderHeader.findByPk(pohId, {
+            attributes: ['pohId'],
+            include: [{
+                model: getDb().PurchaseOrderVendor,
+                attributes: ['povCompId'],
+                required: true,
+            }],
+        });
+        if (!row) return -1;
+        // Association produces row.PurchaseOrderVendor (singular,
+        // belongsTo). defaultScope on PurchaseOrderVendor filters
+        // archived vendors automatically.
+        const vendor = row.PurchaseOrderVendor || row.purchaseOrderVendor;
+        if (!vendor) return -1;
+        const cid = vendor.povCompId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
         log.error({ err: error }, 'auth.getCompanyIdByPohId query failed');
@@ -163,15 +213,18 @@ async function getCompanyIdByJobId(jobId) {
     const idStr = jobId == null ? '' : String(jobId);
     if (idStr.length === 0 || idStr === '0') return -1;
     try {
-        const r = await db.sequelize.query(
-            `SELECT c."custCompId"
-             FROM "dbo"."Job" j
-             JOIN "dbo"."Customer" c ON c."custId" = j."jobCustId"
-             WHERE j."jobId" = ? AND j."jobArch" = false AND c."custArch" = false;`,
-            { replacements: [jobId], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!r || r.length === 0) return -1;
-        const cid = r[0].custCompId;
+        const row = await getDb().Job.findByPk(jobId, {
+            attributes: ['jobId'],
+            include: [{
+                model: getDb().Customer,
+                attributes: ['custCompId'],
+                required: true,
+            }],
+        });
+        if (!row) return -1;
+        const customer = row.Customer || row.customer;
+        if (!customer) return -1;
+        const cid = customer.custCompId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
         log.error({ err: error }, 'auth.getCompanyIdByJobId query failed');
@@ -281,4 +334,9 @@ module.exports = {
     requireAuth,
     resolveAuth,
     hashKey,
+    // Test-only seam: call with a stub db to drive auth functions
+    // through caller-controlled fixtures; call with no args (or null)
+    // to restore the production lookup. Production code MUST NOT call
+    // this. P5-M.
+    _setDbForTesting,
 };

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -1,90 +1,189 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Aaron K. Clark
 //
-// Unit-level tests for the shared auth middleware helpers.
+// Unit tests for the shared auth middleware helpers.
+//
+// P5-M added a `_setDbForTesting(stub)` seam to `app/middleware/auth.js`
+// so tests can drive the model-method success paths that vitest's
+// vi.mock cannot reliably intercept through this codebase's CJS
+// require chains. Each test installs a per-call stub via the setter,
+// invokes the helper, and asserts behavior.
 
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../app/config/db.config.js', () => ({
-    sequelize: {
-        query: vi.fn(),
-        QueryTypes: { SELECT: 'SELECT' },
-    },
+    sequelize: { query: vi.fn(), QueryTypes: { SELECT: 'SELECT' } },
     Sequelize: {},
-    Customer: {}, ApiKey: {}, ApiMaster: {}, TimeEntry: {},
+    ApiMaster: {}, ApiKey: {}, Customer: {},
+    PurchaseOrderVendor: {}, PurchaseOrderHeader: {}, Job: {},
 }));
 
+let auth;
+let stub;
+
+beforeEach(async () => {
+    auth = await import('../../app/middleware/auth.js');
+    stub = {
+        ApiMaster: { findOne: vi.fn() },
+        ApiKey: { findOne: vi.fn() },
+        Customer: { findByPk: vi.fn() },
+        PurchaseOrderVendor: { findByPk: vi.fn() },
+        PurchaseOrderHeader: { findByPk: vi.fn() },
+        Job: { findByPk: vi.fn() },
+    };
+    auth._setDbForTesting(stub);
+});
+
+afterEach(() => {
+    if (auth && auth._setDbForTesting) auth._setDbForTesting(null);
+});
+
 describe('auth.isMaster', () => {
-    test('returns false for empty or missing input', async () => {
-        const auth = await import('../../app/middleware/auth.js');
+    test('returns false for empty / missing input (no DB call made)', async () => {
         expect(await auth.isMaster('')).toBe(false);
         expect(await auth.isMaster(null)).toBe(false);
         expect(await auth.isMaster(undefined)).toBe(false);
+        expect(stub.ApiMaster.findOne).not.toHaveBeenCalled();
     });
 
     test('returns false when no row matches', async () => {
-        const db = await import('../../app/config/db.config.js');
-        const auth = await import('../../app/middleware/auth.js');
-        db.sequelize.query.mockResolvedValueOnce([]);
+        stub.ApiMaster.findOne.mockResolvedValueOnce(null);
         expect(await auth.isMaster('some-key')).toBe(false);
     });
 
-    // The "row found → returns true" path requires the vi.mock to
-    // actually engage with the controller's CJS require chain, which
-    // is finicky in this codebase. Integration tests against a real
-    // Postgres cover this path; the unit test here is intentionally
-    // limited to the no-DB code branches.
+    test('returns TRUE when a real ApiMaster row is found', async () => {
+        stub.ApiMaster.findOne.mockResolvedValueOnce({ amId: 42 });
+        expect(await auth.isMaster('valid-master-key')).toBe(true);
+        // Confirm the lookup was scoped by the hashed key, not the raw value.
+        const call = stub.ApiMaster.findOne.mock.calls[0][0];
+        expect(call.where.amKEY).toBe(auth.hashKey('valid-master-key'));
+    });
 
     test('returns false when amId is zero or non-numeric', async () => {
-        const db = await import('../../app/config/db.config.js');
-        const auth = await import('../../app/middleware/auth.js');
-        db.sequelize.query.mockResolvedValueOnce([{ amId: 0 }]);
+        stub.ApiMaster.findOne.mockResolvedValueOnce({ amId: 0 });
         expect(await auth.isMaster('k')).toBe(false);
-        db.sequelize.query.mockResolvedValueOnce([{ amId: 'oops' }]);
+        stub.ApiMaster.findOne.mockResolvedValueOnce({ amId: 'oops' });
         expect(await auth.isMaster('k')).toBe(false);
     });
 
-    test('swallows DB errors and returns false (does not throw)', async () => {
-        const db = await import('../../app/config/db.config.js');
-        const auth = await import('../../app/middleware/auth.js');
-        db.sequelize.query.mockRejectedValueOnce(new Error('connection refused'));
+    test('swallows DB errors and returns false', async () => {
+        stub.ApiMaster.findOne.mockRejectedValueOnce(new Error('connection refused'));
         expect(await auth.isMaster('k')).toBe(false);
     });
 });
 
 describe('auth.getCompanyId', () => {
     test('returns -1 for empty input', async () => {
-        const auth = await import('../../app/middleware/auth.js');
         expect(await auth.getCompanyId('')).toBe(-1);
         expect(await auth.getCompanyId(null)).toBe(-1);
     });
 
     test('returns -1 when no row matches', async () => {
-        const db = await import('../../app/config/db.config.js');
-        const auth = await import('../../app/middleware/auth.js');
-        db.sequelize.query.mockResolvedValueOnce([]);
+        stub.ApiKey.findOne.mockResolvedValueOnce(null);
         expect(await auth.getCompanyId('k')).toBe(-1);
     });
 
-    // The "row found → returns the company id" path requires the
-    // vi.mock to engage with the CJS require chain (see equivalent
-    // skip in isMaster above). Integration tests cover this path.
+    test('returns the akCompanyId when a row is found', async () => {
+        stub.ApiKey.findOne.mockResolvedValueOnce({ akCompanyId: 7 });
+        expect(await auth.getCompanyId('valid')).toBe(7);
+    });
 
     test('returns -1 for non-positive or non-numeric company id', async () => {
-        const db = await import('../../app/config/db.config.js');
-        const auth = await import('../../app/middleware/auth.js');
-        db.sequelize.query.mockResolvedValueOnce([{ akCompanyId: 0 }]);
+        stub.ApiKey.findOne.mockResolvedValueOnce({ akCompanyId: 0 });
         expect(await auth.getCompanyId('k')).toBe(-1);
-        db.sequelize.query.mockResolvedValueOnce([{ akCompanyId: null }]);
+        stub.ApiKey.findOne.mockResolvedValueOnce({ akCompanyId: null });
         expect(await auth.getCompanyId('k')).toBe(-1);
-        db.sequelize.query.mockResolvedValueOnce([{ akCompanyId: 'wat' }]);
+        stub.ApiKey.findOne.mockResolvedValueOnce({ akCompanyId: 'wat' });
+        expect(await auth.getCompanyId('k')).toBe(-1);
+    });
+
+    test('swallows DB errors and returns -1', async () => {
+        stub.ApiKey.findOne.mockRejectedValueOnce(new Error('boom'));
         expect(await auth.getCompanyId('k')).toBe(-1);
     });
 });
 
+describe('auth.getCompanyIdByCustomerId', () => {
+    test('returns -1 for empty / zero / null input', async () => {
+        expect(await auth.getCompanyIdByCustomerId(null)).toBe(-1);
+        expect(await auth.getCompanyIdByCustomerId(0)).toBe(-1);
+        expect(await auth.getCompanyIdByCustomerId('')).toBe(-1);
+        expect(stub.Customer.findByPk).not.toHaveBeenCalled();
+    });
+
+    test('returns the resolved custCompId on match', async () => {
+        stub.Customer.findByPk.mockResolvedValueOnce({ custCompId: 11 });
+        expect(await auth.getCompanyIdByCustomerId(5)).toBe(11);
+    });
+
+    test('returns -1 when customer not found (e.g. archived under defaultScope)', async () => {
+        stub.Customer.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByCustomerId(99)).toBe(-1);
+    });
+
+    test('returns -1 on a non-positive resolved company id', async () => {
+        stub.Customer.findByPk.mockResolvedValueOnce({ custCompId: 0 });
+        expect(await auth.getCompanyIdByCustomerId(5)).toBe(-1);
+    });
+});
+
+describe('auth.getCompanyIdByPovId', () => {
+    test('returns the resolved povCompId on match', async () => {
+        stub.PurchaseOrderVendor.findByPk.mockResolvedValueOnce({ povCompId: 3 });
+        expect(await auth.getCompanyIdByPovId(1)).toBe(3);
+    });
+
+    test('returns -1 on no-row', async () => {
+        stub.PurchaseOrderVendor.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByPovId(1)).toBe(-1);
+    });
+});
+
+describe('auth.getCompanyIdByPohId', () => {
+    test('resolves through the eager-loaded vendor association', async () => {
+        stub.PurchaseOrderHeader.findByPk.mockResolvedValueOnce({
+            pohId: 1,
+            PurchaseOrderVendor: { povCompId: 9 },
+        });
+        expect(await auth.getCompanyIdByPohId(1)).toBe(9);
+    });
+
+    test('returns -1 if the header is missing', async () => {
+        stub.PurchaseOrderHeader.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByPohId(1)).toBe(-1);
+    });
+
+    test('returns -1 if header has no vendor (broken FK)', async () => {
+        stub.PurchaseOrderHeader.findByPk.mockResolvedValueOnce({
+            pohId: 1,
+            PurchaseOrderVendor: null,
+        });
+        expect(await auth.getCompanyIdByPohId(1)).toBe(-1);
+    });
+});
+
+describe('auth.getCompanyIdByJobId', () => {
+    test('resolves through the eager-loaded customer association', async () => {
+        stub.Job.findByPk.mockResolvedValueOnce({
+            jobId: 1,
+            Customer: { custCompId: 12 },
+        });
+        expect(await auth.getCompanyIdByJobId(1)).toBe(12);
+    });
+
+    test('returns -1 if the job is missing', async () => {
+        stub.Job.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByJobId(1)).toBe(-1);
+    });
+
+    test('returns -1 if the job has no customer linkage', async () => {
+        stub.Job.findByPk.mockResolvedValueOnce({ jobId: 1, Customer: null });
+        expect(await auth.getCompanyIdByJobId(1)).toBe(-1);
+    });
+});
+
 describe('auth.requireAuthKey middleware', () => {
-    test('403s when no authKey header is present', async () => {
-        const auth = await import('../../app/middleware/auth.js');
+    test('403s when no authKey header is present', () => {
         const req = { get: () => undefined };
         const res = {
             status: vi.fn().mockReturnThis(),
@@ -96,8 +195,7 @@ describe('auth.requireAuthKey middleware', () => {
         expect(next).not.toHaveBeenCalled();
     });
 
-    test('calls next() and stashes req.authKey when present', async () => {
-        const auth = await import('../../app/middleware/auth.js');
+    test('calls next() and stashes req.authKey when present', () => {
         const req = { get: (h) => (h === 'authKey' ? 'value' : undefined) };
         const res = {
             status: vi.fn().mockReturnThis(),
@@ -106,6 +204,47 @@ describe('auth.requireAuthKey middleware', () => {
         const next = vi.fn();
         auth.requireAuthKey(req, res, next);
         expect(req.authKey).toBe('value');
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('auth.requireAuth middleware (post-attachAuth strict gate)', () => {
+    test('403 when no authKey on req', () => {
+        const req = { authKey: null };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn().mockReturnThis(),
+        };
+        const next = vi.fn();
+        auth.requireAuth(req, res, next);
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    test('403 when present but unknown (companyId = -1, not master)', () => {
+        const req = { authKey: 'mystery', isMaster: false, companyId: -1 };
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            json: vi.fn().mockReturnThis(),
+        };
+        const next = vi.fn();
+        auth.requireAuth(req, res, next);
+        expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    test('passes through when master', () => {
+        const req = { authKey: 'k', isMaster: true, companyId: -1 };
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        const next = vi.fn();
+        auth.requireAuth(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes through when company-scoped', () => {
+        const req = { authKey: 'k', isMaster: false, companyId: 5 };
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+        const next = vi.fn();
+        auth.requireAuth(req, res, next);
         expect(next).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Closes the architect audit tracker (issue #73 — last item on the list).

## Summary

Two changes in `app/middleware/auth.js`:

1. **Models instead of raw SQL.** `ApiMaster.findOne`, `ApiKey.findOne`, `Customer.findByPk`, `PurchaseOrderVendor.findByPk`, `PurchaseOrderHeader.findByPk` + eager-loaded vendor, `Job.findByPk` + eager-loaded customer. P2-E defaultScope replaces the hand-rolled `<arch>: false` WHERE clause.
2. **`_setDbForTesting(stub)` seam.** vitest's `vi.mock` does not reliably intercept this codebase's CJS `require()` chains. The setter is the smallest practical injection point. Tests call `auth._setDbForTesting({ ApiMaster: { findOne: vi.fn() }, ... })` to wire fixtures.

## Test plan

- [x] `tests/unit/auth.test.js` rewritten to 28 cases (was 14). New coverage on the previously un-mockable success paths.
- [x] Full suite: 420 pass / 4 skip (was 401/4).
- [x] `npm run lint`: 0 errors / 0 warnings.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/