### PR TITLE
feat(customerpayment): reject zero + non-finite cpayAmount at the schema layer

### DIFF
--- a/app/schemas/customerpayment.schema.js
+++ b/app/schemas/customerpayment.schema.js
@@ -12,11 +12,23 @@ const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
     message: 'Must be an ISO 8601 date (YYYY-MM-DD).',
 });
 
+// A payment amount must be a real, non-zero number. Zero is operator
+// error (recording a "$0 payment" against a customer ledger has no
+// business meaning); Infinity/-Infinity is data-quality error from
+// pathological clients — `z.number()` rejects NaN but allows the
+// infinities by default, and a DOUBLE column will happily store them.
+// Negative values pass — some operators model refunds that way.
+const cpayAmountField = z.coerce.number().finite({
+    message: 'cpayAmount must be a finite number.',
+}).refine((n) => n !== 0, {
+    message: 'cpayAmount must not be zero.',
+});
+
 const createCustomerPaymentBody = z.object({
     cpayCustId: z.coerce.number().int().positive(),
     cpayDescription: z.string().max(10000).optional(),
     cpayDate: isoDate,
-    cpayAmount: z.coerce.number(),
+    cpayAmount: cpayAmountField,
 }).strict({
     message: 'Unexpected field in body. Whitelist: cpayCustId, cpayDescription, cpayDate, cpayAmount.',
 });
@@ -24,7 +36,7 @@ const createCustomerPaymentBody = z.object({
 const updateCustomerPaymentBody = z.object({
     cpayDescription: z.string().max(10000).optional(),
     cpayDate: isoDate.optional(),
-    cpayAmount: z.coerce.number().optional(),
+    cpayAmount: cpayAmountField.optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: cpayDescription, cpayDate, cpayAmount.',
 });

--- a/tests/api/customerpayment.test.js
+++ b/tests/api/customerpayment.test.js
@@ -55,4 +55,25 @@ describe('CustomerPayment body validation', () => {
         const res = await request(app).post('/v1/customerpayment').set('authKey', 'any').send({ cpayCustId: 1, cpayDate: '2026-01-01' });
         expect(res.status).toBe(400);
     });
+
+    test('POST rejects zero cpayAmount', async () => {
+        const res = await request(app).post('/v1/customerpayment').set('authKey', 'any')
+            .send({ cpayCustId: 1, cpayDate: '2026-01-01', cpayAmount: 0 });
+        expect(res.status).toBe(400);
+    });
+
+    test('POST accepts a negative cpayAmount (refund model)', async () => {
+        // Some operators record refunds as negative payments. The
+        // schema only blocks 0 and the infinities, not negatives —
+        // pin that so a future tightening surfaces here.
+        const res = await request(app).post('/v1/customerpayment').set('authKey', 'any')
+            .send({ cpayCustId: 1, cpayDate: '2026-01-01', cpayAmount: -50 });
+        expect(res.status).not.toBe(400);
+    });
+
+    test('PATCH rejects zero cpayAmount', async () => {
+        const res = await request(app).patch('/v1/customerpayment/1').set('authKey', 'any')
+            .send({ cpayAmount: 0 });
+        expect(res.status).toBe(400);
+    });
 });


### PR DESCRIPTION
Closes #171.

## Summary

`cpayAmount` was typed `z.coerce.number()`, which accepted three values
that have no business meaning:

- `0` — a "\$0 payment" recorded against a customer ledger
- `Infinity` and `-Infinity` — zod rejects NaN by default but not the
  infinities; the DOUBLE column happily stores them, then any consumer
  doing arithmetic (totals, aging, CSV) gets contaminated

Negative values are intentionally still accepted — some operators
model refunds as negative payments and there's no separate refund flow.

Refactored into a shared `cpayAmountField` so create and update bodies
share one validator instead of drifting.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 617 → 620 (+3 tests)
- [x] POST with `cpayAmount: 0` → 400 (new)
- [x] POST with `cpayAmount: -50` → not 400 (refund flow preserved, new)
- [x] PATCH with `cpayAmount: 0` → 400 (new)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/