### PR TITLE
chore(caddy): switch access log format from console to json for stack-wide log uniformity

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -39,9 +39,18 @@
     # small and aggressive compression on JSON adds a few ms.
     encode gzip
 
-    # Structured access logs to stdout.
+    # Structured access logs to stdout in JSON. Matches the app's
+    # pino output (one JSON object per line) so log shippers like
+    # Vector / Loki / CloudWatch see a single uniform format on
+    # the container's stdout fd rather than having to handle a mix
+    # of free-text `console` lines from Caddy and JSON lines from
+    # the api. Both contribute usable fields:
+    #   - request.headers.X-Request-Id correlates back to a pino
+    #     request log line (the API echoes / forwards it).
+    #   - duration / size let Caddy participate in the same
+    #     dashboards as the application metrics endpoint.
     log {
         output stdout
-        format console
+        format json
     }
 }


### PR DESCRIPTION
Closes #151.

## Summary

`caddy/Caddyfile` wrote access logs in `console` format. The application service (pino) writes structured JSON. Both go to the same container stdout, where log shippers parse line-by-line — the mixed-format split caused parser failure / raw fallback on the Caddy lines and meant queries filtering on `level=error` / `status>=500` silently missed Caddy-level 4xx/5xx.

Flip Caddy to `format json`. Whole container stdout stream becomes one uniform structured format; cross-layer correlation by `X-Request-Id` works because Caddy logs the request header and the API echoes the same id back.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 595 passed, 15 skipped (no application code touched)
- [x] Caddyfile change is config-only; manual verification on a TLS test deploy would confirm log shape, but the change is the documented Caddy JSON access-log option and reverts cleanly if needed

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/