### PR TITLE
chore(openapi): declare Idempotency-Replay as 201 response header on bulk endpoints

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -264,6 +264,27 @@ const idempotencyKeyHeader = {
 };
 
 /**
+ * Reusable response-header spec for `Idempotency-Replay: true`.
+ *
+ * Set by the idempotency middleware (see app/middleware/idempotency.js)
+ * whenever a cached response is replayed for a matching key + body.
+ * Documented inline in the request-header description above, but the
+ * response-header declaration is what SDK generators (openapi-typescript,
+ * etc.) actually surface to client typings. Reference this from every
+ * 200/201 response that flows through the idempotency layer so clients
+ * can branch on "first write" vs. "replay" without re-parsing the body.
+ */
+const idempotencyReplayResponseHeader = {
+    'Idempotency-Replay': {
+        description:
+            'Present with value `true` when the response is a replay from the ' +
+            'idempotency cache. Absent on first-time writes. Useful for client- ' +
+            'side write counters and observability dashboards.',
+        schema: { type: 'string', enum: ['true'] },
+    },
+};
+
+/**
  * OpenAPI path entry for a bulk-create endpoint. Every bulk route
  * shares the same shape — outer JSON key wraps an array of the
  * underlying entity create body, capped at 500 entries, with the
@@ -302,7 +323,10 @@ function bulkPath(bodyKey, schemaName) {
                 },
             },
             responses: {
-                201: { description: 'All entries created' },
+                201: {
+                    description: 'All entries created (or a replay of a previously-cached create)',
+                    headers: idempotencyReplayResponseHeader,
+                },
                 400: { description: 'Validation failure (array empty/capped, missing parent FK, master without scope)' },
                 403: { description: 'Missing authKey or cross-tenant create attempt' },
                 409: { description: 'Idempotency-Key reused with a different body' },

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -134,6 +134,24 @@ describe('OpenAPI spec', () => {
         expect(customer.post).toBeDefined();
     });
 
+    test('bulk endpoints declare Idempotency-Replay on the 201 response', async () => {
+        // Counterpart to the request-header check above: the response
+        // header is what SDK generators (openapi-typescript, etc.)
+        // surface as a client-facing type. Without this declaration,
+        // clients can't tell from the spec that a 201 may carry the
+        // replay flag — it's only mentioned in the request header's
+        // description prose.
+        const res = await request(app).get('/openapi.json');
+        const worker = res.body.paths['/v1/worker/bulk'];
+        const r201 = worker.post.responses['201'];
+        expect(r201, 'worker/bulk 201 response should be declared').toBeDefined();
+        expect(r201.headers, 'worker/bulk 201 should declare response headers').toBeDefined();
+        const replay = r201.headers['Idempotency-Replay'];
+        expect(replay, 'Idempotency-Replay header should appear in 201 headers').toBeDefined();
+        expect(replay.schema).toBeDefined();
+        expect(replay.schema.enum).toContain('true');
+    });
+
     test('/metrics endpoint is documented', async () => {
         const res = await request(app).get('/openapi.json');
         const m = res.body.paths['/metrics'];


### PR DESCRIPTION
Closes #167.

## Summary

The `Idempotency-Replay: true` flag is set by the idempotency
middleware on every cached replay, but the OpenAPI spec only mentioned
it in the request-header description prose. SDK generators
(openapi-typescript, swagger-codegen, etc.) don't read narrative text
— they only surface what's declared as a response header.

This PR adds a reusable `idempotencyReplayResponseHeader` component
and attaches it to the shared `bulkPath()` factory's 201 response.
All 13 bulk-create endpoints inherit the declaration without per-
route duplication.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 615 passed → 616 passed (+1 covering the new spec assertion)
- [x] new test in `tests/api/openapi.test.js` asserts the header appears in the 201 response of `/v1/worker/bulk`

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/