### PR TITLE
chore(sequelize-cli): sync define.timestamps with db.config.js

### DIFF
--- a/app/config/sequelize-cli.config.js
+++ b/app/config/sequelize-cli.config.js
@@ -20,7 +20,18 @@ const common = {
     dialect: 'postgres',
     define: {
         schema: 'dbo',
-        timestamps: false,
+        // Keep in sync with db.config.js's `define.timestamps`.
+        // The runtime flipped this to `true` in PR #148 so every
+        // domain model inherits auto-populated createdAt/updatedAt
+        // instead of carrying an explicit per-model override.
+        // sequelize-cli's migration runner doesn't currently exercise
+        // this default (migrations use queryInterface directly, not
+        // models), but a future contributor adding model-based code
+        // paths to a migration would otherwise get silently
+        // inconsistent behavior between `npm start` and
+        // `npm run migrate`. tests/unit/sequelize-cli-config.test.js
+        // pins the two configs in agreement.
+        timestamps: true,
     },
     // Migrations land in the dbo schema's SequelizeMeta table so we
     // don't pollute the public schema with framework bookkeeping.

--- a/tests/unit/sequelize-cli-config.test.js
+++ b/tests/unit/sequelize-cli-config.test.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Pin that `app/config/sequelize-cli.config.js` and
+// `app/config/db.config.js` agree on the global Sequelize `define`
+// defaults that affect schema-shape decisions (schema, timestamps).
+// Drift between them is a silent bug source — npm start vs.
+// npm run migrate could otherwise inherit different defaults.
+// PR #148 flipped db.config.js's `timestamps` from false to true and
+// missed sequelize-cli.config.js; this guards against a recurrence.
+
+import { describe, test, expect } from 'vitest';
+
+const dbConfig = require('../../app/config/db.config.js');
+const cliConfig = require('../../app/config/sequelize-cli.config.js');
+
+describe('sequelize-cli.config.js stays in sync with db.config.js', () => {
+    const runtimeDefine = dbConfig.sequelize.options.define;
+
+    test('cli `development` env mirrors runtime `define.timestamps`', () => {
+        expect(cliConfig.development.define.timestamps).toBe(runtimeDefine.timestamps);
+    });
+    test('cli `test` env mirrors runtime `define.timestamps`', () => {
+        expect(cliConfig.test.define.timestamps).toBe(runtimeDefine.timestamps);
+    });
+    test('cli `production` env mirrors runtime `define.timestamps`', () => {
+        expect(cliConfig.production.define.timestamps).toBe(runtimeDefine.timestamps);
+    });
+
+    test('cli `development` env mirrors runtime `define.schema`', () => {
+        expect(cliConfig.development.define.schema).toBe(runtimeDefine.schema);
+    });
+    test('cli `test` env mirrors runtime `define.schema`', () => {
+        expect(cliConfig.test.define.schema).toBe(runtimeDefine.schema);
+    });
+    test('cli `production` env mirrors runtime `define.schema`', () => {
+        expect(cliConfig.production.define.schema).toBe(runtimeDefine.schema);
+    });
+});


### PR DESCRIPTION
Closes #177.

## Summary

PR #148 flipped `db.config.js`'s `define.timestamps` from `false` to
`true` so every domain model inherits Sequelize's auto-populated
`createdAt` / `updatedAt`. `sequelize-cli.config.js` was missed and
still declared `timestamps: false`.

Not breaking today (migrations don't use the model layer) but a
latent footgun if anyone adds model-based code to a migration later.

This PR brings the two configs into sync and adds a unit test pinning
both `define.timestamps` and `define.schema` agreement so a future
drift fails CI instead of going silent.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 622 → 628 (+6 cross-config invariants)
- [x] 3 tests assert `cliConfig.<env>.define.timestamps === dbConfig.sequelize.options.define.timestamps`
- [x] 3 tests assert the same for `define.schema`

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/