### PR TITLE
docs(readme): refresh Node 18+ → 20+ badge + add Actions tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Open-source rewrite of Atbash Services' TimeTrackerAPI on **Node.js + PostgreSQL**.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?logo=apache)](LICENSE)
-[![Node.js](https://img.shields.io/badge/Node.js-18%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-14%2B-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![Tests](https://github.com/CryptoJones/TimeTrackerAPI/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/CryptoJones/TimeTrackerAPI/actions/workflows/test.yml)
 [![Codeberg](https://img.shields.io/badge/Codeberg-CryptoJones%2FTimeTrackerAPI-2185D0?logo=codeberg&logoColor=white)](https://codeberg.org/CryptoJones/TimeTrackerAPI)
 [![GitHub](https://img.shields.io/badge/GitHub-CryptoJones%2FTimeTrackerAPI-181717?logo=github&logoColor=white)](https://github.com/CryptoJones/TimeTrackerAPI)
 


### PR DESCRIPTION
## Summary

- Node.js badge was 18+; engines.node is 20+ since #99. Fixed.
- New GitHub Actions tests badge so master's CI state surfaces on the README.

## Test plan

- [x] Documentation only.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/