### PR TITLE
ci: spin up a live Postgres so integration tests run on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,37 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ['20.x', '22.x']
+
+    # Live Postgres so the integration suite
+    # (tests/integration/db-roundtrip.test.js) actually runs in CI
+    # instead of self-skipping. The unit + api suites continue to
+    # pass with or without the DB; this just promotes the integration
+    # branch from "best effort" to a hard gate on every PR.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: timetracker
+          POSTGRES_PASSWORD: ci-test-password
+          POSTGRES_DB: timetracker
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U timetracker -d timetracker"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: '5432'
+      DB_NAME: timetracker
+      DB_USER: timetracker
+      DB_PASSWORD: ci-test-password
+      # Logger is silent in tests by default; allow override here
+      # if we ever need verbose CI logs.
+      LOG_LEVEL: silent
+
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -22,7 +53,22 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Wait for Postgres to accept connections
+        run: |
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U timetracker -d timetracker -q; then
+              echo "postgres ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "postgres not ready after 30s" >&2; exit 1
+      - name: Apply schema bootstrap (dbo schema + Atbash baseline)
+        env:
+          PGPASSWORD: ci-test-password
+        run: psql -h localhost -U timetracker -d timetracker -f setup/TimeTracker.sql
+      - name: Run sequelize migrations
+        run: npm run migrate
       - name: Lint
         run: npm run lint
-      - name: Run vitest
+      - name: Run vitest (unit + api + integration)
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,12 @@ jobs:
             sleep 1
           done
           echo "postgres not ready after 30s" >&2; exit 1
-      - name: Apply schema bootstrap (dbo schema + Atbash baseline)
+      - name: Apply schema bootstrap (dbo schema + Atbash baseline + TimeEntry)
         env:
           PGPASSWORD: ci-test-password
-        run: psql -h localhost -U timetracker -d timetracker -f setup/TimeTracker.sql
+        run: |
+          psql -v ON_ERROR_STOP=1 -h localhost -U timetracker -d timetracker -f setup/TimeTracker.sql
+          psql -v ON_ERROR_STOP=1 -h localhost -U timetracker -d timetracker -f setup/TimeEntry.sql
       - name: Run sequelize migrations
         run: npm run migrate
       - name: Lint

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,7 +31,8 @@ steps:
           fi
           sleep 1
         done
-      - PGPASSWORD=ci-test-password psql -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
+      - PGPASSWORD=ci-test-password psql -v ON_ERROR_STOP=1 -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
+      - PGPASSWORD=ci-test-password psql -v ON_ERROR_STOP=1 -h postgres -U timetracker -d timetracker -f setup/TimeEntry.sql
       - npm ci
       - npm run migrate
       - npm run lint
@@ -55,7 +56,8 @@ steps:
           fi
           sleep 1
         done
-      - PGPASSWORD=ci-test-password psql -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
+      - PGPASSWORD=ci-test-password psql -v ON_ERROR_STOP=1 -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
+      - PGPASSWORD=ci-test-password psql -v ON_ERROR_STOP=1 -h postgres -U timetracker -d timetracker -f setup/TimeEntry.sql
       - npm ci
       - npm run migrate
       - npm run lint

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,17 +2,61 @@ when:
   - event: [push, pull_request]
     branch: [master, main]
 
+# Live Postgres so the integration suite runs in CI rather than
+# self-skipping. The unit + api suites pass with or without the DB.
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: timetracker
+      POSTGRES_PASSWORD: ci-test-password
+      POSTGRES_DB: timetracker
+
 steps:
   test-node-20:
     image: node:20-slim
+    environment:
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_NAME: timetracker
+      DB_USER: timetracker
+      DB_PASSWORD: ci-test-password
+      LOG_LEVEL: silent
     commands:
+      - apt-get update -qq && apt-get install -y -qq postgresql-client
+      - |
+        for i in $(seq 1 30); do
+          if pg_isready -h postgres -p 5432 -U timetracker -d timetracker -q; then
+            echo "postgres ready"; break
+          fi
+          sleep 1
+        done
+      - PGPASSWORD=ci-test-password psql -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
       - npm ci
+      - npm run migrate
       - npm run lint
       - npm test
 
   test-node-22:
     image: node:22-slim
+    environment:
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_NAME: timetracker
+      DB_USER: timetracker
+      DB_PASSWORD: ci-test-password
+      LOG_LEVEL: silent
     commands:
+      - apt-get update -qq && apt-get install -y -qq postgresql-client
+      - |
+        for i in $(seq 1 30); do
+          if pg_isready -h postgres -p 5432 -U timetracker -d timetracker -q; then
+            echo "postgres ready"; break
+          fi
+          sleep 1
+        done
+      - PGPASSWORD=ci-test-password psql -h postgres -U timetracker -d timetracker -f setup/TimeTracker.sql
       - npm ci
+      - npm run migrate
       - npm run lint
       - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **CI gains a live Postgres service**. Both GitHub Actions and
+  Woodpecker spin up `postgres:16-alpine` alongside the Node
+  matrix, run `setup/TimeTracker.sql` for the `dbo` schema
+  bootstrap, then `npm run migrate` to apply every migration. The
+  integration suite at `tests/integration/db-roundtrip.test.js`
+  no longer self-skips in CI — it gates every PR against schema /
+  migration drift. The unit + api suites still pass with or
+  without a DB, so local `npm test` works unchanged.
+
 ### Added
 - **OpenAPI completeness pass**. All 12 previously-undocumented
   bulk-create endpoints now appear in the spec via a shared


### PR DESCRIPTION
## Summary

- GH Actions + Woodpecker now spin up `postgres:16-alpine` as a service alongside the Node matrix.
- Each pipeline: waits for `pg_isready`, applies `setup/TimeTracker.sql`, runs migrations, then lints + tests.
- Integration suite (`tests/integration/db-roundtrip.test.js`) was self-skipping in CI; now it runs and gates every PR against schema/migration drift.
- Unit + api suites still pass without a DB, so local `npm test` is unchanged.

## Test plan

- [x] Local `npm run lint` + `npm test` still 472 pass / 4 skip.
- [ ] Confirmed on CI once this PR lands (will see in the first PR after it).

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/