### PR TITLE
docs(env): note DB_PASSWORD is REQUIRED in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ DB_USER=timetracker
 
 # Set a real password here. The configured database user must have access
 # to the `dbo` schema. Do NOT commit a populated `.env`.
+#
+# REQUIRED in production: if NODE_ENV=production and DB_PASSWORD is empty,
+# the server refuses to start (exits 1) rather than coming up with broken
+# DB connectivity. Dev/test runs warn and keep going.
 DB_PASSWORD=changeme
 
 # ---- Logging ----


### PR DESCRIPTION
Companion to #119. The .env.example DB_PASSWORD entry now documents that NODE_ENV=production with an empty DB_PASSWORD exits 1 at startup. Dev/test paths still warn + keep going.

## Test plan

- [x] Documentation only.

This code proudly made in Nebraska. GO BIG RED! 🌽 https://xkcd.com/2347/