### PR TITLE
docs(readme): use npm run test:watch instead of npm test -- --watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ public host — the override exposes Postgres on :5432.
 ## Testing
 
 ```bash
-npm test          # unit + API suite (mocks the DB; no infra needed)
-npm test -- --watch    # vitest watch mode
+npm test            # unit + API suite (mocks the DB; no infra needed)
+npm run test:watch  # vitest watch mode
 ```
 
 For integration tests against a real Postgres — see


### PR DESCRIPTION
Closes #165.

## Summary

`package.json` exposes a `test:watch` script that runs vitest in watch mode. README's Testing section pointed at `npm test -- --watch`, which works but is the awkward route past a purpose-built alias. `CONTRIBUTING.md` and `tests/README.md` both already correctly point at `npm run test:watch`. Align README so a new contributor's first read is the same shape as the rest.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 614 passed, 15 skipped (doc-only; no behavior change)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/