### PR TITLE
chore(deps): drop express-asyncify + express-promise-router (unused)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^4.22.2",
-        "express-asyncify": "^1.0.1",
-        "express-promise-router": "^4.1.1",
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.1.0",
         "pg": "^8.20.0",
@@ -1897,41 +1895,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-asyncify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/express-asyncify/-/express-asyncify-1.0.1.tgz",
-      "integrity": "sha512-eaAtzRRUbZMHKrgAthIFIloci7pMmJf4PFAhFEof/caukFi6oroe8ps3FuDOk0h57epaEKuzTfF5wSWEsqFxXg==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/express-promise-router": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-4.1.1.tgz",
-      "integrity": "sha512-Lkvcy/ZGrBhzkl3y7uYBHLMtLI4D6XQ2kiFg9dq7fbktBch5gjqJ0+KovX0cvCAvTJw92raWunRLM/OM+5l4fA==",
-      "dependencies": {
-        "is-promise": "^4.0.0",
-        "lodash.flattendeep": "^4.0.0",
-        "methods": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.0.0",
-        "express": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express-promise-router/node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
     "node_modules/express-rate-limit": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
@@ -2849,11 +2812,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.22.2",
-    "express-asyncify": "^1.0.1",
-    "express-promise-router": "^4.1.1",
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.1.0",
     "pg": "^8.20.0",


### PR DESCRIPTION
Follow-up to closed #108.

## Summary

- Both `express-asyncify` and `express-promise-router` were in package.json since the initial port but never imported anywhere in the source.
- Closing dependabot's major-version-bump PR #108 surfaced this; removing the deps is cleaner than bumping deadweight.
- `pg-hstore` stays — Sequelize lazy-loads it for hstore column types; the convention is to install it alongside `pg`.

## Test plan

- [x] `grep -rn 'express-asyncify\|express-promise-router' app/ server.js` → 0 hits.
- [x] Suite: 479 pass / 4 skip. Lint clean.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/