### PR TITLE
fix(server): use ipKeyGenerator helper for IPv6-safe rate limiting

### DIFF
--- a/app/middleware/rate-limit-key.js
+++ b/app/middleware/rate-limit-key.js
@@ -17,18 +17,33 @@
  * keyspace separation and keeps the raw token out of any
  * downstream rate-limiter store.
  *
+ * IPv6 handling: express-rate-limit v8+ refuses to start unless any
+ * custom keyGenerator that touches `req.ip` routes the value through
+ * `ipKeyGenerator(req, res)`. The helper canonicalizes IPv4 and IPv6
+ * addresses (matching them to a /64 prefix on IPv6 to prevent a
+ * single client from bypassing limits by rotating through their /64
+ * allocation). Without this wrapper, IPv6 clients could each present
+ * a unique address and slip past the per-IP budget.
+ *
  * Exported separately from server.js so unit tests can exercise
  * the keying directly without spinning up an HTTP server.
  */
 
 const crypto = require('crypto');
+const { ipKeyGenerator } = require('express-rate-limit');
 
 function keyByAuthKeyOrIp(req /*, res */) {
     const authKey = req.get && req.get('authKey');
     if (authKey) {
         return 'k:' + crypto.createHash('sha256').update(authKey).digest('hex').slice(0, 16);
     }
-    return 'ip:' + (req.ip || (req.connection && req.connection.remoteAddress) || 'unknown');
+    // express-rate-limit v8+ requires the helper. It takes the raw
+    // IP string and returns the IPv4 address verbatim or the IPv6
+    // /64 prefix. Fall back to 'unknown' when no source IP is
+    // available (e.g. unit-test fixtures or non-IP transports).
+    const ip = req.ip || (req.connection && req.connection.remoteAddress);
+    if (!ip) return 'ip:unknown';
+    return 'ip:' + ipKeyGenerator(ip);
 }
 
 module.exports = { keyByAuthKeyOrIp };


### PR DESCRIPTION
**Real bug, real bypass.** Caught while smoke-testing server startup after the dependabot bumps.

## Summary

- The custom `keyByAuthKeyOrIp` rate-limit key generator was reading `req.ip` directly and concatenating it into the key. express-rate-limit v8+ refuses to start with `ERR_ERL_KEY_GEN_IPV6` and the underlying concern is real: IPv6 clients could rotate through their /64 allocation, each appearing as a distinct IP, to bypass the per-IP rate-limit budget on anonymous endpoints (the brute-force path).
- Fix routes the IP through `ipKeyGenerator(ip)` from express-rate-limit, which:
  - returns IPv4 verbatim
  - normalizes IPv6 to a /64 prefix
- Authenticated keying (sha256 of the authKey header) is unchanged.
- Verified locally: `DB_PASSWORD=x node server.js` now prints "Server listening" instead of exiting 1.

## Test plan

- [x] `tests/unit/rate-limit-key.test.js` (7 cases) still passes — fixture mocks now produce normalized output.
- [x] Full suite: 479 pass / 4 skip.
- [x] Lint clean.
- [x] Manual server boot verified.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/