### PR TITLE
chore(ci): npm audit gate on production deps + engines.node pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,5 +72,7 @@ jobs:
         run: npm run migrate
       - name: Lint
         run: npm run lint
+      - name: npm audit (production deps, high+)
+        run: npm run audit
       - name: Run vitest (unit + api + integration)
         run: npm test

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -36,6 +36,7 @@ steps:
       - npm ci
       - npm run migrate
       - npm run lint
+      - npm run audit
       - npm test
 
   test-node-22:
@@ -61,4 +62,5 @@ steps:
       - npm ci
       - npm run migrate
       - npm run lint
+      - npm run audit
       - npm test

--- a/package.json
+++ b/package.json
@@ -15,10 +15,14 @@
     "test:watch": "vitest",
     "lint": "eslint app/ server.js tests/",
     "lint:fix": "eslint --fix app/ server.js tests/",
+    "audit": "npm audit --audit-level=high --omit=dev",
     "migrate": "sequelize-cli db:migrate",
     "migrate:undo": "sequelize-cli db:migrate:undo",
     "migrate:status": "sequelize-cli db:migrate:status",
     "migrate:generate": "sequelize-cli migration:generate --name"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   },
   "author": "https://github.com/CryptoJones",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- New `npm run audit` script wraps `npm audit --audit-level=high --omit=dev`.
- GH Actions + Woodpecker both run it between lint and the test matrix. CI fails on any high-or-critical advisory affecting production dependencies. Dev tools excluded.
- `engines.node` in package.json pins minimum to >=20.0.0 (matches CI matrix + Docker base).

## Test plan

- [x] `npm run audit` → 0 vulnerabilities on master.
- [x] Suite still 479 pass / 4 skip.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/