### PR TITLE
docs(dependabot): "Two ecosystems" → "Three" — config actually tracks npm/actions/docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 # Dependabot configuration. Automates dependency updates so the
 # `npm audit` CI gate doesn't surprise us at release time.
 #
-# Two ecosystems get watched:
+# Three ecosystems get watched:
 #   1. npm — the production + dev tree in package.json.
 #   2. github-actions — workflow action versions in .github/workflows/.
 #   3. docker — base images in Dockerfile / docker-compose.yml.


### PR DESCRIPTION
Closes #185.

## Summary

`.github/dependabot.yml`'s header comment opened with "Two ecosystems get watched" but listed three. One-character fix.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 632 passed (docs-only change)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/