### PR TITLE
chore(models): strip trailing whitespace + standardize "use strict" in legacy models

### DIFF
--- a/app/models/apikey.model.js
+++ b/app/models/apikey.model.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Aaron K. Clark
-'use strict';
+"use strict";
 module.exports = (sequelize, Sequelize) => {
     const ApiKey = sequelize.define('ApiKey', {
         akId: {
@@ -12,22 +12,18 @@ module.exports = (sequelize, Sequelize) => {
         akKEY: {
             field: 'akKEY',
             type: Sequelize.STRING
-            
         },
         akCompanyId: {
             field: 'akCompanyId',
             type: Sequelize.INTEGER
-            
         },
         akArchive: {
             field: 'akArchive',
             type: Sequelize.BOOLEAN
-            
         },
         akArchiveDate: {
             field: 'akArchiveDate',
             type: Sequelize.DATE
-            
         }
     },
         {

--- a/app/models/apimaster.model.js
+++ b/app/models/apimaster.model.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Aaron K. Clark
-'use strict';
+"use strict";
 module.exports = (sequelize, Sequelize) => {
     const ApiMaster = sequelize.define('ApiMaster', {
         amId: {
@@ -12,17 +12,14 @@ module.exports = (sequelize, Sequelize) => {
         amKEY: {
             field: 'amKEY',
             type: Sequelize.STRING
-            
         },
         amArchive: {
             field: 'amArchive',
             type: Sequelize.BOOLEAN
-            
         },
         amArchiveDate: {
             field: 'amArchiveDate',
             type: Sequelize.DATE
-            
         }
     },
         {
@@ -31,8 +28,6 @@ module.exports = (sequelize, Sequelize) => {
             defaultScope: { where: { amArchive: false } }
         }
     );
-
-
 
     return ApiMaster;
 }

--- a/app/models/customer.model.js
+++ b/app/models/customer.model.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Aaron K. Clark
-'use strict';
+"use strict";
 module.exports = (sequelize, Sequelize) => {
     const Customer = sequelize.define('Customer', {
         custId: {
@@ -12,37 +12,30 @@ module.exports = (sequelize, Sequelize) => {
         custCompanyName: {
             field: 'custCompanyName',
             type: Sequelize.STRING
-            
         },
         custFName: {
             field: 'custFName',
             type: Sequelize.STRING
-            
         },
         custLName: {
             field: 'custLName',
             type: Sequelize.STRING
-            
         },
         custAddress1: {
             field: 'custAddress1',
             type: Sequelize.STRING
-            
         },
         custAddress2: {
             field: 'custAddress2',
             type: Sequelize.STRING
-            
         },
         custCity: {
             field: 'custCity',
             type: Sequelize.STRING
-            
         },
         custState: {
             field: 'custState',
             type: Sequelize.STRING
-            
         },
         custZip: {
             field: 'custZip',
@@ -55,7 +48,6 @@ module.exports = (sequelize, Sequelize) => {
         custPhone: {
             field: 'custPhone',
             type: Sequelize.STRING
-            
         },
         custEmail: {
             field: 'custEmail',
@@ -72,8 +64,6 @@ module.exports = (sequelize, Sequelize) => {
             defaultScope: { where: { custArch: false } }
         }
     );
-
-
 
     return Customer;
 }


### PR DESCRIPTION
Closes #183.

## Summary

The 3 oldest model files (`apikey`, `apimaster`, `customer`) used
`'use strict';` (single-quoted) and carried trailing whitespace on
every field. The other 15 models follow the current convention:
`"use strict";` (double-quoted) and no trailing whitespace per
`.editorconfig`.

Mechanical cleanup only. Field declarations stay verbatim — no
`allowNull` / `defaultValue` additions (those would be real behavior
changes, and the DDL is authoritative for what the DB enforces).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 632 passed (no test surface affected)
- [x] No `allowNull` / `defaultValue` additions
- [x] Module shape, options block, `defaultScope`, `tableName` unchanged

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/