### PR TITLE
fix(server): honor PORT=0 instead of falling through to 3000

### DIFF
--- a/server.js
+++ b/server.js
@@ -186,7 +186,14 @@ app.use(errorHandler);
 
 // Listen port — env-configurable. Defaults to 3000 so the API can be
 // started by a non-root user. Bind to 0.0.0.0 for container friendliness.
-const port = parseInt(process.env.PORT, 10) || 3000;
+//
+// Note: `parseInt(...) || 3000` would incorrectly coerce a legitimate
+// PORT=0 (kernel-pick-a-free-port, used by tests/api/server-boots.test.js
+// to avoid colliding with another dev process on :3000) to the 3000
+// fallback. Branch explicitly so 0 is honored and only NaN / negatives
+// fall through to the default.
+const portRaw = parseInt(process.env.PORT, 10);
+const port = Number.isFinite(portRaw) && portRaw >= 0 ? portRaw : 3000;
 const host = process.env.HOST || '0.0.0.0';
 
 const server = app.listen(port, host, () => {


### PR DESCRIPTION
Closes #123.

## Summary

`const port = parseInt(process.env.PORT, 10) || 3000` short-circuits the moment `parseInt` returns `0` because `0 || 3000` evaluates to `3000`. That's wrong when `PORT=0` is legitimate — the kernel-pick-a-free-port idiom. The smoke-test `tests/api/server-boots.test.js` relies on this exact behavior to avoid colliding with whatever is already on `:3000` on the dev box, so the test currently fails on `master` for anyone with a busy 3000.

Replace the falsy-fallback with an explicit `Number.isFinite(parsed) && parsed >= 0` check so `0` passes through and only `NaN` / negatives fall back to 3000.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 484 passed (was 483 + 1 fail before this change), 15 skipped
- [x] Manually verified `tests/api/server-boots.test.js` passes (it was failing on master because port 3000 is in use on the dev box)
- [x] Negative / NaN / unset PORT all still fall through to 3000 by exclusion

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/