### PR TITLE
docs(readme): Node.js 18+ → 20+ to match engines pin + CI matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ node -e "require('fs').writeFileSync('/tmp/oas.json', JSON.stringify(require('./
 
 ## Requirements
 
-- **Node.js 18+** (tested on 20 and 22)
+- **Node.js 20+** (matches `engines.node` in `package.json`; CI tests against 20 and 22)
 - **PostgreSQL 14+**
 - A modern Linux distribution (any currently supported LTS — Ubuntu 22.04 / 24.04, Debian 12, RHEL 9, etc.)
 


### PR DESCRIPTION
Closes #189.

## Summary

README's Requirements line said "Node.js 18+" but `engines.node` is
`">=20.0.0"`, the badge says 20+, and CI tests only 20+22. One-line
fix.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 635 passed (docs-only change)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/