### PR TITLE
chore(postman): regenerate collection from openapi.js

### DIFF
--- a/setup/TimeTrackerAPI.postman_collection.json
+++ b/setup/TimeTrackerAPI.postman_collection.json
@@ -5,7 +5,7 @@
             "description": "",
             "item": [
                 {
-                    "id": "1cb1427d-2d20-42cd-ab70-0f808f49dcd9",
+                    "id": "11b3bdc3-fb7b-49b7-8469-df7b9264a327",
                     "name": "Liveness + DB readiness probe",
                     "request": {
                         "name": "Liveness + DB readiness probe",
@@ -35,7 +35,7 @@
                     },
                     "response": [
                         {
-                            "id": "3b16a172-d161-46c5-a3c8-1bebbcf164ea",
+                            "id": "eb5b5a2e-e5c7-4cc4-b5ab-4daac7e9a188",
                             "name": "OK — DB ping succeeded",
                             "originalRequest": {
                                 "url": {
@@ -65,12 +65,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"status\": \"ok\",\n  \"db\": \"ok\",\n  \"uptime_s\": \"<integer>\",\n  \"version\": \"<string>\",\n  \"elapsed_ms\": \"<number>\"\n}",
+                            "body": "{\n  \"status\": \"ok\",\n  \"db\": \"ok\",\n  \"uptime_s\": \"<integer>\",\n  \"version\": \"<string>\",\n  \"elapsed_ms\": \"<number>\",\n  \"migration\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e820291b-d80a-4cd5-850e-1ed25e128b29",
+                            "id": "29a18a08-cd15-4121-a2f7-332b36445c59",
                             "name": "Degraded — DB unreachable",
                             "originalRequest": {
                                 "url": {
@@ -105,15 +105,1057 @@
             "description": "",
             "item": [
                 {
+                    "name": "whoami",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "ea45f976-26b2-4ec8-8379-8c2918489d2c",
+                            "name": "Identity probe — what does the calling authKey resolve to?",
+                            "request": {
+                                "name": "Identity probe — what does the calling authKey resolve to?",
+                                "description": {
+                                    "content": "Returns whether the supplied authKey is recognized, whether it is a master key, and which company it is scoped to. Useful for SDK clients confirming wiring without firing a domain endpoint and inferring from a 403/200.",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "v1",
+                                        "whoami"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "apikey",
+                                    "apikey": [
+                                        {
+                                            "key": "key",
+                                            "value": "authKey"
+                                        },
+                                        {
+                                            "key": "value",
+                                            "value": "{{apiKey}}"
+                                        },
+                                        {
+                                            "key": "in",
+                                            "value": "header"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "909bf076-fe1a-47cc-ab95-e9d56008d17e",
+                                    "name": "OK — body indicates whether the key is recognized",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "whoami"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: apikey",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "authKey",
+                                                "value": "<API Key>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "body": "{\n  \"authenticated\": \"<boolean>\",\n  \"isMaster\": \"<boolean>\",\n  \"companyId\": \"<integer>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "json"
+                                },
+                                {
+                                    "id": "2a514684-726e-45d1-9a2f-8efd68a137ce",
+                                    "name": "authKey header missing entirely",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "whoami"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: apikey",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "authKey",
+                                                "value": "<API Key>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Forbidden",
+                                    "code": 403,
+                                    "header": [],
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                },
+                                {
+                                    "id": "d5c8e6a6-e220-46c6-bce7-fc78917810fd",
+                                    "name": "Server error (DB lookup failed)",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "whoami"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: apikey",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "authKey",
+                                                "value": "<API Key>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "header": [],
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "customer",
                     "description": "",
                     "item": [
+                        {
+                            "name": "export.csv",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "cf9ea678-db05-4aeb-89e4-fb318949b24b",
+                                    "name": "CSV export of customers in a company",
+                                    "request": {
+                                        "name": "CSV export of customers in a company",
+                                        "description": {
+                                            "content": "text/csv response (no JSON envelope), `Content-Disposition: attachment` set so browsers download as `customers-company-<id>.csv`. Capped at 5000 rows per call; an oversize result appends a `# truncated...` comment row so callers know to page via offset.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "customer",
+                                                "export.csv"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "Required for master keys.",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "companyId",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "limit",
+                                                    "value": "5000"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "offset",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "text/csv"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "14bcb3f3-238d-4f32-b721-3bc9280768f0",
+                                            "name": "CSV body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "text/csv"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "text/csv"
+                                                }
+                                            ],
+                                            "body": "<string>",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "85d93020-ac58-48c1-a7fa-4face7e9b165",
+                                            "name": "Master without companyId",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "441c1e0b-8071-405f-b080-a191f8df2845",
+                                            "name": "Missing authKey, or cross-tenant export attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "835ef73d-3dd1-4857-bbec-63c09a82065d",
+                                    "name": "Bulk-create customers (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create customers (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ customers: [{...}, ...] }`. Each entry follows the same shape as POST /v1/customer. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert the whole transaction rolls back.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "customer",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"customers\": [\n    {\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "73992078-c443-4b49-ac5b-c61fcb0ca21f",
+                                            "name": "All customers created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customers\": [\n    {\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "beabbf51-2de2-48d4-a72c-5ddac9f27e23",
+                                            "name": "Validation failure (array empty / master without custCompId on some entry)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customers\": [\n    {\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "09ed8089-6cba-4c5a-8709-5b1015289881",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customers\": [\n    {\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "158cff1d-78e9-4bbc-bc10-3950c8e80a13",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customers\": [\n    {\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "search",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "843f90a9-d6a2-453a-9160-ef5c79b70562",
+                                    "name": "Search customers by substring (company-scoped)",
+                                    "request": {
+                                        "name": "Search customers by substring (company-scoped)",
+                                        "description": {
+                                            "content": "Case-insensitive ILIKE match on custCompanyName / custFName / custLName. Non-master keys are auto-scoped to their authKey company; master keys must pass companyId explicitly (no global cross-tenant search).",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "customer",
+                                                "search"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "q",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "Required for master keys. Forbidden when it does not match a non-master authKey's own company.",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "companyId",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "limit",
+                                                    "value": "100"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "offset",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "0e19e6af-42cf-4746-b206-457878723e15",
+                                            "name": "OK — search results",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "search"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "q",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys. Forbidden when it does not match a non-master authKey's own company.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "100"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "body": "{\n  \"message\": \"<string>\",\n  \"q\": \"<string>\",\n  \"companyId\": \"<integer>\",\n  \"count\": \"<integer>\",\n  \"limit\": \"<integer>\",\n  \"offset\": \"<integer>\",\n  \"customers\": [\n    {\n      \"custId\": \"<integer>\",\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\",\n      \"custArch\": \"<boolean>\"\n    },\n    {\n      \"custId\": \"<integer>\",\n      \"custCompanyName\": \"<string>\",\n      \"custFName\": \"<string>\",\n      \"custLName\": \"<string>\",\n      \"custAddress1\": \"<string>\",\n      \"custAddress2\": \"<string>\",\n      \"custCity\": \"<string>\",\n      \"custState\": \"<string>\",\n      \"custZip\": \"<string>\",\n      \"custPhone\": \"<string>\",\n      \"custEmail\": \"<email>\",\n      \"custCompId\": \"<integer>\",\n      \"custArch\": \"<boolean>\"\n    }\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "json"
+                                        },
+                                        {
+                                            "id": "c1e83a04-fdc9-4bd1-970d-9838ef9d5c4f",
+                                            "name": "Bad request — q missing/too short, or master without companyId",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "search"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "q",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys. Forbidden when it does not match a non-master authKey's own company.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "100"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "79fd1e85-5d91-49f4-991b-445733265d41",
+                                            "name": "Missing authKey, or cross-tenant search attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customer",
+                                                        "search"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "q",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys. Forbidden when it does not match a non-master authKey's own company.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "100"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
                         {
                             "name": "{id}",
                             "description": "",
                             "item": [
                                 {
-                                    "id": "24de32e1-103c-45b4-954b-d90364249b8e",
+                                    "id": "a3d08ade-1c77-4959-8884-593beda40945",
                                     "name": "Get one customer by id",
                                     "request": {
                                         "name": "Get one customer by id",
@@ -169,7 +1211,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "79b31df0-d669-4f70-8786-eb0a7b243f7f",
+                                            "id": "ae2c791f-5f80-43d3-a6c1-9d79f0e3b70f",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -182,7 +1224,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -214,7 +1267,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "f414c114-ace8-4440-895b-72fa9e1aba0c",
+                                            "id": "f92c9ab6-3578-4eeb-a9a2-4548d471e015",
                                             "name": "Missing or invalid authKey",
                                             "originalRequest": {
                                                 "url": {
@@ -227,7 +1280,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -275,7 +1339,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "036653ee-f93a-4cd4-bb99-e2d109470d82",
+                                            "id": "7b55b8b0-9a09-44e1-8c3f-0d24b5ff5e01",
                                             "name": "List customers in a company (paginated)",
                                             "request": {
                                                 "name": "List customers in a company (paginated)",
@@ -345,7 +1409,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "3f51c575-eb66-41e0-9ba4-d1afd8a64a60",
+                                                    "id": "64f12112-6142-4f17-abab-eda4a6ac94d8",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -378,7 +1442,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -400,7 +1475,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "24b1dfc3-86ec-43f3-95f3-005b9efc9bfe",
+                                                    "id": "ba2e4f0b-f741-400e-8de9-c240e3296451",
                                                     "name": "Missing or invalid authKey",
                                                     "originalRequest": {
                                                         "url": {
@@ -433,7 +1508,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -465,7 +1551,7 @@
                             ]
                         },
                         {
-                            "id": "f13460c4-27a2-47a2-b1cd-dba55b4a76ae",
+                            "id": "fbbca808-21e5-403c-ae3a-698cdea4bc30",
                             "name": "Create a customer",
                             "request": {
                                 "name": "Create a customer",
@@ -522,7 +1608,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "fab66c15-64aa-466c-bf98-3b5b233f319d",
+                                    "id": "40453465-ee68-40c3-abe3-44f3f784e33e",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -579,7 +1665,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "9204f8e7-b207-40a9-b7e7-17f7cc52a9cf",
+                                    "id": "bd916d23-fe85-4a30-8f43-a8251a4d1df5",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -626,7 +1712,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "1b075901-90a4-4381-bb8e-a96cdb21e1b4",
+                                    "id": "94e1c550-fa86-49d6-9093-784bb8aab245",
                                     "name": "Missing or invalid authKey",
                                     "originalRequest": {
                                         "url": {
@@ -685,7 +1771,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "eee2eb36-1828-45c7-8db9-d1d2105b616c",
+                            "id": "6bdb0b0c-789b-4235-a4fd-7f872a0d2e1c",
                             "name": "Create a time entry",
                             "request": {
                                 "name": "Create a time entry",
@@ -738,7 +1824,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "7116285b-6cc1-402a-a48c-c52fff718c30",
+                                    "id": "86b29491-f994-4b9c-bb94-7ae2c079cc29",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -785,7 +1871,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "1bb8501d-404c-4771-8125-76dec758163d",
+                                    "id": "79808167-e9b6-48ee-9b05-ced7a7e52a9e",
                                     "name": "Bad request — missing teCustId or teStartedAt",
                                     "originalRequest": {
                                         "url": {
@@ -832,7 +1918,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "27f58511-fd17-4e69-913c-07ac3c21c29f",
+                                    "id": "fe3cfbcd-cb7b-477f-97ba-0ab6a04d56dc",
                                     "name": "Missing or invalid authKey",
                                     "originalRequest": {
                                         "url": {
@@ -889,7 +1975,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "1dba0736-0d70-48d7-aa9e-52004df50050",
+                                    "id": "131e8d74-7cef-4f86-8cf3-051203466dd6",
                                     "name": "Get one time entry",
                                     "request": {
                                         "name": "Get one time entry",
@@ -939,7 +2025,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "e0152818-8ca0-4733-a337-d7833a7d279c",
+                                            "id": "4fc74813-526e-4097-9a4d-9633f53119d4",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -952,7 +2038,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -974,7 +2071,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e96a9d85-0d6d-4f16-a848-bfd200c976fe",
+                                            "id": "7a79fc09-7bd1-4df8-bb55-2060cea5e7bd",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -987,7 +2084,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1009,7 +2117,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "bdda9fee-2910-4a17-957c-65cbdadf40e9",
+                                            "id": "ada46386-95e0-4242-93e1-bc1c41a81e8d",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -1022,7 +2130,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1050,7 +2169,7 @@
                                     }
                                 },
                                 {
-                                    "id": "b220f9fa-82fa-459d-83c2-259c17266ac8",
+                                    "id": "96a06208-909e-44a4-a87a-d52fc949dfc2",
                                     "name": "Partial update of a time entry",
                                     "request": {
                                         "name": "Partial update of a time entry",
@@ -1115,7 +2234,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "a22e7a60-0691-473c-a3f3-38548ec9055c",
+                                            "id": "02f6ccab-52d2-4f9c-90ed-c9ee8a23746d",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -1128,7 +2247,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1163,7 +2293,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "810f37c3-f501-4370-b97a-f0867ebaaec7",
+                                            "id": "dc9dee0d-53b7-497e-80db-8aca563030a9",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -1176,7 +2306,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1211,7 +2352,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "09227a29-d1bb-46ed-a133-bf6f324fdc4c",
+                                            "id": "a616b06e-01c9-432f-a1a5-48e548990cfc",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -1224,7 +2365,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1259,7 +2411,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "264588b6-2d9e-4992-8227-4672445ca6cf",
+                                            "id": "76113c0a-d739-4817-9714-5ef98a0b4622",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -1272,7 +2424,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1313,7 +2476,7 @@
                                     }
                                 },
                                 {
-                                    "id": "1c395572-f89c-4d49-9c39-1560c8a51caa",
+                                    "id": "42a18bbe-4ce7-4abe-af9e-949ec9232af2",
                                     "name": "Soft-delete a time entry",
                                     "request": {
                                         "name": "Soft-delete a time entry",
@@ -1363,7 +2526,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "af26c77f-b3e1-48ba-a290-a88497aa637d",
+                                            "id": "d58b0292-aade-4b9a-b7fc-ec0c3369c882",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -1376,7 +2539,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1398,7 +2572,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "9a4b9409-0b98-4677-b938-540102fdb1d8",
+                                            "id": "9710054e-2099-4e64-90e8-c9f7bf07ea8a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -1411,7 +2585,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1433,7 +2618,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "a3c996ef-85ac-4600-ab1e-b711487b9994",
+                                            "id": "63fdaed7-c88b-4887-bb2a-d3850f566487",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -1446,7 +2631,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -1476,6 +2672,401 @@
                             ]
                         },
                         {
+                            "name": "export.csv",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "783115ee-bc43-46a5-b18f-9d5a5fae8541",
+                                    "name": "CSV export of time entries (invoicing-friendly)",
+                                    "request": {
+                                        "name": "CSV export of time entries (invoicing-friendly)",
+                                        "description": {
+                                            "content": "text/csv response with attachment Content-Disposition. Same filter set as bycompany (customerId, from, to) plus a master-only `companyId` requirement. 5000-row hard cap; oversize results append `# truncated…` comment row.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "timeentry",
+                                                "export.csv"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "Required for master keys.",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "companyId",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "customerId",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "from",
+                                                    "value": "<dateTime>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "to",
+                                                    "value": "<dateTime>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "limit",
+                                                    "value": "5000"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "offset",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "text/csv"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "78e35e32-f34c-40be-9730-b7f3b3daf3cb",
+                                            "name": "CSV body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "timeentry",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "customerId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "from",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "to",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "text/csv"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "text/csv"
+                                                }
+                                            ],
+                                            "body": "<string>",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "db1e6460-acf0-44cf-bdde-9cd0ed4ddda9",
+                                            "name": "Master without companyId",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "timeentry",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "customerId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "from",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "to",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "4a651ece-2565-4c49-a1f3-de45a96fda78",
+                                            "name": "Missing authKey or cross-tenant export attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "timeentry",
+                                                        "export.csv"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "Required for master keys.",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "customerId",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "from",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "to",
+                                                            "value": "<dateTime>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "5000"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "offset",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "bycompany",
                             "description": "",
                             "item": [
@@ -1484,7 +3075,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "d2b575e8-646b-458e-a919-a95319decaf1",
+                                            "id": "884e0fc0-3fdf-46fc-a444-5353e582e993",
                                             "name": "List time entries for a company",
                                             "request": {
                                                 "name": "List time entries for a company",
@@ -1572,7 +3163,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "86fa42eb-501d-406f-bc88-ae881089000c",
+                                                    "id": "6f1993e9-e8ef-4d7b-a922-00a472ae3457",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -1623,7 +3214,18 @@
                                                                     "value": "100"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -1645,7 +3247,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "35bdf30b-450f-4999-8a29-8b8f559ef8fe",
+                                                    "id": "775a0de0-44df-483d-839e-a6b574592eba",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -1696,7 +3298,18 @@
                                                                     "value": "100"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -1718,7 +3331,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "55f801e3-a750-4f2f-a7b4-6d6d95a6ba7a",
+                                                    "id": "81843478-c7f5-4886-8f21-7509d7f942a2",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -1769,7 +3382,18 @@
                                                                     "value": "100"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -1807,7 +3431,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "ca0c5ae0-1474-4024-a511-cdc6a623ad95",
+                            "id": "a9e64108-ce8e-4881-9f51-ee26743528ff",
                             "name": "Create a worker",
                             "request": {
                                 "name": "Create a worker",
@@ -1864,7 +3488,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "241125c4-3688-4cbf-8571-8575a882b66c",
+                                    "id": "16ed82a0-eb2a-475a-bc35-ae7ca82c8cb3",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -1921,7 +3545,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "afa2e1b3-6923-4b7e-8ce5-54c30c47128e",
+                                    "id": "601b7c30-6035-4fac-90fe-0b95e99878c7",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -1968,7 +3592,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "b8b95b3c-9d98-4d52-872a-22d08b2823f8",
+                                    "id": "f789e8a1-a2ab-4ebf-9f86-3abe626d3b1c",
                                     "name": "Missing or invalid authKey",
                                     "originalRequest": {
                                         "url": {
@@ -2025,7 +3649,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "61709763-18ec-4c67-920f-688bf97e001c",
+                                    "id": "d77b9e78-7225-4598-9782-985822c49217",
                                     "name": "Get one worker",
                                     "request": {
                                         "name": "Get one worker",
@@ -2075,7 +3699,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "257d171a-f7dd-4a4c-85ba-22ee92857c63",
+                                            "id": "86d3f4af-59c3-45fc-a5c1-4359d98a715a",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -2088,7 +3712,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2110,7 +3745,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "876624d4-57dd-4b63-8a97-6af6d92a2553",
+                                            "id": "9cd6381c-0593-48f0-9e50-5c3c7cecd26e",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -2123,7 +3758,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2145,7 +3791,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "7ff4b4e9-b6c4-46ea-819d-f33e04caa559",
+                                            "id": "29ec2ad9-a4b5-46cf-a229-edba506921ac",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -2158,7 +3804,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2186,7 +3843,7 @@
                                     }
                                 },
                                 {
-                                    "id": "7037372f-7850-482f-a35c-6ca2b8156943",
+                                    "id": "9e2f5531-17cb-4a94-b78d-6c2aa8c028f4",
                                     "name": "Partial update of a worker",
                                     "request": {
                                         "name": "Partial update of a worker",
@@ -2251,7 +3908,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "fffcd9e9-3f80-46b6-825e-8b606479ce0c",
+                                            "id": "b090d2bf-e46e-4577-b7c5-13d09e49de7f",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -2264,7 +3921,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2299,7 +3967,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e132de64-0cc5-4c0b-9043-6d5181992987",
+                                            "id": "aa2891de-348e-444c-a284-820f83952426",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -2312,7 +3980,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2347,7 +4026,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "3d7735ae-9054-4bd8-8184-78fc244cafb7",
+                                            "id": "1bc22990-220f-412a-aab5-3671016697ef",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -2360,7 +4039,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2395,7 +4085,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "76418390-e9b5-41d4-8807-dfe8067b641e",
+                                            "id": "5f0650d7-d254-45a6-bb80-0558f7ee2c54",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -2408,7 +4098,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2449,7 +4150,7 @@
                                     }
                                 },
                                 {
-                                    "id": "fe32c5ab-4af7-48fd-95a1-6cf22b2a3a7f",
+                                    "id": "6ee3ba0f-e732-4012-b256-0f5d5f652045",
                                     "name": "Soft-delete a worker",
                                     "request": {
                                         "name": "Soft-delete a worker",
@@ -2499,7 +4200,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "cdd86f07-449b-411e-aa5f-d0032bc3be49",
+                                            "id": "24a8534b-3414-4abb-ad09-c368155c3e60",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -2512,7 +4213,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2534,7 +4246,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "7c49bcdc-6e5a-4fcf-9a6e-9ea96efeb90c",
+                                            "id": "2bac5adb-6a73-40db-8533-1ccfb70cf793",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -2547,7 +4259,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2569,7 +4292,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d4bf016b-a73e-4bb0-8e62-c5284355a51a",
+                                            "id": "b78b8ce6-5b97-46fc-b9a8-f38a43d6c0c7",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -2582,7 +4305,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -2620,7 +4354,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "81f64bb2-90bd-4345-a736-d10531620b91",
+                                            "id": "49381d9b-d61f-4833-8c17-08cdb6aed1bd",
                                             "name": "List workers in a company (paginated)",
                                             "request": {
                                                 "name": "List workers in a company (paginated)",
@@ -2690,7 +4424,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "6a23b950-7568-464b-a788-1cbfbe89afed",
+                                                    "id": "539d71e4-5d60-4075-a450-2ea5c89fdf18",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -2723,7 +4457,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -2745,7 +4490,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "3ad22c95-4bdd-417f-959a-8225a37b304b",
+                                                    "id": "1497bc5f-8ae7-44f6-ada7-fede33acd90f",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -2778,7 +4523,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -2800,7 +4556,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "a1ed4d96-f091-4ec3-8f1e-427db94da1b1",
+                                                    "id": "f20c85e5-2743-4deb-8660-f46fb021f615",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -2833,7 +4589,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -2863,6 +4630,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "54c7063b-2564-4747-8012-5edd214a0fa7",
+                                    "name": "Bulk-create workers (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create workers (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ workers: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "worker",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "33385836-49ec-4774-9de2-cdb1351434f9",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "worker",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "33a682aa-82cf-47b9-9d7b-d61ff2ec766c",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "worker",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "fc383b93-e378-4731-aa50-2c65192026db",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "worker",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "db83cb9f-88b1-46e5-be73-201da35dd828",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "worker",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "a21af8a1-3e2b-447e-9d96-df1fa59b19ff",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "worker",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"workers\": [\n    {\n      \"workerFName\": \"<string>\",\n      \"workerLName\": \"<string>\",\n      \"workerTitle\": \"<string>\",\n      \"workerDefaultBillType\": \"<integer>\",\n      \"workerCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -2871,7 +5001,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "231a3088-33f3-4b8a-8bf2-8d72eddf9fe4",
+                            "id": "b7cc8ab4-22a2-4a55-9f32-6c4d426128db",
                             "name": "Create a billing type",
                             "request": {
                                 "name": "Create a billing type",
@@ -2924,7 +5054,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b406cdac-99c2-4ee0-a2a1-8461c613d738",
+                                    "id": "195fcd00-39fb-4f75-9367-c9006bb383fd",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -2971,7 +5101,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "02badb0f-ef6f-4115-922a-afa4ee5049f9",
+                                    "id": "dc834c25-a1ca-4144-8d55-42a651df1bf9",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -3018,7 +5148,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "d8da3550-2d74-4748-a788-9286c959a9f4",
+                                    "id": "4d646d84-ea24-473f-9faa-9d133418fb54",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -3075,7 +5205,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "823731d9-4788-4849-b308-3eb4fd18bc2a",
+                                    "id": "9aec2d64-c8c7-49fa-b024-a33eb6ce80cd",
                                     "name": "Get one billing type",
                                     "request": {
                                         "name": "Get one billing type",
@@ -3125,7 +5255,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "c10e5b0c-790a-4850-a930-c0b64f4f2e45",
+                                            "id": "0758f57f-06f8-4873-8fb6-4302248a7301",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -3138,7 +5268,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3160,7 +5301,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "10bf0804-7e96-40e6-9855-0d6c16f7608c",
+                                            "id": "ea1008ce-3eb9-48cf-ac6b-98b167d5216c",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -3173,7 +5314,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3195,7 +5347,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "8afc2142-8137-4dda-8a39-5fdc70aae85c",
+                                            "id": "3f550426-99e7-4e7b-9ace-fb3afed6a9eb",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -3208,7 +5360,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3236,7 +5399,7 @@
                                     }
                                 },
                                 {
-                                    "id": "f9ce43d7-b79b-453a-9539-bb74f1832029",
+                                    "id": "cedbeca3-8cf6-45c6-9de6-eb8d00bf1071",
                                     "name": "Partial update of a billing type",
                                     "request": {
                                         "name": "Partial update of a billing type",
@@ -3301,7 +5464,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "bcc5c6c6-7eeb-4d64-be3d-4f61766201dc",
+                                            "id": "bc01da5e-829b-4715-b439-28d4b64ed22c",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -3314,7 +5477,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3349,7 +5523,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "7681d7fc-5a48-4a50-864a-14e9192f4cea",
+                                            "id": "ff1f83d0-1b3c-4752-8c47-bb2b6a0acd78",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -3362,7 +5536,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3397,7 +5582,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "dc94588e-7adc-4955-994f-59bf71cb2d5c",
+                                            "id": "4243bace-797c-41c7-b662-04ce88a99b66",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -3410,7 +5595,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3445,7 +5641,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "b30770f7-005a-46d8-a6e7-b13781f6b54e",
+                                            "id": "9fe63ab1-d846-41b7-a803-33c1c97f4142",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -3458,7 +5654,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3499,7 +5706,7 @@
                                     }
                                 },
                                 {
-                                    "id": "e14418fe-394d-4181-957d-ea20a875f50e",
+                                    "id": "799d0a9d-ecc3-4e4a-acb5-a513d52c3c7e",
                                     "name": "Soft-delete a billing type",
                                     "request": {
                                         "name": "Soft-delete a billing type",
@@ -3549,7 +5756,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "04e6a4e9-694b-41ff-9cac-769e0e6d8c60",
+                                            "id": "d31d85a4-f63f-495a-92bb-96d42fba0711",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -3562,7 +5769,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3584,7 +5802,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "2248d8a3-a46a-47ad-8617-7c48e38f9f5f",
+                                            "id": "634d385b-6761-46fd-8204-059b5fbeebad",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -3597,7 +5815,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3619,7 +5848,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "2beccd9a-e946-4d03-bdc4-227abd713eb4",
+                                            "id": "159c0660-2136-4024-b534-de5a58affb5d",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -3632,7 +5861,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -3670,7 +5910,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "a8f590c8-3afe-48a8-83b6-50df09f6b0e7",
+                                            "id": "575eb490-7ef7-43de-85ee-9a16587dd945",
                                             "name": "List billing types in a company (paginated)",
                                             "request": {
                                                 "name": "List billing types in a company (paginated)",
@@ -3740,7 +5980,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "c628be7f-1bdb-4980-96b9-e4dd43d8c7d5",
+                                                    "id": "9bec20d8-a434-40b7-8b8a-6bc6d904f860",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -3773,7 +6013,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -3795,7 +6046,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "957af760-afea-4be9-9836-8f3493f7f3a9",
+                                                    "id": "9effb3a4-ea6d-4166-95da-d8ae5ba19563",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -3828,7 +6079,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -3850,7 +6112,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "de123468-0325-4e01-9007-f9bd5e23c3b8",
+                                                    "id": "ba1b2da6-fb64-4917-9b45-8312ae11f3df",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -3883,7 +6145,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -3913,6 +6186,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "515c0adf-8710-435d-9b1e-0ca965110a86",
+                                    "name": "Bulk-create billingTypes (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create billingTypes (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ billingTypes: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "billingtype",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "1b6f63bb-afd9-4b0f-8d0e-73a04159799e",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "billingtype",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ed5d1eab-3bb6-43eb-a6f9-b9707d6860ff",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "billingtype",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "5c5caa20-2ab3-4df7-b1e4-b06fbb90ae67",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "billingtype",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ad2175a3-5ae8-4c5e-89c6-71bf8e4495a4",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "billingtype",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "3230a80a-15b4-4b68-b081-ac6407f0bc1e",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "billingtype",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"billingTypes\": [\n    {\n      \"btName\": \"<string>\",\n      \"btHourlyRate\": \"<number>\",\n      \"btCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -3921,7 +6557,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "6b03c944-f313-41ea-a46f-59d51cb100a4",
+                            "id": "dbd4b049-4127-42e8-b7df-932387f6443e",
                             "name": "Create an inventory item",
                             "request": {
                                 "name": "Create an inventory item",
@@ -3974,7 +6610,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "38de6c1e-00c5-4025-82c0-fbce72f7ef4a",
+                                    "id": "a430ef5d-bc49-4c00-b1d9-517d5bb7341f",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -4021,7 +6657,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "4a877d16-b75a-4af4-885c-600d8e1b1979",
+                                    "id": "9058ec30-a66c-4838-a0e1-fbffe79f193b",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -4068,7 +6704,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "a5dc1705-cc27-4049-ba84-19a839571e5b",
+                                    "id": "6fe34f8c-4d18-4312-b2b4-50c2eca4bb50",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -4125,7 +6761,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "96280652-f424-4ef5-9bc6-73e11c32a63e",
+                                    "id": "4ea16af6-0229-4bc3-a8c7-739097abdf5e",
                                     "name": "Get one inventory item",
                                     "request": {
                                         "name": "Get one inventory item",
@@ -4175,7 +6811,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "249c7421-4214-464c-b354-6fa3c526082c",
+                                            "id": "a23c5492-29e2-435c-9e31-0d9b30bea7c1",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -4188,7 +6824,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4210,7 +6857,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "f9df51ab-6631-436b-a266-a7bcf3770b70",
+                                            "id": "17496b74-e252-44d0-8c20-ce5d12665847",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -4223,7 +6870,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4245,7 +6903,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "22879ed5-f742-4404-9f40-9b2313c4e81e",
+                                            "id": "3be69821-6e5c-46bf-96e6-d2d3e4791e2c",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -4258,7 +6916,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4286,7 +6955,7 @@
                                     }
                                 },
                                 {
-                                    "id": "7c44b3fc-8c32-4b88-ae65-4c96002b485d",
+                                    "id": "51a6761b-8f48-4c96-a170-1f4c40f3c9ae",
                                     "name": "Partial update of an inventory item",
                                     "request": {
                                         "name": "Partial update of an inventory item",
@@ -4351,7 +7020,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "947c404f-99cd-4e86-9f63-7d425c3f1fdc",
+                                            "id": "779d8e4e-7f1b-4f85-918a-3f1c07e8c5fd",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -4364,7 +7033,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4399,7 +7079,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "0dc11686-02a4-4db4-9869-47352189023c",
+                                            "id": "318272aa-6f5b-4d4c-bd81-8a3722e9ee8b",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -4412,7 +7092,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4447,7 +7138,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "27f6255e-afb2-483f-89f6-0b702db66a90",
+                                            "id": "89e6382d-4931-4db7-96ea-de49d00d38f6",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -4460,7 +7151,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4495,7 +7197,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "30ef24d3-ae14-45e9-b3ff-49d0bbaac3be",
+                                            "id": "75e89ae8-e0bb-40ce-b310-2a7f5922f931",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -4508,7 +7210,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4549,7 +7262,7 @@
                                     }
                                 },
                                 {
-                                    "id": "8c4de4ef-1efc-4601-add4-c9b43dcf41b8",
+                                    "id": "9da43291-a9cf-47c7-badf-61920335ced3",
                                     "name": "Soft-delete an inventory item",
                                     "request": {
                                         "name": "Soft-delete an inventory item",
@@ -4599,7 +7312,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "8e93249e-25ab-44a4-ba5b-57697f107bd7",
+                                            "id": "38cc906d-9a63-494d-9e71-2f3e264ee183",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -4612,7 +7325,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4634,7 +7358,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "40b66146-d004-40b9-bc27-b14e9f588cfd",
+                                            "id": "61a3acc8-bd6b-45db-b2f0-dc9c0681ffca",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -4647,7 +7371,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4669,7 +7404,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "5cd1fb13-dc5f-4359-af1c-1c3163969bb5",
+                                            "id": "eadb4f63-9e36-4f35-a356-be809e09bef0",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -4682,7 +7417,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -4720,7 +7466,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "720b5896-4f10-4e34-915a-c8d070972d45",
+                                            "id": "a5e9fe6a-2a75-4e4b-88d0-4e64dec8236f",
                                             "name": "List inventory items in a company (paginated)",
                                             "request": {
                                                 "name": "List inventory items in a company (paginated)",
@@ -4790,7 +7536,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "5ecfb55b-8539-4c17-bfdf-9991aeada1fc",
+                                                    "id": "98778849-1f6d-4324-b462-57822b54464b",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -4823,7 +7569,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -4845,7 +7602,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "917b3c93-80b1-4bef-a68b-67f25640a8c5",
+                                                    "id": "aabaf110-a22b-4e79-85c2-631c877e932c",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -4878,7 +7635,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -4900,7 +7668,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "001bbb14-6df0-4acc-94e2-2613c2fcec2f",
+                                                    "id": "7ef65e18-d544-4eb5-8ce3-e7675cd59282",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -4933,7 +7701,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -4963,6 +7742,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "2354ed8c-8b88-4ecb-a222-a03839e54f1e",
+                                    "name": "Bulk-create inventoryItems (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create inventoryItems (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ inventoryItems: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "inventoryitem",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "9ea3ead5-aa28-45ab-84f1-565ce8f9466e",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventoryitem",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "cc8ec4ed-2027-4eb0-8944-17b3094539a2",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventoryitem",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "a48610d3-526e-411a-bf78-0481a5a1504e",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventoryitem",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "2d9f7de7-1933-429d-9947-b54850e856d2",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventoryitem",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "9f52940a-b96c-4a0b-a9a2-d08acba9c72c",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventoryitem",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryItems\": [\n    {\n      \"invitDescription\": \"<string>\",\n      \"invitQty\": \"<number>\",\n      \"invitCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -4971,7 +8113,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "77e39be3-21a7-4a15-94d2-5466ffb5457f",
+                            "id": "619f2553-3136-499f-9279-d6c8f890c7c4",
                             "name": "Create a company (master keys only)",
                             "request": {
                                 "name": "Create a company (master keys only)",
@@ -5024,7 +8166,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a0a6ca3b-77b2-4223-808b-6010e4bb8b66",
+                                    "id": "a0becf42-92bc-42ee-8a7b-df13f57fb310",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -5071,7 +8213,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "8550e3a8-3372-4320-a4cc-9fc4c26e19e3",
+                                    "id": "b260a462-9d1b-4e6a-8515-2a955c6a5b66",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -5118,7 +8260,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "11b72911-bb3a-4b53-a84f-7e5258be60e1",
+                                    "id": "64c50e6e-8501-4c6f-8725-9af56bf1f4b8",
                                     "name": "Non-master key",
                                     "originalRequest": {
                                         "url": {
@@ -5171,7 +8313,7 @@
                             }
                         },
                         {
-                            "id": "c17767c4-352d-4e25-b03f-40d8934b8945",
+                            "id": "7f0f3a7f-5ba7-4a53-bbfe-5ca9f7eea069",
                             "name": "List all companies (master keys only, paginated)",
                             "request": {
                                 "name": "List all companies (master keys only, paginated)",
@@ -5228,7 +8370,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "2fb82863-30e4-4761-a6a2-b480ae0535bf",
+                                    "id": "391be466-274b-4e8b-ba26-3f1eaf5f17e5",
                                     "name": "OK",
                                     "originalRequest": {
                                         "url": {
@@ -5281,7 +8423,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "3bea5195-1002-4468-b6a1-940ba87c3a74",
+                                    "id": "0185ecc4-b81c-43b7-a398-1febfde565d3",
                                     "name": "Non-master key",
                                     "originalRequest": {
                                         "url": {
@@ -5344,7 +8486,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "a532ccc9-d94a-4d59-adf9-9b248ff0717d",
+                                    "id": "ff570f6a-7226-4768-b513-61ff1f8706e2",
                                     "name": "Get one company (master: any; non-master: own only)",
                                     "request": {
                                         "name": "Get one company (master: any; non-master: own only)",
@@ -5394,7 +8536,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "bad73f20-304f-4d76-abb5-82249c37a27b",
+                                            "id": "279eb4d2-496a-4780-9d99-b24e33cf5968",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -5407,7 +8549,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5429,7 +8582,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "402566a0-a6d9-495b-a6d5-761ecaaf5b9b",
+                                            "id": "5d294a5b-c02b-47c7-a3bf-3c64c69d49ff",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -5442,7 +8595,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5464,7 +8628,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "57e27490-15a8-4341-b74d-b2e54120fbd2",
+                                            "id": "0aa7407d-8eab-48ff-a740-6c7227d31328",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -5477,7 +8641,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5505,7 +8680,7 @@
                                     }
                                 },
                                 {
-                                    "id": "9b4e53c6-1375-4723-a016-054a9ade3c79",
+                                    "id": "eef5042d-6e58-433d-a2f9-c59266175425",
                                     "name": "Partial update of a company (master: any; non-master: own only)",
                                     "request": {
                                         "name": "Partial update of a company (master: any; non-master: own only)",
@@ -5570,7 +8745,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "fe95fc10-a87a-4b85-a23e-b4492fc7ff5c",
+                                            "id": "d5aa771d-0d78-4844-9d60-0041e51e0e73",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -5583,7 +8758,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5618,7 +8804,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "4c044c30-e53e-4af7-8aef-cf5caf05b01e",
+                                            "id": "4d7f7262-aa2d-48a7-ae74-d16b2fa6b1fd",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -5631,7 +8817,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5666,7 +8863,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "287d0d0a-6039-4798-a3a1-37da766c3822",
+                                            "id": "3b7b3e40-ada9-4aa7-a763-afab8c968d68",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -5679,7 +8876,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5714,7 +8922,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e5610294-174a-4f08-ab60-e9e4b51ed539",
+                                            "id": "58eb3685-0591-459f-9b2f-ff2380bd04c5",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -5727,7 +8935,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5768,7 +8987,7 @@
                                     }
                                 },
                                 {
-                                    "id": "a180e596-faea-4ef1-a737-f5147f9b4d84",
+                                    "id": "bd08a943-9828-4dba-ad2e-aec03370915e",
                                     "name": "Soft-delete a company (master keys only)",
                                     "request": {
                                         "name": "Soft-delete a company (master keys only)",
@@ -5818,7 +9037,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "c3eb7736-c6fb-44c8-8b38-3815631052b5",
+                                            "id": "3cdbbea5-2221-4463-8bdf-04b82bc71de6",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -5831,7 +9050,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5853,7 +9083,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "0f872dbe-5e44-4ef2-b263-a7d829531dbf",
+                                            "id": "5bfbcde5-bbec-40e3-a0b0-cf2478a05f32",
                                             "name": "Non-master key",
                                             "originalRequest": {
                                                 "url": {
@@ -5866,7 +9096,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5888,7 +9129,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "3996f6fa-d235-4b43-a9ed-77e43a50b002",
+                                            "id": "44534aa8-e579-4ec0-bd1a-9e97e92e0eff",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -5901,7 +9142,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -5937,7 +9189,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "4016ab78-3a1a-428d-82d3-e7932418f8a8",
+                            "id": "c2cf486a-1eb7-48ff-8b1a-63c238e3ae73",
                             "name": "Create a job",
                             "request": {
                                 "name": "Create a job",
@@ -5990,7 +9242,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4110ad47-29a2-4b78-bc6d-f3a02c8a544c",
+                                    "id": "5efb9c93-6731-4b74-9857-bb07953c8242",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -6037,7 +9289,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "f24d6b14-7afa-4be5-9bca-0c005b337e01",
+                                    "id": "890d1a18-d784-42d7-9577-7c3d43dc6765",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -6084,7 +9336,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "9b225262-1f7a-431e-84d1-c5137ffdd67c",
+                                    "id": "12696937-be2e-483b-a63b-9f3a75040757",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -6141,7 +9393,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "38d2ced1-2aad-41c0-a5fd-28bb2fdcc202",
+                                    "id": "8ec976c4-2312-43b0-a94f-a1fa21e79ad2",
                                     "name": "Get one job",
                                     "request": {
                                         "name": "Get one job",
@@ -6191,7 +9443,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "26d950e7-ac8a-4a46-ada0-dfa592bb3326",
+                                            "id": "d350cea7-0a8b-431a-8054-bcf5db2139bd",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -6204,7 +9456,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6226,7 +9489,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "52bc599a-6144-409b-b771-3a76a84d34b8",
+                                            "id": "5bc69e34-992e-4dd8-b1cc-a14ef80a05f5",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -6239,7 +9502,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6261,7 +9535,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d21f4b6d-e048-47ce-855e-a72afb55f26a",
+                                            "id": "db9cc5dd-b5d1-45d4-8830-a5d2f913eef6",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -6274,7 +9548,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6302,7 +9587,7 @@
                                     }
                                 },
                                 {
-                                    "id": "fd59cb21-dcae-4237-b44c-d6e30b6b10b8",
+                                    "id": "fa5f9fb0-d3bb-48b9-a51b-12c81693e77b",
                                     "name": "Partial update of a job",
                                     "request": {
                                         "name": "Partial update of a job",
@@ -6367,7 +9652,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "ae962461-d6e2-40f1-b06e-3990ac71bb0a",
+                                            "id": "5be155b6-1f39-461e-a3d0-038b07ca4eb8",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -6380,7 +9665,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6415,7 +9711,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "630c902a-c87e-47b7-85db-b8cfc0947f15",
+                                            "id": "3fbc3d64-6274-4282-8525-454fafba5b09",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -6428,7 +9724,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6463,7 +9770,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d172d81f-43da-4a75-a24e-c4397952d692",
+                                            "id": "4f816bed-fb57-43b1-a2e0-6f025280c35a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -6476,7 +9783,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6511,7 +9829,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "5f1dbfbb-f684-4934-bcd2-9001f6d1b303",
+                                            "id": "2401e82e-2067-4f04-a665-0495152b1a5c",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -6524,7 +9842,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6565,7 +9894,7 @@
                                     }
                                 },
                                 {
-                                    "id": "577665b2-4df0-4205-9c26-63b101404d07",
+                                    "id": "c78e61b5-b695-4f4d-9cf4-1970a22fa8d0",
                                     "name": "Soft-delete a job",
                                     "request": {
                                         "name": "Soft-delete a job",
@@ -6615,7 +9944,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "91df928c-b6ab-4748-84e1-629000953325",
+                                            "id": "b79e6396-4cfb-4561-a0d7-5764409db671",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -6628,7 +9957,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6650,7 +9990,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "526a975e-933c-4c7b-9ce1-467864a735d3",
+                                            "id": "de9c8e6a-c8ab-4fff-9689-1a9ad7b2b934",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -6663,7 +10003,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6685,7 +10036,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "5bf15acf-7fac-48a2-a888-051dc0d2fcb4",
+                                            "id": "5bdf6248-338e-4f8f-a586-58e60dbd80a3",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -6698,7 +10049,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -6736,7 +10098,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "198608a3-865d-451c-8c9b-aaec19d4e661",
+                                            "id": "21e83c0f-27b6-4525-bc98-83d9fcd8b36f",
                                             "name": "List jobs for a customer (paginated)",
                                             "request": {
                                                 "name": "List jobs for a customer (paginated)",
@@ -6806,7 +10168,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "b3dc74b7-6a5e-4929-9d6d-1cc5d078ef4f",
+                                                    "id": "39a41571-07cb-419d-97a0-4685fd4e6ad9",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -6839,7 +10201,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -6861,7 +10234,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "3131e68c-c5c6-4292-9dd5-6f5fb0337099",
+                                                    "id": "4b6b11ff-ddbf-405f-985d-6e8fccfbfc28",
                                                     "name": "Invalid customer id",
                                                     "originalRequest": {
                                                         "url": {
@@ -6894,7 +10267,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -6916,7 +10300,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "b347a980-ae71-408d-b588-dbef1af5e458",
+                                                    "id": "69dc3bc2-a869-414d-ba12-1c6811cad8fb",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -6949,7 +10333,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -6979,6 +10374,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "29edf595-6487-4d87-beb3-7b317045fb07",
+                                    "name": "Bulk-create jobs (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create jobs (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ jobs: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "job",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "78f86961-6f29-4df7-9063-ec620740c1db",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "job",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "fe76212c-1448-47ed-a84c-3d3e3f8df4b6",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "job",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "309f9616-5ce7-4e95-8897-e6019f7525d9",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "job",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "69b4f69e-0bdb-431e-9943-094fbf9aea14",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "job",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "40f5945d-ad79-42d4-9dc9-9ad62b6ef596",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "job",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"jobs\": [\n    {\n      \"jobCustId\": \"<integer>\",\n      \"jobDesc\": \"<string>\",\n      \"jobInvoiced\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -6987,7 +10745,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "4fc4494f-7690-4067-b073-d79b6959036e",
+                            "id": "05ee9c3f-9efe-49c3-ab9c-b658ca8fe874",
                             "name": "Create an invoice",
                             "request": {
                                 "name": "Create an invoice",
@@ -7040,7 +10798,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "577aa02a-8451-458d-9c07-da5658f7e68c",
+                                    "id": "12453ad0-54c3-4a5d-b134-2baea41b7f43",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -7087,7 +10845,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "ef02a6d0-24bd-4fa2-a859-c5db4c9bcc42",
+                                    "id": "53d61a3b-b1af-4ed1-a212-872fb461312b",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -7134,7 +10892,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "9d5168b1-44ec-4f08-908c-adcdc7439091",
+                                    "id": "0327a2fb-db20-4c31-b5dc-8a32cdf22cfc",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -7191,7 +10949,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "b69cbfea-455a-4d64-badd-ea3cc2256bf3",
+                                    "id": "906d6b2d-bed9-4243-89ec-9c7d556f27dd",
                                     "name": "Get one invoice",
                                     "request": {
                                         "name": "Get one invoice",
@@ -7241,7 +10999,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "c5ce5fc7-9849-4c51-8979-0f30bad86eef",
+                                            "id": "a6c1c960-4a68-4d29-8b62-61f14f762a01",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -7254,7 +11012,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7276,7 +11045,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "6bb58bc7-2f54-4b61-9ca8-2fb9c6e8746b",
+                                            "id": "87a50be0-c71b-4399-b888-b250d58daa5f",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -7289,7 +11058,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7311,7 +11091,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "509777e7-792a-43cc-b2e0-8deff7fdbb22",
+                                            "id": "91597680-a7fc-4421-aa4f-c7811fbb1aec",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -7324,7 +11104,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7352,7 +11143,7 @@
                                     }
                                 },
                                 {
-                                    "id": "a1d1b050-042f-4be5-9ffd-41a07006089d",
+                                    "id": "ea11c4a8-7c6f-43c0-9e50-eff53914e23c",
                                     "name": "Partial update of an invoice",
                                     "request": {
                                         "name": "Partial update of an invoice",
@@ -7417,7 +11208,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "d72ee4ce-09f3-420b-a22e-d1f9ce3f76b2",
+                                            "id": "6eddb409-6135-4d2c-919a-d88ad47cc708",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -7430,7 +11221,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7465,7 +11267,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "fa6b654c-433a-41b7-bef2-3b03ae9395f6",
+                                            "id": "9b359b0a-2a4f-466a-b143-2b395163f25e",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -7478,7 +11280,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7513,7 +11326,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d850fc05-4ec0-43e8-9000-298b03d62825",
+                                            "id": "147a1d51-9fad-4640-aeb3-f2ccb5a383c6",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -7526,7 +11339,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7561,7 +11385,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "dd4d9af8-07c9-4ccd-af55-d686d7158543",
+                                            "id": "c78a8dd5-599a-4539-baab-1696d0796e71",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -7574,7 +11398,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7615,7 +11450,7 @@
                                     }
                                 },
                                 {
-                                    "id": "af005593-7ef0-4ef5-8cb6-5228c7f8ef31",
+                                    "id": "23b0fadf-4241-4233-884b-08828e6df6b3",
                                     "name": "Soft-delete an invoice",
                                     "request": {
                                         "name": "Soft-delete an invoice",
@@ -7665,7 +11500,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "df8fb935-a7aa-466d-9ac4-6a7f1bb85d7f",
+                                            "id": "6c6068e4-4d95-4f48-ae9e-dcde45c3fccb",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -7678,7 +11513,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7700,7 +11546,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "08e4fbeb-8898-47fa-9974-9a9ba4550d9b",
+                                            "id": "05171721-3cd3-498e-9520-ae72d107de85",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -7713,7 +11559,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7735,7 +11592,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "7c00066a-fb30-4d44-a970-643ed4f257e6",
+                                            "id": "67e7eb66-2fbd-461d-96cf-320814393128",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -7748,7 +11605,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -7786,7 +11654,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "58f7c5fd-38de-47e1-b9e6-fadf0a9bfbf9",
+                                            "id": "21204676-4264-485e-af6d-dba7c4dc1026",
                                             "name": "List invoices for a customer (paginated)",
                                             "request": {
                                                 "name": "List invoices for a customer (paginated)",
@@ -7856,7 +11724,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "cc8f7889-c276-4954-a4d1-2bc2d6ca3612",
+                                                    "id": "d5fe3447-740b-4078-bbbe-75fbbfa0e5c2",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -7889,7 +11757,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -7911,7 +11790,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "53ef2d08-f409-4bbc-871e-154e1b27bff1",
+                                                    "id": "f4c92355-331c-4f35-978f-9dc8a8779541",
                                                     "name": "Invalid customer id",
                                                     "originalRequest": {
                                                         "url": {
@@ -7944,7 +11823,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -7966,7 +11856,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "dd749c68-0144-411a-b9ea-91ce6ba00c18",
+                                                    "id": "07cbfea2-a855-450c-b4a3-26252cedc64c",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -7999,7 +11889,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -8029,6 +11930,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "02ded388-21a6-464d-ae0e-19b2ecca31ed",
+                                    "name": "Bulk-create invoices (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create invoices (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ invoices: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "invoice",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "c504e717-1b28-46bf-a156-f8e9afadc925",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoice",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "a2e5cb1e-fe4c-4157-80b5-21ef61d641db",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoice",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "26d90349-12dc-4ce4-8d40-4f116f21f5e8",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoice",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "9128ca22-750b-43bf-9de0-326caa6ce89b",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoice",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "2dc24487-6cc5-4cc8-afe5-79c1513bdb54",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoice",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoices\": [\n    {\n      \"invCustId\": \"<integer>\",\n      \"invDate\": \"<date>\",\n      \"invDueDate\": \"<date>\",\n      \"invPaid\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -8037,7 +12301,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "3a597c20-9ca3-4dc8-90a3-12ecbe9780ed",
+                            "id": "b0467e3a-33b5-44e1-b78f-4ef73852ebfb",
                             "name": "Create a customer payment",
                             "request": {
                                 "name": "Create a customer payment",
@@ -8090,7 +12354,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e758dcda-114e-4021-85aa-381e5dfde599",
+                                    "id": "d23fda79-ecf2-428d-91c4-c6c8a0a26130",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -8137,7 +12401,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "8a10cbdb-ee7c-4383-8082-b0bd5ee0789d",
+                                    "id": "3cae4c7c-0179-45fe-829e-5f202294adb4",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -8184,7 +12448,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "b88c7511-451f-462c-b707-8a31fe232f16",
+                                    "id": "1aa4eacf-fa9b-472b-b9c0-5261f066bab8",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -8241,7 +12505,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "5e4161c5-5547-4ab1-98ba-67999f239703",
+                                    "id": "4f9d7592-590d-4c66-89af-18dce986fff6",
                                     "name": "Get one customer payment",
                                     "request": {
                                         "name": "Get one customer payment",
@@ -8291,7 +12555,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "8f41d25f-0cd9-41c8-b26b-9a5d56c0092c",
+                                            "id": "6153cde0-076d-422e-af0b-672982255ce5",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -8304,7 +12568,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8326,7 +12601,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "86b4dc38-f39a-49c5-bfbe-c9792b168383",
+                                            "id": "712ae0c2-6795-46c2-bed1-5d08758c5215",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -8339,7 +12614,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8361,7 +12647,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d42c2d1a-72b2-4967-a8a7-baa8a97330c0",
+                                            "id": "1a277641-8133-41ea-9f97-d51d173d8ec9",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -8374,7 +12660,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8402,7 +12699,7 @@
                                     }
                                 },
                                 {
-                                    "id": "06e71196-0820-416f-b97a-16e7a1476a04",
+                                    "id": "a6f21532-02dc-41db-af5f-de285a1a0199",
                                     "name": "Partial update of a customer payment",
                                     "request": {
                                         "name": "Partial update of a customer payment",
@@ -8467,7 +12764,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "ccac52de-ec39-49f7-ad12-6745d34d42a1",
+                                            "id": "33cbc001-f6fb-4575-ac11-1cbded3795ff",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -8480,7 +12777,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8515,7 +12823,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "94e41d1d-b88b-4c58-8bc5-6c79c9fa607a",
+                                            "id": "5be4fa0f-af39-44bb-96ce-4930a2008136",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -8528,7 +12836,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8563,7 +12882,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "0958f03b-7027-4279-8ca9-2fd2e712a57b",
+                                            "id": "0628b039-8439-4a91-987c-ffb51829d48c",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -8576,7 +12895,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8611,7 +12941,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "85cbe19e-ad0a-4f8a-b8af-0550c5998f7c",
+                                            "id": "572ddf4f-735f-4513-acb2-b9c4472c3f35",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -8624,7 +12954,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8665,7 +13006,7 @@
                                     }
                                 },
                                 {
-                                    "id": "acb2fec0-9117-44e5-a0a7-c8fe216821bc",
+                                    "id": "d03b4826-8b2d-4409-b9e6-5994bd52f26b",
                                     "name": "Soft-delete a customer payment",
                                     "request": {
                                         "name": "Soft-delete a customer payment",
@@ -8715,7 +13056,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "cd7a3813-fb23-4499-82a4-da29b95afc09",
+                                            "id": "baec947f-af0d-48ce-ba51-13c17e65883b",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -8728,7 +13069,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8750,7 +13102,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "249f5224-913d-4068-a808-860d8f2d4f01",
+                                            "id": "0630e4b2-4d54-42d1-94dc-10eb37ae8521",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -8763,7 +13115,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8785,7 +13148,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "cd0d458f-fe9a-4181-bebb-678ddf004d1a",
+                                            "id": "7230aecf-08e9-4424-b89b-a27edb090f9e",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -8798,7 +13161,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -8836,7 +13210,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "61134cc0-e787-4983-99f4-16a977e645d6",
+                                            "id": "bd7ff1ec-f24d-4d60-8f36-553b247b058f",
                                             "name": "List customer payments for a customer (paginated, newest first)",
                                             "request": {
                                                 "name": "List customer payments for a customer (paginated, newest first)",
@@ -8906,7 +13280,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "83515d0f-70c6-4c9e-8afc-da12de42f958",
+                                                    "id": "2b1515b7-484e-4bd5-b9b2-2bf4b6881ae8",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -8939,7 +13313,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -8961,7 +13346,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "3711e7ff-fea1-45c3-8a8e-5dc7ad973c3a",
+                                                    "id": "9c17b2d7-82ee-4613-bbac-33ec591a72bb",
                                                     "name": "Invalid customer id",
                                                     "originalRequest": {
                                                         "url": {
@@ -8994,7 +13379,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -9016,7 +13412,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "a959ae74-4d86-433f-94be-b6df72646b2a",
+                                                    "id": "d9b19445-dab3-49c1-bb67-6ed46bb89582",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -9049,7 +13445,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -9079,6 +13486,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "7777bd9a-8de7-432c-a2d4-ed635807c5ac",
+                                    "name": "Bulk-create customerPayments (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create customerPayments (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ customerPayments: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "customerpayment",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "398a501f-ad0f-4bc1-9908-1022690c2d22",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customerpayment",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "48732921-f4f3-4a4d-a865-0e2c4df7d638",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customerpayment",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "a753ec50-f538-448c-a138-fcdf76c01b4c",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customerpayment",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "a327e238-3b26-4189-8e2c-fa64e3a41548",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customerpayment",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "21f28b46-5e10-407a-9c7e-8eefe1e2422d",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "customerpayment",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"customerPayments\": [\n    {\n      \"cpayCustId\": \"<integer>\",\n      \"cpayDescription\": \"<string>\",\n      \"cpayDate\": \"<date>\",\n      \"cpayAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -9087,7 +13857,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "a82393a1-be73-42f7-93cf-6e4b1d890840",
+                            "id": "bbbb9a06-dc1c-45f2-926d-5b10e7d6e2be",
                             "name": "Create an invoice line (job → invoice)",
                             "request": {
                                 "name": "Create an invoice line (job → invoice)",
@@ -9140,7 +13910,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8883d280-4a0d-455f-9bd2-264dafb65814",
+                                    "id": "d8871053-a99c-41b1-9819-faa47f8dad4e",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -9187,7 +13957,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "d0156c8f-30be-4ee3-a545-f2dd987f4ea9",
+                                    "id": "442b9aa1-e3c2-45a7-9c0c-95373838b14b",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -9234,7 +14004,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "0c8742a6-b940-413a-bb25-ba9fd4838f05",
+                                    "id": "83a4ddee-6e52-4646-af0b-a3c09231d61a",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -9291,7 +14061,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "7f8596fe-5094-481c-8849-3f52312e652d",
+                                    "id": "8855c983-520b-416a-be9d-adb607869c92",
                                     "name": "Get one invoice line",
                                     "request": {
                                         "name": "Get one invoice line",
@@ -9341,7 +14111,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "2b3376db-2695-4346-9614-89b960f8422f",
+                                            "id": "c4ff66fd-6ec2-437f-b223-412b661b0c18",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -9354,7 +14124,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9376,7 +14157,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "386c6e28-159c-4e05-9b0c-f9db2e011349",
+                                            "id": "bbd8585a-db9d-4816-9e75-3a51e46b7f2a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -9389,7 +14170,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9411,7 +14203,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "a93b16a3-e151-4d77-965f-aa5912d63653",
+                                            "id": "dbfcaa71-3f4a-4c32-ad25-b1c209d39ad5",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -9424,7 +14216,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9452,7 +14255,7 @@
                                     }
                                 },
                                 {
-                                    "id": "9ef92106-93b0-45ca-87e1-c3de34563677",
+                                    "id": "213a2675-2169-4bac-9c42-2ec5a67b4dce",
                                     "name": "Partial update of an invoice line",
                                     "request": {
                                         "name": "Partial update of an invoice line",
@@ -9517,7 +14320,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "708e6b45-0b52-4a5b-a5ba-cc6f6b60d4cb",
+                                            "id": "6da904df-352c-465f-97b6-0ae87bc2c2f6",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -9530,7 +14333,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9565,7 +14379,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "21249e19-4876-41c2-a8de-076b6b64d2f5",
+                                            "id": "bc97a624-41eb-4d3a-896a-bda1ca62cf7b",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -9578,7 +14392,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9613,7 +14438,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "107e56b1-788e-4c4e-89df-964553d69a4f",
+                                            "id": "4e17f40d-6c5c-4f8a-977a-c6df3f6b8702",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -9626,7 +14451,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9661,7 +14497,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "c70dac85-196e-4faf-a544-9041a0b7fbeb",
+                                            "id": "b6f0155c-ad8a-48f1-b6c5-cbca16c2a6f5",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -9674,7 +14510,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9715,7 +14562,7 @@
                                     }
                                 },
                                 {
-                                    "id": "76740634-3222-46de-93ee-c200b4ad7cc7",
+                                    "id": "f8a6c5cb-1cd7-411e-8d33-ec6f21169d47",
                                     "name": "Soft-delete an invoice line",
                                     "request": {
                                         "name": "Soft-delete an invoice line",
@@ -9765,7 +14612,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "1768b827-f900-4357-b162-b7b463c830f7",
+                                            "id": "fa72a66d-8f43-4412-ba55-d4628733a58c",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -9778,7 +14625,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9800,7 +14658,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "204dbaec-fed6-4a7c-aebc-7b8fde706cab",
+                                            "id": "837ca313-f2ae-4888-93a1-c10557681e78",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -9813,7 +14671,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9835,7 +14704,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "ae37c4c0-7386-4792-b922-7ab4649d49b1",
+                                            "id": "24a4d544-a0ab-4b3e-a5e9-cfa5c2c21226",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -9848,7 +14717,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -9886,7 +14766,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "b8431a79-f170-4bca-bf16-99e42bd28c2b",
+                                            "id": "8d32e2f0-61ee-4ed9-a023-7120b2c861be",
                                             "name": "List invoice lines for an invoice (paginated)",
                                             "request": {
                                                 "name": "List invoice lines for an invoice (paginated)",
@@ -9956,7 +14836,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "8b60664b-35dd-4d11-86e4-270f2ba6b9b8",
+                                                    "id": "50bb8447-05a1-45dd-8aaa-c1b5130daf41",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -9989,7 +14869,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -10011,7 +14902,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "2af61a48-7698-48b1-92fe-7233de0ec3a5",
+                                                    "id": "78975c96-eecf-40ad-9a3d-7777269baf89",
                                                     "name": "Invalid invoice id",
                                                     "originalRequest": {
                                                         "url": {
@@ -10044,7 +14935,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -10066,7 +14968,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "ed9e48b0-5ca9-4b00-a7d4-465493d0f20f",
+                                                    "id": "671d121e-4e8f-42c3-8a30-3c719e3a8b7d",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -10099,7 +15001,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -10129,6 +15042,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "ca4c6243-7043-4526-8f2a-710540219a3d",
+                                    "name": "Bulk-create invoiceJobs (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create invoiceJobs (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ invoiceJobs: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "invoicejob",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "27b43ef3-9a75-4709-8c6f-025272071658",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoicejob",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "fdb0b206-47a6-48eb-9f29-ca6f033b550e",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoicejob",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ea0585c8-bc0b-4477-a44b-5cc392e168a8",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoicejob",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ef198e54-af74-4e55-beb7-4d950e8eb24b",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoicejob",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "728f0f0f-cee1-4833-98ec-8257a781c77c",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "invoicejob",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"invoiceJobs\": [\n    {\n      \"injbInvId\": \"<integer>\",\n      \"injbJobId\": \"<integer>\",\n      \"injbAmount\": \"<number>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -10137,7 +15413,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "56d7ea41-cc30-4f91-b3b4-d889b9f0d12b",
+                            "id": "280c7c96-c065-4afd-9a51-ed83b7e46f95",
                             "name": "Create a product entry",
                             "request": {
                                 "name": "Create a product entry",
@@ -10190,7 +15466,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "cea82dd6-c2d6-4f78-9470-2d8c18cd6774",
+                                    "id": "4e924b79-c079-4884-a002-150e1da89a8c",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -10237,7 +15513,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "5bb19b41-61ca-4ecc-9097-352d0e5968ba",
+                                    "id": "0a477d38-40cc-42a7-95ab-b39bd5e99465",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -10284,7 +15560,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "acc601ac-f14e-4b12-8f33-a55bf5b0268e",
+                                    "id": "b143e62a-07f5-4c2e-a1bb-6abf27b7881c",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -10341,7 +15617,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "78fdcbc5-25ee-4e4a-b277-6d9854832dca",
+                                    "id": "ae34de99-4d84-453c-9c69-87943592012c",
                                     "name": "Get one product entry",
                                     "request": {
                                         "name": "Get one product entry",
@@ -10391,7 +15667,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "1189bd0d-718a-42e1-a90d-5daa31c0b24c",
+                                            "id": "95eab3cc-fcfc-4e5f-86bd-eec82f5b1882",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -10404,7 +15680,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10426,7 +15713,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "4401314d-fd21-461c-95bf-98b5e1d0f05b",
+                                            "id": "3e99113f-aa8b-42fb-b82f-4b7dcf92bd7a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -10439,7 +15726,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10461,7 +15759,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e7ce819e-bbaf-466b-b06c-035275340c65",
+                                            "id": "38c484a4-cbd6-4c20-9b85-c691e37667c4",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -10474,7 +15772,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10502,7 +15811,7 @@
                                     }
                                 },
                                 {
-                                    "id": "4022a583-9055-4e7f-94ba-e97702cb5cf2",
+                                    "id": "5622f800-e3b5-4d03-a199-662899d770bf",
                                     "name": "Partial update of a product entry",
                                     "request": {
                                         "name": "Partial update of a product entry",
@@ -10567,7 +15876,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "d2f8b016-e48b-437e-b9bc-791b6a6799d0",
+                                            "id": "88d37720-6fce-4223-bcc0-c7a6972be52c",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -10580,7 +15889,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10615,7 +15935,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "12bdc890-f5b0-4755-9c80-4b1ad0585a49",
+                                            "id": "13b0f0d6-7b9a-4713-bad0-73ffc0263a25",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -10628,7 +15948,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10663,7 +15994,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "5fea4a04-e938-43fc-905e-db6b6435f1c3",
+                                            "id": "0c9f44fe-28f3-4a0d-9efb-6674a153103a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -10676,7 +16007,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10711,7 +16053,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "6d365a69-6a78-473e-9254-26873b7bcc3c",
+                                            "id": "91f5f213-a910-45af-866e-82b6a16dcac9",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -10724,7 +16066,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10765,7 +16118,7 @@
                                     }
                                 },
                                 {
-                                    "id": "1d3f2adb-82a8-4c57-a2ff-183557fa8e99",
+                                    "id": "9a556234-899b-42ee-a0fd-c406bad7325d",
                                     "name": "Soft-delete a product entry",
                                     "request": {
                                         "name": "Soft-delete a product entry",
@@ -10815,7 +16168,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "c2f0a85a-815a-45e3-8422-a907c7f51455",
+                                            "id": "ec09ca30-ab2c-4719-a940-57f121805bbb",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -10828,7 +16181,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10850,7 +16214,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "9b1b387a-54af-4351-96ec-0273f96a1ad8",
+                                            "id": "08ab0402-b0eb-4585-8e45-733c4c54eac9",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -10863,7 +16227,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10885,7 +16260,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "8b65083f-ef0f-44a6-bb9b-1326eb9582dd",
+                                            "id": "04061cf9-8383-445c-88eb-cb86717144be",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -10898,7 +16273,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -10936,7 +16322,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "597e63c0-04b4-4ac5-a927-491f913995bf",
+                                            "id": "5a8fe209-a7e4-4dac-b42d-e0905b46dbf1",
                                             "name": "List product entries for a job (paginated)",
                                             "request": {
                                                 "name": "List product entries for a job (paginated)",
@@ -11006,7 +16392,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "4ef12b4d-7e80-43e8-a8cb-c11e7cd17c2e",
+                                                    "id": "c5afb155-4b6e-45f2-a2dd-7be7ab53245b",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -11039,7 +16425,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -11061,7 +16458,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "094f4a1a-ca4e-4148-9113-bbb83608a94c",
+                                                    "id": "8b63a4c0-623c-45b8-b492-7348c3aeb30a",
                                                     "name": "Invalid job id",
                                                     "originalRequest": {
                                                         "url": {
@@ -11094,7 +16491,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -11116,7 +16524,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "eed7a264-c697-454c-ad8e-75ff36dd9f72",
+                                                    "id": "8e68a9be-a022-4e7e-85cb-0db6958607d7",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -11149,7 +16557,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -11179,6 +16598,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "55b1c917-27dc-44c0-8b15-c59d9514a53c",
+                                    "name": "Bulk-create productEntries (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create productEntries (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ productEntries: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "productentry",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "0f1d4c9e-597c-478f-9f7d-269c147a70ce",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "productentry",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "717acc6e-897a-47bb-8787-fd80e60307ef",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "productentry",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "8aafaa91-d836-427d-bb79-722da7510d4c",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "productentry",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "c07cfca4-b5a5-4d50-8d29-a7f6c01e62ac",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "productentry",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "1214d3c3-d28f-4b33-b891-022ad8cc373c",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "productentry",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"productEntries\": [\n    {\n      \"pentQty\": \"<integer>\",\n      \"pentJobId\": \"<integer>\",\n      \"pentInvtId\": \"<integer>\",\n      \"pentTaxable\": \"<boolean>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -11187,7 +16969,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "845c95db-0a1b-46bb-be8f-f55303a6505d",
+                            "id": "aa1aaedd-1c61-451b-a131-c09f20354324",
                             "name": "Create a version info record (master keys only)",
                             "request": {
                                 "name": "Create a version info record (master keys only)",
@@ -11240,7 +17022,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4ec73e3d-5315-4cff-9e95-26817664f220",
+                                    "id": "aed5930a-cd1f-4de7-9050-aa1889306f25",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -11287,7 +17069,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "5f6b0b7c-87a6-4a7d-a814-dbe172a5f860",
+                                    "id": "44a0fbd9-e21a-4208-ac3e-5565e4db60f0",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -11334,7 +17116,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "6d173088-342c-45b2-adfe-5ea25a2e41b0",
+                                    "id": "8f27dbfb-535c-4712-95ec-2e270ad9fa8d",
                                     "name": "Non-master key",
                                     "originalRequest": {
                                         "url": {
@@ -11387,7 +17169,7 @@
                             }
                         },
                         {
-                            "id": "afad17ef-4ecb-4430-8736-17273c659302",
+                            "id": "19a272fb-1822-481a-94d9-e9afef61ab7e",
                             "name": "List version info (any authKey)",
                             "request": {
                                 "name": "List version info (any authKey)",
@@ -11444,7 +17226,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "9ff2c587-66bb-4152-b3c8-090b5423f6c9",
+                                    "id": "bda13cf9-0def-4549-8f7b-393f0b47e6b4",
                                     "name": "OK",
                                     "originalRequest": {
                                         "url": {
@@ -11497,7 +17279,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "66d9ae0c-6617-404c-b2bb-d549dc2c7eea",
+                                    "id": "c33b04cd-4527-460d-aab0-aada7ed6be8f",
                                     "name": "Missing authKey",
                                     "originalRequest": {
                                         "url": {
@@ -11560,7 +17342,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "3be9d6cc-878d-4835-800e-96f5ce9c0759",
+                                    "id": "ce0afcbe-464d-4935-a20a-29c5a5b08132",
                                     "name": "Get one version info (any authKey)",
                                     "request": {
                                         "name": "Get one version info (any authKey)",
@@ -11610,7 +17392,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "4043564a-0a69-4449-b5f3-a5bbfa815ff6",
+                                            "id": "04e71026-e7ca-4962-ad71-e001a20a1e08",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -11623,7 +17405,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11645,7 +17438,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "b7e130d5-9d6b-4c3e-8503-baff4068a36d",
+                                            "id": "a3f644c1-e2d3-4f32-846a-a21678e5f28f",
                                             "name": "Missing authKey",
                                             "originalRequest": {
                                                 "url": {
@@ -11658,7 +17451,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11680,7 +17484,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d60e82df-9a54-44e2-aa21-4e9df47d5911",
+                                            "id": "f83a73b4-106e-456f-9189-a98d1870e7b5",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -11693,7 +17497,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11721,7 +17536,7 @@
                                     }
                                 },
                                 {
-                                    "id": "caa9798b-4baf-4b4e-8005-72f26ef6502b",
+                                    "id": "3ee00032-edc2-441f-b014-1b6ae20ae6a6",
                                     "name": "Partial update of a version info (master keys only)",
                                     "request": {
                                         "name": "Partial update of a version info (master keys only)",
@@ -11786,7 +17601,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "5b1fa7c7-9a53-4ba7-8ef4-71d109a5fd67",
+                                            "id": "3e29aeee-dc4d-4e44-a089-61b7a7f80705",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -11799,7 +17614,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11834,7 +17660,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "62f1811f-635d-4cba-ad9f-12bdbba50351",
+                                            "id": "e1486f85-85ef-4fa5-8cf6-074bf26fe42e",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -11847,7 +17673,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11882,7 +17719,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "623e63a2-2f3f-452d-b662-9036379109c0",
+                                            "id": "51a4f8bd-cf0c-4efb-a815-170657a6bd64",
                                             "name": "Non-master key",
                                             "originalRequest": {
                                                 "url": {
@@ -11895,7 +17732,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11930,7 +17778,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "8ca8858a-2df1-41a5-94eb-0ac1b29c2e30",
+                                            "id": "08690b11-3c89-495c-9231-ddec4457c3e0",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -11943,7 +17791,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -11984,7 +17843,7 @@
                                     }
                                 },
                                 {
-                                    "id": "8a06ac5f-3a30-4f36-b29c-961698513ee4",
+                                    "id": "6d9af43b-233a-43fc-b8bf-3d9e1c843eba",
                                     "name": "Hard-delete a version info (master keys only — no archive column on this table)",
                                     "request": {
                                         "name": "Hard-delete a version info (master keys only — no archive column on this table)",
@@ -12034,7 +17893,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "3dca64c9-7ad7-480a-ac8e-a104f20814a9",
+                                            "id": "94f48768-8ddf-495c-bbc4-47ecb41a4741",
                                             "name": "Deleted",
                                             "originalRequest": {
                                                 "url": {
@@ -12047,7 +17906,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12069,7 +17939,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "834592a9-90b4-4373-a68c-d0a39e7f088e",
+                                            "id": "f4047aa0-cdcc-4b45-a25f-797570da1d07",
                                             "name": "Non-master key",
                                             "originalRequest": {
                                                 "url": {
@@ -12082,7 +17952,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12104,7 +17985,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "1b31f772-c34e-4487-b480-33bec2dd7547",
+                                            "id": "fd5b2f9c-2608-453b-b448-a18e05c2f06a",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -12117,7 +17998,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12153,7 +18045,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "6b30826f-0954-4e0a-91ea-1b2c09360453",
+                            "id": "0040cf6d-5ca2-44aa-beec-1593abbe34a6",
                             "name": "Create a PO vendor",
                             "request": {
                                 "name": "Create a PO vendor",
@@ -12206,7 +18098,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0210e07e-95a5-4401-a20d-28b5ea8ed8d3",
+                                    "id": "9fb46219-ce3a-40f7-8499-4e3d9cf5356b",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -12253,7 +18145,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "cb0bb5ab-d2ff-4563-a179-0e37ca4b4fb4",
+                                    "id": "b85f5590-76b6-4ca0-9065-b450204d4e09",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -12300,7 +18192,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "ce50aa97-5a20-48b4-8e43-026e74009793",
+                                    "id": "73cfed7c-f2f3-4e74-8c3b-1c009a6cd92b",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -12357,7 +18249,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "4a68167e-efe7-4642-a7cd-062f7a32a127",
+                                    "id": "8a17d957-d804-412a-a6e8-574d0705afa3",
                                     "name": "Get one PO vendor",
                                     "request": {
                                         "name": "Get one PO vendor",
@@ -12407,7 +18299,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "9438af4c-b54f-4468-8118-b056d8eaecb4",
+                                            "id": "d0cb8c8b-a729-44d7-886f-2b11c18b5c3b",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -12420,7 +18312,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12442,7 +18345,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "ade92767-5faf-4ebd-bca7-e7f75f287581",
+                                            "id": "cffd91b1-ff39-4a4b-911c-9e5200490d75",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -12455,7 +18358,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12477,7 +18391,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "3385dee2-105b-4ee2-98ed-07990677d8cf",
+                                            "id": "b2b37b77-82a7-4ed9-b960-11f8eedc3e52",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -12490,7 +18404,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12518,7 +18443,7 @@
                                     }
                                 },
                                 {
-                                    "id": "5bbb977c-3b81-42b6-af6c-bef17342c066",
+                                    "id": "78fbe2d2-819e-447c-b5be-fa151b49fd87",
                                     "name": "Partial update of a PO vendor",
                                     "request": {
                                         "name": "Partial update of a PO vendor",
@@ -12583,7 +18508,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "9bfde47b-8a19-4f1a-94b4-09dd7a988c7d",
+                                            "id": "115ef8df-9d63-45b4-9b3c-11f572a6bab1",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -12596,7 +18521,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12631,7 +18567,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e0ad15b5-570e-4c42-b1a6-fd96a261e214",
+                                            "id": "396bf679-3ea8-41b2-afe7-6b08ef38ab8b",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -12644,7 +18580,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12679,7 +18626,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "ed3891f4-c6d4-47f5-8240-88f0fb69ab09",
+                                            "id": "ac312246-bbf2-47bf-bfcf-f140c257349b",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -12692,7 +18639,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12727,7 +18685,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "2e23d686-4ea6-4238-af71-fa8940a9ca68",
+                                            "id": "0c3bb7b9-3342-46ff-a00e-5b024c456c48",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -12740,7 +18698,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12781,7 +18750,7 @@
                                     }
                                 },
                                 {
-                                    "id": "4004e9f9-083c-4712-91e4-96e4e9094513",
+                                    "id": "a273dd6e-320b-4f67-9a7b-995cf6ecbc74",
                                     "name": "Soft-delete a PO vendor",
                                     "request": {
                                         "name": "Soft-delete a PO vendor",
@@ -12831,7 +18800,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "7dcdf6f4-b160-4029-a84a-aaa1740c7494",
+                                            "id": "f57517cb-d9ea-4539-8ec9-729690ef5324",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -12844,7 +18813,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12866,7 +18846,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "b174e3c5-e2a5-4f48-9ae0-8a5ffc423fc6",
+                                            "id": "b12deb12-64e0-46ac-b7ca-ffdea602ecac",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -12879,7 +18859,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12901,7 +18892,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "6e6ed9ff-25c7-451f-b3ad-95ca60f3d927",
+                                            "id": "431a0bfd-23f2-4ee9-8a39-f6bae3066c48",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -12914,7 +18905,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -12952,7 +18954,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "0cc625d2-6c61-4da1-8668-06e798eb1064",
+                                            "id": "70255bdc-8e25-4c60-bf0a-95df25ea8f36",
                                             "name": "List PO vendors in a company (paginated)",
                                             "request": {
                                                 "name": "List PO vendors in a company (paginated)",
@@ -13022,7 +19024,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "acef6d51-e88d-4f77-9073-f8f17110fb89",
+                                                    "id": "6f35629d-f0a4-4d8b-921b-0d7764579ccb",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -13055,7 +19057,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -13077,7 +19090,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "fab05b1a-a78f-457d-be6c-b1f87e40ddf2",
+                                                    "id": "dfb65ce6-bf59-4ebe-9be5-1499e935e83b",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -13110,7 +19123,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -13132,7 +19156,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "6569d048-3cae-428c-9ca4-eb44ce18dbc7",
+                                                    "id": "fdfb6cb9-679d-4a22-917b-a986cccda484",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -13165,7 +19189,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -13195,6 +19230,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "55c80fa7-cb4a-4fd1-88f7-c76f1be49b20",
+                                    "name": "Bulk-create vendors (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create vendors (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ vendors: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "purchaseordervendor",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "fd141664-56c3-4c18-8d0e-064d1b2a2250",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseordervendor",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "f2a92969-1aa0-4aea-9f2a-3179e742fbfb",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseordervendor",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "328bf9f0-f676-4fce-b8fb-8c2f5de1e5a0",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseordervendor",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "9876000e-d913-4d40-a5c3-0dce1547e662",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseordervendor",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "bbeb9fc6-bae7-45eb-aaa4-c788a513488a",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseordervendor",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"vendors\": [\n    {\n      \"povName\": \"<string>\",\n      \"povMailingAddress1\": \"<string>\",\n      \"povMailingAddress2\": \"<string>\",\n      \"povMailingCity\": \"<string>\",\n      \"povMailingState\": \"<string>\",\n      \"povMailingCountry\": \"<string>\",\n      \"povMailingZip\": \"<string>\",\n      \"povBillingAddress1\": \"<string>\",\n      \"povBillingAddress2\": \"<string>\",\n      \"povBillingCity\": \"<string>\",\n      \"povBillingState\": \"<string>\",\n      \"povBillingCountry\": \"<string>\",\n      \"povBillingZip\": \"<string>\",\n      \"povPhone\": \"<string>\",\n      \"povEMail\": \"<email>\",\n      \"povCompId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -13203,7 +19601,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "6ae548c8-4a1f-4529-8438-e21984083ebd",
+                            "id": "4aeee2f5-f957-4762-b81d-12c333d4943f",
                             "name": "Create a PO header",
                             "request": {
                                 "name": "Create a PO header",
@@ -13256,7 +19654,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8fff414d-72f7-4475-9284-1de5bf4065d7",
+                                    "id": "86ffd9b5-68ab-4c87-9212-05acf4484079",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -13303,7 +19701,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "13783597-2308-41e8-8d78-dff0587a16ba",
+                                    "id": "f96c6b96-002f-4eb9-9a37-6045695dbb8c",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -13350,7 +19748,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "c7751a0a-4e03-41a0-9f21-f709a42f898b",
+                                    "id": "df62f372-f272-440f-921e-1f14222d361e",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -13407,7 +19805,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "48437b73-e04c-41e1-9f3e-a7048c919a23",
+                                    "id": "4fcb851e-2029-4c98-9dc0-62a5f7c46609",
                                     "name": "Get one PO header",
                                     "request": {
                                         "name": "Get one PO header",
@@ -13457,7 +19855,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "86c0752e-db11-4a27-95ed-dc80d108fba4",
+                                            "id": "791ab34c-d36e-4589-b026-f40879d77a9f",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -13470,7 +19868,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13492,7 +19901,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "fef9427e-8949-43e5-a8ad-e415231456a6",
+                                            "id": "d3aa9d42-12c2-4733-9727-dcad5e5abb4b",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -13505,7 +19914,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13527,7 +19947,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "9094a00a-977d-4f58-afb0-5d7bf9869990",
+                                            "id": "11b43f3c-74bb-45cb-83a6-fc15003b154a",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -13540,7 +19960,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13568,7 +19999,7 @@
                                     }
                                 },
                                 {
-                                    "id": "ac5bf365-4236-4ac4-919e-894368bb82cd",
+                                    "id": "d340403b-0aaf-4750-bfb0-8d40b9c7f3ef",
                                     "name": "Partial update of a PO header",
                                     "request": {
                                         "name": "Partial update of a PO header",
@@ -13633,7 +20064,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "f522cfb4-ab7e-4ae9-8ccc-af9da979eb2a",
+                                            "id": "92da214d-49ea-4082-91eb-71d0dfb5631e",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -13646,7 +20077,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13681,7 +20123,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "d8ca5750-e983-465f-b95f-3de84b72e9f7",
+                                            "id": "7b184ec1-9586-4029-90e4-e04b6487f947",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -13694,7 +20136,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13729,7 +20182,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "528825d5-01f8-4385-a7d7-4dd4c93bb419",
+                                            "id": "4e5d6b6d-9129-44a3-bd20-f2a24b6939d5",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -13742,7 +20195,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13777,7 +20241,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "ee5716e5-2242-4547-a6f7-de7c9942dde7",
+                                            "id": "84c51982-810b-4938-84e0-530eecd63a3d",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -13790,7 +20254,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13831,7 +20306,7 @@
                                     }
                                 },
                                 {
-                                    "id": "cc410321-c3da-403f-853c-f7ea69aa7236",
+                                    "id": "0f7a8e19-a445-44a9-8370-944a551a3ca9",
                                     "name": "Soft-delete a PO header",
                                     "request": {
                                         "name": "Soft-delete a PO header",
@@ -13881,7 +20356,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "db18b88c-140c-4d81-b1fb-8929bdbd419e",
+                                            "id": "11daefb5-d485-4cc3-ab2d-2731da65f9c1",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -13894,7 +20369,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13916,7 +20402,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e0332caf-ca6e-4191-b2e0-263d958e6907",
+                                            "id": "9004abc1-1146-43ba-8a36-f82ec56fa594",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -13929,7 +20415,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -13951,7 +20448,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "612ec71b-0d96-49b2-b096-0463a88ecfbe",
+                                            "id": "5fa95b66-f37a-4153-9799-db4025a8d6fe",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -13964,7 +20461,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14002,7 +20510,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "9158e3f3-2001-43dc-85a8-d161966d3897",
+                                            "id": "a49f1c9f-7070-42ac-be10-e1dc860a9a61",
                                             "name": "List PO headers for a vendor (paginated, newest first)",
                                             "request": {
                                                 "name": "List PO headers for a vendor (paginated, newest first)",
@@ -14072,7 +20580,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "c6b18113-3e6a-4669-94d4-fb7cfa53d2d7",
+                                                    "id": "7bfdb369-5d07-405d-8e33-e84985141ac2",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -14105,7 +20613,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -14127,7 +20646,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "5dacad91-d1bc-4773-86f6-f7c9610279fc",
+                                                    "id": "c95ee1a3-dbee-4639-8cf6-9437590905a9",
                                                     "name": "Invalid vendor id",
                                                     "originalRequest": {
                                                         "url": {
@@ -14160,7 +20679,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -14182,7 +20712,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "d4db215f-9325-44a2-b2b5-12aa510adff5",
+                                                    "id": "9cddad6f-2439-4de5-bfe5-7eabe7c977d3",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -14215,7 +20745,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -14245,6 +20786,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "fed5e33a-5b94-4c70-8079-c0c315f99941",
+                                    "name": "Bulk-create purchaseOrderHeaders (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create purchaseOrderHeaders (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ purchaseOrderHeaders: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "purchaseorderheader",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "5123052d-d85d-427e-bb1a-538924a29774",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderheader",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "290b6976-61f0-4e46-a225-9dd691171fdc",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderheader",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "1584bdcd-3830-4b04-b3b4-567cbd1f12c3",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderheader",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "63725bd5-82ce-449d-adfe-13022e75a431",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderheader",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "37bc5f2c-1cfd-486d-8c90-f7620c8bdd56",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderheader",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderHeaders\": [\n    {\n      \"pohDate\": \"<dateTime>\",\n      \"pohReference\": \"<string>\",\n      \"pohTerms\": \"<string>\",\n      \"pohPovId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -14253,7 +21157,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "9c27b424-6a42-4b46-b590-4b54c4405a30",
+                            "id": "2a500132-f21f-40ed-aeee-6c4b0732e7f6",
                             "name": "Create a PO line",
                             "request": {
                                 "name": "Create a PO line",
@@ -14306,7 +21210,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c36c7045-e3cd-4332-96ac-0afb0fd3af27",
+                                    "id": "c20bef3a-0239-4eb1-86ec-97c105c942db",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -14353,7 +21257,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "198b6773-335a-4fcc-90d7-79639a986225",
+                                    "id": "2ecf5cf0-dc72-4d0a-a37e-adff15f78045",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -14400,7 +21304,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "de7da770-4baa-4d13-ba17-dcd8983d8f00",
+                                    "id": "f1ce6c3f-a0d4-4fe8-8a2c-d11d4e79e66b",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -14457,7 +21361,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "267382a6-e435-4402-a1e8-a0ffe6e38762",
+                                    "id": "a76f3e70-f922-47bc-93c2-affba74319a7",
                                     "name": "Get one PO line",
                                     "request": {
                                         "name": "Get one PO line",
@@ -14507,7 +21411,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "198bb602-535d-42fc-89c5-1ee43bc24e81",
+                                            "id": "d9356eed-35e3-46a0-bb8a-b33ca12b6f39",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -14520,7 +21424,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14542,7 +21457,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "92e8f3d3-399a-4a8d-8c5b-fbe1ed251382",
+                                            "id": "9c45988c-2934-44fd-906a-df4a92d73158",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -14555,7 +21470,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14577,7 +21503,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "5139aca4-c196-414b-8929-05b1a0cbad03",
+                                            "id": "08513d92-1b1f-485d-8358-50ac456add02",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -14590,7 +21516,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14618,7 +21555,7 @@
                                     }
                                 },
                                 {
-                                    "id": "d7065203-043c-43aa-a582-59b8350f6b31",
+                                    "id": "4f9526d3-58fb-4315-a85f-5f32ccd8eedf",
                                     "name": "Partial update of a PO line",
                                     "request": {
                                         "name": "Partial update of a PO line",
@@ -14683,7 +21620,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "14f34f17-a592-44a0-9086-1c3a4467b8a5",
+                                            "id": "1a4d3701-e7f7-4e85-b99f-a28fde24a7c1",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -14696,7 +21633,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14731,7 +21679,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "0bed14b9-a5b7-4a12-9914-5a99a206597b",
+                                            "id": "d56add38-95b4-4233-b877-34f892d1aadf",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -14744,7 +21692,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14779,7 +21738,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "cad0d67d-a8a2-459f-9c99-ad5212aa6f1b",
+                                            "id": "6dbe70d9-66c3-4b09-bcb8-415cb738879f",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -14792,7 +21751,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14827,7 +21797,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "05eb26d7-433e-4894-9316-02e799a82176",
+                                            "id": "87cef4ad-66e2-4bb8-9eaf-1155cbfc26ff",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -14840,7 +21810,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14881,7 +21862,7 @@
                                     }
                                 },
                                 {
-                                    "id": "85d18e38-61b7-48e3-9f8a-8b232e8cccd1",
+                                    "id": "5cda08fa-d53b-4077-af9e-ecb5ccdfefda",
                                     "name": "Soft-delete a PO line",
                                     "request": {
                                         "name": "Soft-delete a PO line",
@@ -14931,7 +21912,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "7092402d-3a3e-4b85-99da-ca3d52ba32fb",
+                                            "id": "127093b6-7f4f-448b-bc6e-03fbb53a8fd8",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -14944,7 +21925,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -14966,7 +21958,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "2f09c2f9-c6a6-4251-a810-171a20c75b87",
+                                            "id": "89ea1777-f4da-4f9c-ad66-558cb65c640f",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -14979,7 +21971,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15001,7 +22004,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "17a4a498-02f2-4f6f-8a0f-a89a8958082b",
+                                            "id": "9144983d-6ddd-477d-8ef9-f14fabd197f2",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -15014,7 +22017,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15052,7 +22066,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "d9b947dd-c098-4c83-a19e-d543561e342e",
+                                            "id": "25d4d6b8-e697-4aaa-a4a2-864556cbc55f",
                                             "name": "List PO lines for a header (paginated)",
                                             "request": {
                                                 "name": "List PO lines for a header (paginated)",
@@ -15122,7 +22136,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "a3e9a6f9-629c-47f1-97a1-05e41e7a2979",
+                                                    "id": "ab4b0dfe-e112-41b9-aab4-ba28eeb71753",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -15155,7 +22169,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -15177,7 +22202,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "114aeded-c91f-4a2f-8008-13c0af0260ee",
+                                                    "id": "22d12ecb-6007-4733-a475-3f1cd3406a66",
                                                     "name": "Invalid header id",
                                                     "originalRequest": {
                                                         "url": {
@@ -15210,7 +22235,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -15232,7 +22268,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "6d50aed3-6f4b-4ad8-a9a8-56e042789956",
+                                                    "id": "44adcebe-7b82-4389-a47d-bf1117efb19b",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -15265,7 +22301,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -15295,6 +22342,369 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "c173a71a-45f5-4435-916c-da249dc112a4",
+                                    "name": "Bulk-create purchaseOrderLines (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create purchaseOrderLines (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ purchaseOrderLines: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "purchaseorderline",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "999553ab-02da-4beb-87f4-8176fe948ace",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderline",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "bdfb7621-8242-49ad-ba6e-99b871c7184d",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderline",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "8c95335c-0bab-4e4b-9076-93afa6782a8a",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderline",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "06340629-cae6-4ea8-825f-a2a27b55629e",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderline",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "29fc325a-6739-4d67-b55d-712367d3cc23",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "purchaseorderline",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"purchaseOrderLines\": [\n    {\n      \"polpoh\": \"<integer>\",\n      \"polItemDesc\": \"<string>\",\n      \"polQty\": \"<number>\",\n      \"polPrice\": \"<number>\",\n      \"polInvtId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -15303,7 +22713,7 @@
                     "description": "",
                     "item": [
                         {
-                            "id": "8167e9c5-4f98-4f44-9476-c781b66262e4",
+                            "id": "39d7a424-dac8-4aed-8a61-7aa31ee3018e",
                             "name": "Create an inventory transaction",
                             "request": {
                                 "name": "Create an inventory transaction",
@@ -15328,7 +22738,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -15356,7 +22766,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "18790a0f-7a2f-4fe3-a284-91ba793cf36c",
+                                    "id": "8db5e828-47cd-458a-8067-674ec401d817",
                                     "name": "Created",
                                     "originalRequest": {
                                         "url": {
@@ -15387,7 +22797,7 @@
                                         "method": "POST",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -15403,7 +22813,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "a8c83faf-7696-4bc4-a199-51f10096c841",
+                                    "id": "a3334562-3a90-4dda-8034-2b7e013d649c",
                                     "name": "Bad request",
                                     "originalRequest": {
                                         "url": {
@@ -15434,7 +22844,7 @@
                                         "method": "POST",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -15450,7 +22860,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "3b9ccf9a-c0a8-40d0-9351-f7fd45e56733",
+                                    "id": "6de9f662-f64d-4154-ae33-3b2622f66cda",
                                     "name": "Auth failure",
                                     "originalRequest": {
                                         "url": {
@@ -15481,7 +22891,7 @@
                                         "method": "POST",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -15507,7 +22917,7 @@
                             "description": "",
                             "item": [
                                 {
-                                    "id": "3ab9a609-1adc-4259-89c3-ddeb58cd0400",
+                                    "id": "d3672959-21e1-4e3b-bee5-434f2d8c14b8",
                                     "name": "Get one inventory transaction",
                                     "request": {
                                         "name": "Get one inventory transaction",
@@ -15557,7 +22967,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "1c9877f4-abe9-4013-b082-14572f6182a7",
+                                            "id": "0fcac53b-4d7b-47c7-978d-e0e751b4d50e",
                                             "name": "Found",
                                             "originalRequest": {
                                                 "url": {
@@ -15570,7 +22980,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15592,7 +23013,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "29dfbe87-dfac-498d-a3ad-c5ecd7ea3245",
+                                            "id": "06afa16c-c7b7-4b44-91ae-6a769a82600a",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -15605,7 +23026,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15627,7 +23059,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "34fd26af-b0e1-4ad1-92e6-6a4217da88fa",
+                                            "id": "2a770c00-f8e3-445e-b79a-15108260f1eb",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -15640,7 +23072,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15668,7 +23111,7 @@
                                     }
                                 },
                                 {
-                                    "id": "be423df5-24a4-46dd-be05-a7c1373bc8ee",
+                                    "id": "dc1cf8e1-babe-4149-9861-dd5b3f002c5f",
                                     "name": "Partial update of an inventory transaction (unusual — reversing entries are the production pattern)",
                                     "request": {
                                         "name": "Partial update of an inventory transaction (unusual — reversing entries are the production pattern)",
@@ -15705,7 +23148,7 @@
                                         "method": "PATCH",
                                         "body": {
                                             "mode": "raw",
-                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                            "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                             "options": {
                                                 "raw": {
                                                     "headerFamily": "json",
@@ -15733,7 +23176,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "e438feb9-f4aa-41f1-bede-cb7b3961be66",
+                                            "id": "6d8f67e5-cc3d-41d2-8287-dd993046cbc8",
                                             "name": "Updated",
                                             "originalRequest": {
                                                 "url": {
@@ -15746,7 +23189,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15765,7 +23219,7 @@
                                                 "method": "PATCH",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -15781,7 +23235,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "e15c566c-751d-40b1-83c3-17b23745cca4",
+                                            "id": "71e78840-ecb4-4376-b648-ee5c4545b8ea",
                                             "name": "No updatable fields supplied",
                                             "originalRequest": {
                                                 "url": {
@@ -15794,7 +23248,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15813,7 +23278,7 @@
                                                 "method": "PATCH",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -15829,7 +23294,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "fbb0350e-be7d-416b-81f6-789dc4a966a1",
+                                            "id": "ec59714a-0d88-4304-be09-1cfe304f1e71",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -15842,7 +23307,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15861,7 +23337,7 @@
                                                 "method": "PATCH",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -15877,7 +23353,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "08c139f8-f783-4c23-ac4b-ef2dfa34246c",
+                                            "id": "33682847-4dc2-40fc-86c6-9cdb9970236a",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -15890,7 +23366,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -15909,7 +23396,7 @@
                                                 "method": "PATCH",
                                                 "body": {
                                                     "mode": "raw",
-                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 1,\n  \"invtInitId\": \"<integer>\"\n}",
+                                                    "raw": "{\n  \"invtCompanyId\": \"<integer>\",\n  \"invtDirection\": 0,\n  \"invtInitId\": \"<integer>\"\n}",
                                                     "options": {
                                                         "raw": {
                                                             "headerFamily": "json",
@@ -15931,7 +23418,7 @@
                                     }
                                 },
                                 {
-                                    "id": "d2ed8244-2051-4394-bfcd-e6ed093dfb17",
+                                    "id": "71261c85-c5af-4070-a894-dc45c5d63c96",
                                     "name": "Soft-delete an inventory transaction",
                                     "request": {
                                         "name": "Soft-delete an inventory transaction",
@@ -15981,7 +23468,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "a4fe4f6f-5433-401d-b47a-c74653d00cd6",
+                                            "id": "4e908d4d-25ea-4b2b-bd54-c856154d50be",
                                             "name": "Archived",
                                             "originalRequest": {
                                                 "url": {
@@ -15994,7 +23481,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -16016,7 +23514,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "9c16cf16-3c12-42fa-b8b7-3b656594e3b9",
+                                            "id": "ad878f18-39aa-4757-afa7-f52cdb04d4f4",
                                             "name": "Auth failure",
                                             "originalRequest": {
                                                 "url": {
@@ -16029,7 +23527,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -16051,7 +23560,7 @@
                                             "_postman_previewlanguage": "text"
                                         },
                                         {
-                                            "id": "0346470e-1049-43fb-aa1f-e1677ad78d1a",
+                                            "id": "094ee5b4-ffff-483b-b42c-888cae27833d",
                                             "name": "Not found",
                                             "originalRequest": {
                                                 "url": {
@@ -16064,7 +23573,18 @@
                                                         "{{baseUrl}}"
                                                     ],
                                                     "query": [],
-                                                    "variable": []
+                                                    "variable": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "type": "any",
+                                                            "value": "<integer>",
+                                                            "key": "id"
+                                                        }
+                                                    ]
                                                 },
                                                 "header": [
                                                     {
@@ -16102,7 +23622,7 @@
                                     "description": "",
                                     "item": [
                                         {
-                                            "id": "3d43033b-8cfa-4b59-92f5-cd8096d6536b",
+                                            "id": "a45db431-7cdc-4ba6-8c9d-0e96776831ab",
                                             "name": "List inventory transactions in a company (paginated, newest first)",
                                             "request": {
                                                 "name": "List inventory transactions in a company (paginated, newest first)",
@@ -16172,7 +23692,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "9c519406-62b4-4a56-aabd-01c09e0047e8",
+                                                    "id": "14e863cb-3283-4890-8b53-f07692dde31c",
                                                     "name": "OK",
                                                     "originalRequest": {
                                                         "url": {
@@ -16205,7 +23725,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -16227,7 +23758,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "0a8aaefd-1dab-449f-b1cd-8fd98db812f1",
+                                                    "id": "1d0ef3fd-66f2-4c73-ba31-1d3c07122536",
                                                     "name": "Invalid company id",
                                                     "originalRequest": {
                                                         "url": {
@@ -16260,7 +23791,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -16282,7 +23824,7 @@
                                                     "_postman_previewlanguage": "text"
                                                 },
                                                 {
-                                                    "id": "5fb0b0a3-2381-4757-8eb5-01d299aa491f",
+                                                    "id": "aa647488-4e6c-4363-a24f-ca16ed0b788c",
                                                     "name": "Auth failure",
                                                     "originalRequest": {
                                                         "url": {
@@ -16315,7 +23857,18 @@
                                                                     "value": "0"
                                                                 }
                                                             ],
-                                                            "variable": []
+                                                            "variable": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "(Required) ",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "type": "any",
+                                                                    "value": "<integer>",
+                                                                    "key": "id"
+                                                                }
+                                                            ]
                                                         },
                                                         "header": [
                                                             {
@@ -16345,8 +23898,471 @@
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "name": "bulk",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "de3cfac5-7aab-407c-abf3-97fef19b5b77",
+                                    "name": "Bulk-create inventoryTransactions (transaction-wrapped, all-or-nothing)",
+                                    "request": {
+                                        "name": "Bulk-create inventoryTransactions (transaction-wrapped, all-or-nothing)",
+                                        "description": {
+                                            "content": "Body: `{ inventoryTransactions: [{...}, ...] }`. Each entry follows the same shape as the single-create endpoint. Capped at 500 entries; ETL jobs should chunk. If any entry fails to insert, the whole transaction rolls back — partial success is never observable.",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "v1",
+                                                "inventorytransaction",
+                                                "bulk"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "disabled": false,
+                                                "description": {
+                                                    "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Idempotency-Key",
+                                                "value": "<string>"
+                                            },
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "apikey",
+                                            "apikey": [
+                                                {
+                                                    "key": "key",
+                                                    "value": "authKey"
+                                                },
+                                                {
+                                                    "key": "value",
+                                                    "value": "{{apiKey}}"
+                                                },
+                                                {
+                                                    "key": "in",
+                                                    "value": "header"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "ec61388c-27cf-4b62-a4cc-ebf50cd5a185",
+                                            "name": "All entries created",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventorytransaction",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Created",
+                                            "code": 201,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "f5305924-ada2-491f-9d79-55d183afd595",
+                                            "name": "Validation failure (array empty/capped, missing parent FK, master without scope)",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventorytransaction",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "895234e9-e458-482a-b5f5-78aa364a03e7",
+                                            "name": "Missing authKey or cross-tenant create attempt",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventorytransaction",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Forbidden",
+                                            "code": 403,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "32ad1a17-2be6-465d-91ab-60a6972ab2cf",
+                                            "name": "Idempotency-Key reused with a different body",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventorytransaction",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Conflict",
+                                            "code": 409,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "fc642d3b-fcfc-4d41-93fa-1ecb367d9a1f",
+                                            "name": "Transaction rolled back due to DB error",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "v1",
+                                                        "inventorytransaction",
+                                                        "bulk"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "disabled": false,
+                                                        "description": {
+                                                            "content": "Client-chosen string (printable ASCII, 1-255 chars) that pins a POST as idempotent for 24h. First success is cached; replays of the same key + body return the cached response with `Idempotency-Replay: true`. Replays of the same key with a DIFFERENT body return 409 to flag the misuse.",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Idempotency-Key",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: apikey",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "authKey",
+                                                        "value": "<API Key>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"inventoryTransactions\": [\n    {\n      \"invtCompanyId\": \"<integer>\",\n      \"invtDirection\": 1,\n      \"invtInitId\": \"<integer>\"\n    }\n  ]\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
                         }
                     ]
+                }
+            ]
+        },
+        {
+            "name": "metrics",
+            "description": "",
+            "item": [
+                {
+                    "id": "da16819b-658c-485b-b1f6-b3bedcb459eb",
+                    "name": "Prometheus scrape endpoint",
+                    "request": {
+                        "name": "Prometheus scrape endpoint",
+                        "description": {
+                            "content": "Returns prom-client text-format metrics: default Node.js series (event-loop, heap, GC) plus per-request `http_requests_total` and `http_request_duration_seconds`. Route labels use the Express route pattern (e.g. `/v1/customer/:id`) so cardinality stays bounded. Authentication is OPTIONAL: leave `METRICS_BEARER_TOKEN` env unset for an open scrape (the usual private-network deployment), or set it to require `Authorization: Bearer <token>` on the scrape.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "metrics"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "text/plain"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "d27eb418-6e0e-4294-9166-7df466d775b3",
+                            "name": "OK — Prometheus text-format metrics",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "metrics"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "text/plain"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "text/plain"
+                                }
+                            ],
+                            "body": "<string>",
+                            "cookie": [],
+                            "_postman_previewlanguage": "text"
+                        },
+                        {
+                            "id": "d68428dc-e2e2-4b37-a2ee-c926d4443756",
+                            "name": "Bearer token required (when METRICS_BEARER_TOKEN is set) and missing/invalid",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "metrics"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [],
+                            "cookie": [],
+                            "_postman_previewlanguage": "text"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
             ]
         }
@@ -16359,7 +24375,7 @@
         }
     ],
     "info": {
-        "_postman_id": "bc25074a-96f4-4767-99d1-22bca7df1c2f",
+        "_postman_id": "72d91124-f889-4a75-b665-930b473fd770",
         "name": "TimeTrackerAPI",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
## Summary

Regenerated the Postman collection to match the live API surface — the committed copy had drifted since the audit cycle added 13 bulk endpoints, `/metrics`, and the `Idempotency-Key` parameter.

Request count: 79 → 97.

## Test plan

- [x] Regenerated via the README-documented one-liner.
- [x] Suite still 472 pass / 4 skip.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/