### PR TITLE
fix(inventoryitem): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/inventoryitemcontroller.js
+++ b/app/controllers/inventoryitemcontroller.js
@@ -91,8 +91,13 @@ exports.getById = async (req, res) => {
     const isMaster = await IsMaster(authKey);
     if (!isMaster) {
         const companyId = await GetCompanyId(authKey);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which InventoryItem ids are
+        // populated across the whole tenant table by status code.
+        // Same secure-404 pattern as #174 (company), #188 (billingtype),
+        // #192 (worker).
         if (companyId === -1 || inventoryItem.invitCompId !== companyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", inventoryItem });
@@ -168,8 +173,9 @@ exports.update = async (req, res) => {
     const isMaster = await IsMaster(authKey);
     if (!isMaster) {
         const companyId = await GetCompanyId(authKey);
+        // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || inventoryItem.invitCompId !== companyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -211,8 +217,9 @@ exports.remove = async (req, res) => {
     const isMaster = await IsMaster(authKey);
     if (!isMaster) {
         const companyId = await GetCompanyId(authKey);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || inventoryItem.invitCompId !== companyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/inventoryitem.test.js
+++ b/tests/api/inventoryitem.test.js
@@ -76,3 +76,87 @@ describe('InventoryItem body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('InventoryItem tenant-enumeration defense (secure 404)', () => {
+    // Same pattern as worker/billingtype/company secure-404 tests:
+    // drive the controller directly with stubbed Model + spied auth
+    // helpers so we don't have to wire every upstream middleware.
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/inventoryitemcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InventoryItem.findByPk = vi.fn().mockResolvedValue({
+                invitId: 99, invitCompId: 99, invitArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 99 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/inventoryitemcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InventoryItem.findByPk = vi.fn().mockResolvedValue({
+                invitId: 99, invitCompId: 99, invitArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 99 },
+                body: { invitDescription: 'X' },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/inventoryitemcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InventoryItem.findByPk = vi.fn().mockResolvedValue({
+                invitId: 99, invitCompId: 99, invitArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 99 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #195.

## Summary

`/v1/inventoryitem/:id` GET/PATCH/DELETE returned 403 when a scoped caller asked about an inventory item belonging to another tenant, vs 404 for ids that don't exist. A non-master caller could iterate \`invitId\` values and learn which are populated.

Collapse both cases into 404 with the same body. Same secure-404 pattern landed for `/v1/company` (#174), `/v1/billingtype` (#188), `/v1/worker` (#192).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\" — 643 → 646 (+3 controller-level tests)
- [x] getById / update / remove: non-master + existing-but-not-yours → 404 (new)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/