### PR TITLE
fix(compose): use DB_USER consistently — DB_USERNAME silently dropped operator overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Short version:
 cp .env.example .env   # set DB_PASSWORD
 sudo docker compose up -d postgres setup migrate
 DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker \
-    DB_USERNAME=timetracker DB_PASSWORD=$(grep ^DB_PASSWORD= .env | cut -d= -f2-) \
+    DB_USER=timetracker DB_PASSWORD=$(grep ^DB_PASSWORD= .env | cut -d= -f2-) \
     npx vitest run tests/integration
 sudo docker compose down -v   # cleanup
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,13 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${DB_USERNAME:-timetracker}
+      POSTGRES_USER: ${DB_USER:-timetracker}
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set in .env}
       POSTGRES_DB: ${DB_NAME:-timetracker}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-timetracker} -d ${DB_NAME:-timetracker}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-timetracker} -d ${DB_NAME:-timetracker}"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -43,7 +43,7 @@ services:
         condition: service_healthy
     environment:
       PGHOST: postgres
-      PGUSER: ${DB_USERNAME:-timetracker}
+      PGUSER: ${DB_USER:-timetracker}
       PGPASSWORD: ${DB_PASSWORD}
       PGDATABASE: ${DB_NAME:-timetracker}
     volumes:
@@ -73,7 +73,7 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ${DB_NAME:-timetracker}
-      DB_USERNAME: ${DB_USERNAME:-timetracker}
+      DB_USER: ${DB_USER:-timetracker}
       DB_PASSWORD: ${DB_PASSWORD}
       NODE_ENV: production
     # npx + the locally-installed sequelize-cli — no global install
@@ -96,7 +96,7 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ${DB_NAME:-timetracker}
-      DB_USERNAME: ${DB_USERNAME:-timetracker}
+      DB_USER: ${DB_USER:-timetracker}
       DB_PASSWORD: ${DB_PASSWORD}
       PORT: 3000
       HOST: 0.0.0.0

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,7 +23,7 @@ sudo docker compose up -d postgres setup migrate
 sudo docker compose ps -a   # postgres: healthy, setup/migrate: Exited (0)
 
 # 3. Run the integration suite with DB vars set.
-export DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker DB_USERNAME=timetracker
+export DB_HOST=localhost DB_PORT=5432 DB_NAME=timetracker DB_USER=timetracker
 export DB_PASSWORD=$(grep '^DB_PASSWORD=' .env | cut -d= -f2-)
 npx vitest run tests/integration
 


### PR DESCRIPTION
Closes #141.

## Summary

`app/config/env.js` reads `process.env.DB_USER` and `.env.example` documents `DB_USER=timetracker`. But `docker-compose.yml` and two README sections referenced `DB_USERNAME`. The mismatch was silent on defaults (both sides fall back to `"timetracker"`), but meant an operator who set `DB_USER=foo` in their `.env` got that value **silently dropped** by compose's `${DB_USERNAME:-timetracker}` interpolation — both Postgres and the app ended up on the default user, not the configured one.

Replace every `DB_USERNAME` reference with `DB_USER`:
- `docker-compose.yml` — 5 occurrences (postgres `POSTGRES_USER`, `pg_isready` healthcheck, `PGUSER` on setup service, env passthrough on migrate + api)
- `tests/integration/README.md` — 1 occurrence in the env-var export example
- `README.md` — 1 occurrence in the integration-test quickstart

Backward-compat note: anyone with an existing `.env` that set the undocumented `DB_USERNAME` will need to rename it to `DB_USER`. The default-user path is unchanged.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 515 passed, 15 skipped (no source code touched, so no test count change)
- [x] `grep -rEn 'DB_USERNAME' . --include='*.yml' --include='*.md'` returns empty across tracked files

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/