### PR TITLE
chore(db): flip global timestamps default from false to true to match every model's explicit override

### DIFF
--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -29,7 +29,17 @@ const sequelize = new Sequelize(env.database, env.username, env.password, {
     logging: dbQueryLog,
     define: {
         schema: 'dbo',
-        timestamps: false,
+        // Match the de facto pattern: every model in app/models/
+        // already sets `timestamps: true` explicitly (the 20260520
+        // migration added `createdAt` / `updatedAt` columns to every
+        // domain table + the auth tables, and the model overrides
+        // were added at the same time). The previous global default
+        // of `false` was misleading because no model honoured it,
+        // and a future model that forgot the explicit override would
+        // silently skip the timestamps Sequelize otherwise auto-
+        // populates. Flip the default so new models inherit the
+        // right behaviour without ceremony.
+        timestamps: true,
     },
 });
 


### PR DESCRIPTION
Closes #147.

## Summary

`app/config/db.config.js` set `define.timestamps: false` as a global default for every Sequelize model. But every one of the 18 model files in `app/models/` overrides it with `timestamps: true` (introduced alongside the 20260520-timestamps migration). The global default never matched reality and sat as dead, misleading code.

The trap is for future models. A new model file that forgets the explicit `timestamps: true` override would silently inherit the global `false` and skip the timestamps every other table has — subtle bug, easy to miss in review.

Flip the global to `true` so new models inherit the right behaviour without ceremony. Existing per-model overrides stay (visible documentation; a follow-up could strip them for consistency). No behaviour change for any existing model.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 520 passed, 15 skipped (unchanged from master; no model's behaviour shifts)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/