### PR TITLE
fix(healthz): read version from package.json (not npm_package_version)

### DIFF
--- a/app/controllers/healthcontroller.js
+++ b/app/controllers/healthcontroller.js
@@ -2,7 +2,24 @@
 // Copyright 2026 Aaron K. Clark
 "use strict";
 
+const path = require('node:path');
 const db = require('../config/db.config.js');
+
+// Read the version from package.json once at module load. `npm_package_version`
+// is only set when the process is started via an npm script — production
+// deployments that launch `node server.js` directly (including the Dockerfile
+// in this repo, CMD ["node", "server.js"]) get `undefined` there and the
+// /healthz response degrades to `version: "unknown"`. Reading the manifest
+// gives operators a real version string regardless of how the process started.
+let PACKAGE_VERSION = 'unknown';
+try {
+    PACKAGE_VERSION = require(path.resolve(__dirname, '../../package.json')).version
+        || PACKAGE_VERSION;
+} catch (_err) {
+    // package.json missing or malformed — keep the 'unknown' fallback rather
+    // than crashing module load. /healthz is operationally important and
+    // must come up even on a broken install.
+}
 
 /**
  * GET /healthz
@@ -83,7 +100,7 @@ exports.healthz = async (req, res) => {
         status: dbOk ? 'ok' : 'degraded',
         db: dbOk ? 'ok' : 'down',
         uptime_s: Math.round(process.uptime()),
-        version: process.env.npm_package_version || 'unknown',
+        version: PACKAGE_VERSION,
         elapsed_ms: Math.round(elapsedMs * 100) / 100,
         migration,
     };

--- a/tests/api/healthz.test.js
+++ b/tests/api/healthz.test.js
@@ -78,4 +78,18 @@ describe('GET /healthz', () => {
         const m = res.body.migration;
         expect(m === null || typeof m === 'string').toBe(true);
     });
+
+    test('`version` is read from package.json, not npm_package_version', async () => {
+        // Production Dockerfile launches `node server.js` directly — no
+        // npm wrapper, so process.env.npm_package_version is undefined.
+        // The controller must read package.json directly so /healthz
+        // reports a real version regardless of how the process started.
+        const pkg = require('../../package.json');
+        const res = await request(app).get('/healthz');
+        expect(res.body.version).toBe(pkg.version);
+        // Defensive: the version must NEVER fall back to 'unknown' when
+        // package.json is readable — that fallback path is only for the
+        // exotic case of a broken install.
+        expect(res.body.version).not.toBe('unknown');
+    });
 });


### PR DESCRIPTION
Closes #133.

## Summary

`process.env.npm_package_version` is only set when the process is launched via an npm script. The repo Dockerfile (line 80) launches via `CMD ["node", "server.js"]` — no npm wrapper — so in production deployments `/healthz` always returned `version: "unknown"`. Operators verifying a rolling deploy ("is the new pod at v1.2.3 yet?") got no signal.

Read `version` from `package.json` once at module load. Wrapped in try/catch so a broken install can't take `/healthz` down — the endpoint is operationally critical and must come up even when the manifest is missing.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 492 passed (was 491 + new regression test), 15 skipped
- [x] New test asserts `body.version === require('../../package.json').version` and that the `'unknown'` fallback never appears on a healthy install

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/