### PR TITLE
docs: GitHub + Gitea PR and issue templates

### DIFF
--- a/.gitea/PULL_REQUEST_TEMPLATE.md
+++ b/.gitea/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for the PR! A few notes before you hit Submit:
+
+- Security vulnerabilities go through SECURITY.md (private channels),
+  NOT a public PR.
+- See CONTRIBUTING.md for the pre-PR checklist (lint, test, audit,
+  OpenAPI updates, CHANGELOG entry).
+- Both GitHub and Codeberg are accepted forges; commits land on
+  both regardless of where the PR was opened.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changed and why. Link to any tracking issue. -->
+
+
+## Test plan
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` passes locally
+- [ ] `npm run audit` clean (production deps)
+- [ ] OpenAPI spec updated if endpoints / parameters / response shapes changed
+- [ ] CHANGELOG entry added under `[Unreleased]`
+- [ ] <!-- Anything else specific to this change -->
+
+
+## Review notes (optional)
+
+<!--
+Anything reviewers should focus on or know? Tricky edge cases,
+deliberate non-decisions, follow-ups you've already filed, etc.
+-->
+
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

--- a/.gitea/issue_template/bug_report.md
+++ b/.gitea/issue_template/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Something is broken or behaves unexpectedly
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+For security vulnerabilities, follow SECURITY.md (private channels),
+NOT this template.
+-->
+
+## Summary
+
+<!-- One sentence describing the bug. -->
+
+
+## To reproduce
+
+1.
+2.
+3.
+
+### Expected
+<!-- What should have happened? -->
+
+### Actual
+<!-- What did happen? Include the response body / status / log line if you have it. -->
+
+
+## Environment
+
+- TimeTrackerAPI commit / tag:
+- Node version:
+- Postgres version:
+- Deployment shape: <!-- docker compose / bare metal / k8s / etc. -->
+
+
+## Anything else?
+
+<!-- Logs, screenshots, related issues, what you've already ruled out. -->
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

--- a/.gitea/issue_template/feature_request.md
+++ b/.gitea/issue_template/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Propose new functionality or an API change
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What user / operator pain are you trying to solve? Be specific. -->
+
+
+## Proposed approach
+
+<!-- Sketch the API shape (request / response), schema changes, or
+middleware behavior. "What would the OpenAPI entry look like?" is a
+helpful framing. -->
+
+
+## Alternatives considered
+
+<!-- Other paths you thought about and why this one wins. -->
+
+
+## Migration notes
+
+<!-- Anything operators upgrading from an existing deployment need to do?
+New env var? Migration that requires downtime? -->
+
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Something is broken or behaves unexpectedly
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+For security vulnerabilities, follow SECURITY.md (private channels),
+NOT this template.
+-->
+
+## Summary
+
+<!-- One sentence describing the bug. -->
+
+
+## To reproduce
+
+1.
+2.
+3.
+
+### Expected
+<!-- What should have happened? -->
+
+### Actual
+<!-- What did happen? Include the response body / status / log line if you have it. -->
+
+
+## Environment
+
+- TimeTrackerAPI commit / tag:
+- Node version:
+- Postgres version:
+- Deployment shape: <!-- docker compose / bare metal / k8s / etc. -->
+
+
+## Anything else?
+
+<!-- Logs, screenshots, related issues, what you've already ruled out. -->
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
+#
+# GitHub picks up this file under .github/ISSUE_TEMPLATE/ and uses it
+# to render the "additional links" section on the New Issue picker.
+
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/CryptoJones/TimeTrackerAPI/security/advisories/new
+    about: Report a security vulnerability privately. NEVER open a public issue.
+  - name: Codeberg mirror
+    url: https://codeberg.org/CryptoJones/TimeTrackerAPI/issues
+    about: Issues filed on the Codeberg mirror are equally accepted.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Propose new functionality or an API change
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What user / operator pain are you trying to solve? Be specific. -->
+
+
+## Proposed approach
+
+<!-- Sketch the API shape (request / response), schema changes, or
+middleware behavior. "What would the OpenAPI entry look like?" is a
+helpful framing. -->
+
+
+## Alternatives considered
+
+<!-- Other paths you thought about and why this one wins. -->
+
+
+## Migration notes
+
+<!-- Anything operators upgrading from an existing deployment need to do?
+New env var? Migration that requires downtime? -->
+
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for the PR! A few notes before you hit Submit:
+
+- Security vulnerabilities go through SECURITY.md (private channels),
+  NOT a public PR.
+- See CONTRIBUTING.md for the pre-PR checklist (lint, test, audit,
+  OpenAPI updates, CHANGELOG entry).
+- Both GitHub and Codeberg are accepted forges; commits land on
+  both regardless of where the PR was opened.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changed and why. Link to any tracking issue. -->
+
+
+## Test plan
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` passes locally
+- [ ] `npm run audit` clean (production deps)
+- [ ] OpenAPI spec updated if endpoints / parameters / response shapes changed
+- [ ] CHANGELOG entry added under `[Unreleased]`
+- [ ] <!-- Anything else specific to this change -->
+
+
+## Review notes (optional)
+
+<!--
+Anything reviewers should focus on or know? Tricky edge cases,
+deliberate non-decisions, follow-ups you've already filed, etc.
+-->
+
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/


### PR DESCRIPTION
## Summary

- GitHub: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md`, `.github/ISSUE_TEMPLATE/config.yml`.
- Codeberg: same set under `.gitea/`.
- PR template references SECURITY.md + the CONTRIBUTING.md pre-PR checklist. Issue templates ask for commit/Node/PG/deployment info up front.

## Test plan

- [x] Documentation only — no code changes.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/