### PR TITLE
fix(logger): actually verify pino-pretty is installed before configuring it

### DIFF
--- a/app/config/logger.js
+++ b/app/config/logger.js
@@ -18,13 +18,26 @@ const level = process.env.LOG_LEVEL || 'info';
 
 let transport;
 if (process.env.LOG_PRETTY === '1') {
+    // Check `pino-pretty` is actually installed BEFORE handing the
+    // transport config to pino. Assigning the object literal alone
+    // never throws — pino lazy-resolves the `target` module later
+    // and emits a cryptic error on startup if it's missing. The
+    // `require.resolve` synchronously throws MODULE_NOT_FOUND when
+    // the module isn't on disk, so the catch below fires cleanly
+    // and we fall through to default JSON output, matching the
+    // "pino-pretty is NOT a required dependency" header comment.
     try {
+        require.resolve('pino-pretty');
         transport = {
             target: 'pino-pretty',
             options: { colorize: true, translateTime: 'SYS:standard' },
         };
-    } catch (_) {
-        // pino-pretty not installed — fall through to JSON output.
+    } catch (_err) {
+        // pino-pretty not installed — silently fall through to JSON
+        // output. We don't warn here because the only consumer of
+        // LOG_PRETTY=1 is interactive dev, and a noisy stderr line
+        // would clutter the very output the operator was trying to
+        // make readable.
     }
 }
 


### PR DESCRIPTION
Closes #137.

## Summary

The existing `try` block around the `transport = { target: 'pino-pretty', … }` assignment was a no-op — object-literal construction doesn't throw. Pino lazy-resolves the `target` module the first time the logger emits, so a deployment that sets `LOG_PRETTY=1` without `pino-pretty` on disk crashes on first log line (often during DB init seconds into startup) with a confusing pino-internal error. The "fall through to JSON output" path the comment promised never ran.

Insert an explicit `require.resolve('pino-pretty')` inside the try block. `require.resolve` synchronously throws `MODULE_NOT_FOUND` when the module is missing, so the catch fires cleanly and `transport` stays undefined — pino then falls through to default JSON output, matching the "pino-pretty is NOT a required dependency" comment at the top of the file.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 495 passed, 15 skipped (no test count change; existing logger tests pin the loaded-module case)
- [x] No new regression test: exercising the missing-pino-pretty branch requires either a subprocess spawn (heavyweight) or filesystem mocking that interacts with Node's module loader (brittle); the change is a behavior-correctness fix that brings the code in line with what the comment already promised

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/