### PR TITLE
chore: add npm run dev (Node --watch, no nodemon needed)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ docker compose up -d postgres setup       # local Postgres + schema bootstrap
 npm run migrate                            # apply all sequelize migrations
 npm test                                   # unit + api + integration
 npm start                                  # serves on PORT (default 3000)
+npm run dev                                # same, but auto-reloads on app/ + server.js edits
 ```
 
 `npm test` runs the full vitest suite (45+ files, 479+ cases at this

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "start": "node server.js",
+    "dev": "node --watch --watch-path=./app --watch-path=./server.js server.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint app/ server.js tests/",


### PR DESCRIPTION
## Summary

Adds an `npm run dev` script using Node's built-in `--watch` flag. Restarts on changes to `app/` + `server.js` only (not deps / tests / configs).

No new dev dependency needed; the flag has been stable since Node 22 and the project's engines pin is `>=20`. CONTRIBUTING.md quick-start gets the new line.

## Test plan

- [x] `DB_PASSWORD=x npm run dev` boots cleanly → "Server listening".

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/