### PR TITLE
refactor(controllers): drop redundant arch filters now that defaultScope handles them (P2-E2)

### DIFF
--- a/app/controllers/billingtypecontroller.js
+++ b/app/controllers/billingtypecontroller.js
@@ -128,7 +128,7 @@ exports.listByCompany = async (req, res) => {
 
     try {
         const { count, rows } = await BillingType.findAndCountAll({
-            where: { btCompId: targetCompanyId, btArch: false },
+            where: { btCompId: targetCompanyId },
             limit,
             offset,
             order: [['btId', 'ASC']],

--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -103,7 +103,6 @@ exports.list = async (req, res) => {
 
     try {
         const { count, rows } = await Company.findAndCountAll({
-            where: { compArch: false },
             limit,
             offset,
             order: [['compId', 'ASC']],

--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -230,7 +230,7 @@ exports.getAllByCompanyId = async (req, res) => {
     // Soft-deleted customers are not returned. Older clients that
     // weren't checking custArch already filter manually; this just
     // makes the server's behavior match the documented contract.
-    const where = { custCompId: companyId, custArch: false };
+    const where = { custCompId: companyId };
 
     try {
         const { count, rows } = await Customer.findAndCountAll({
@@ -328,7 +328,7 @@ exports.exportCsv = async (req, res) => {
     let rows;
     try {
         rows = await Customer.findAll({
-            where: { custCompId: effectiveCompanyId, custArch: false },
+            where: { custCompId: effectiveCompanyId },
             limit: limit + 1, // +1 to detect "did we hit the cap"
             offset,
             order: [['custId', 'ASC']],
@@ -553,7 +553,6 @@ exports.search = async (req, res) => {
     const pattern = `%${q}%`;
     const where = {
         custCompId: effectiveCompanyId,
-        custArch: false,
         [Op.or]: [
             { custCompanyName: { [Op.iLike]: pattern } },
             { custFName: { [Op.iLike]: pattern } },

--- a/app/controllers/customerpaymentcontroller.js
+++ b/app/controllers/customerpaymentcontroller.js
@@ -114,7 +114,7 @@ exports.listByCustomer = async (req, res) => {
 
     try {
         const { count, rows } = await CustomerPayment.findAndCountAll({
-            where: { cpayCustId: targetCustomerId, cpayArch: false },
+            where: { cpayCustId: targetCustomerId },
             limit, offset,
             order: [['cpayDate', 'DESC']],
         });

--- a/app/controllers/inventoryitemcontroller.js
+++ b/app/controllers/inventoryitemcontroller.js
@@ -128,7 +128,7 @@ exports.listByCompany = async (req, res) => {
 
     try {
         const { count, rows } = await InventoryItem.findAndCountAll({
-            where: { invitCompId: targetCompanyId, invitArch: false },
+            where: { invitCompId: targetCompanyId },
             limit,
             offset,
             order: [['invitId', 'ASC']],

--- a/app/controllers/inventorytransactioncontroller.js
+++ b/app/controllers/inventorytransactioncontroller.js
@@ -128,7 +128,7 @@ exports.listByCompany = async (req, res) => {
 
     try {
         const { count, rows } = await InventoryTransaction.findAndCountAll({
-            where: { invtCompanyId: targetCompanyId, invtArch: false },
+            where: { invtCompanyId: targetCompanyId },
             limit, offset,
             order: [['invtId', 'DESC']],
         });

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -115,7 +115,7 @@ exports.listByCustomer = async (req, res) => {
 
     try {
         const { count, rows } = await Invoice.findAndCountAll({
-            where: { invCustId: targetCustomerId, invArch: false },
+            where: { invCustId: targetCustomerId },
             limit, offset,
             order: [['invId', 'ASC']],
         });

--- a/app/controllers/invoicejobcontroller.js
+++ b/app/controllers/invoicejobcontroller.js
@@ -133,7 +133,7 @@ exports.listByInvoice = async (req, res) => {
 
     try {
         const { count, rows } = await InvoiceJob.findAndCountAll({
-            where: { injbInvId: targetInvoiceId, injbArch: false },
+            where: { injbInvId: targetInvoiceId },
             limit, offset,
             order: [['injbId', 'ASC']],
         });

--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -122,7 +122,7 @@ exports.listByCustomer = async (req, res) => {
 
     try {
         const { count, rows } = await Job.findAndCountAll({
-            where: { jobCustId: targetCustomerId, jobArch: false },
+            where: { jobCustId: targetCustomerId },
             limit,
             offset,
             order: [['jobId', 'ASC']],

--- a/app/controllers/productentrycontroller.js
+++ b/app/controllers/productentrycontroller.js
@@ -111,7 +111,7 @@ exports.listByJob = async (req, res) => {
 
     try {
         const { count, rows } = await ProductEntry.findAndCountAll({
-            where: { pentJobId: targetJobId, penArch: false },
+            where: { pentJobId: targetJobId },
             limit, offset,
             order: [['pentId', 'ASC']],
         });

--- a/app/controllers/purchaseorderheadercontroller.js
+++ b/app/controllers/purchaseorderheadercontroller.js
@@ -114,7 +114,7 @@ exports.listByVendor = async (req, res) => {
 
     try {
         const { count, rows } = await PurchaseOrderHeader.findAndCountAll({
-            where: { pohPovId: targetVendorId, pohArch: false },
+            where: { pohPovId: targetVendorId },
             limit, offset,
             order: [['pohDate', 'DESC']],
         });

--- a/app/controllers/purchaseorderlinecontroller.js
+++ b/app/controllers/purchaseorderlinecontroller.js
@@ -114,7 +114,7 @@ exports.listByHeader = async (req, res) => {
 
     try {
         const { count, rows } = await PurchaseOrderLine.findAndCountAll({
-            where: { polpoh: targetHeaderId, polArch: false },
+            where: { polpoh: targetHeaderId },
             limit, offset,
             order: [['polId', 'ASC']],
         });

--- a/app/controllers/purchaseordervendorcontroller.js
+++ b/app/controllers/purchaseordervendorcontroller.js
@@ -143,7 +143,7 @@ exports.listByCompany = async (req, res) => {
 
     try {
         const { count, rows } = await PurchaseOrderVendor.findAndCountAll({
-            where: { povCompId: targetCompanyId, povArch: false },
+            where: { povCompId: targetCompanyId },
             limit, offset,
             order: [['povId', 'ASC']],
         });

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -144,7 +144,7 @@ exports.listByCompany = async (req, res) => {
         }
     }
 
-    const where = { teCompId: targetCompanyId, teArch: false };
+    const where = { teCompId: targetCompanyId };
     const customerId = Number(req.query.customerId);
     if (Number.isInteger(customerId) && customerId > 0) {
         where.teCustId = customerId;
@@ -349,7 +349,7 @@ exports.exportCsv = async (req, res) => {
         effectiveCompanyId = authKeyCompanyId;
     }
 
-    const where = { teCompId: effectiveCompanyId, teArch: false };
+    const where = { teCompId: effectiveCompanyId };
     const customerId = Number(req.query.customerId);
     if (Number.isInteger(customerId) && customerId > 0) {
         where.teCustId = customerId;

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -154,7 +154,7 @@ exports.listByCompany = async (req, res) => {
 
     try {
         const { count, rows } = await Worker.findAndCountAll({
-            where: { workerCompId: targetCompanyId, workerArch: false },
+            where: { workerCompId: targetCompanyId },
             limit,
             offset,
             order: [['workerId', 'ASC']],


### PR DESCRIPTION
Follow-up to #78 (P2-E).

## Summary

- Removes the hand-rolled `<arch>: false` from every controller WHERE — defaultScope now provides it.
- 15 controllers touched; pure cleanup, identical SQL emitted.
- Defensive guards (`if (!instance || instance.<arch>) return 404`) and CREATE-time defaults stay.

## Test plan

- [x] 420 pass / 4 skip — unchanged.
- [x] Lint clean.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/