### PR TITLE
chore(compose): set NODE_ENV=production by default on the api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,14 @@ services:
       migrate:
         condition: service_completed_successfully
     environment:
+      # Default to production mode in compose. Several libraries
+      # (Express, Sequelize, pg) gate performance optimizations on
+      # NODE_ENV === 'production'; without it the api was running
+      # with dev-mode defaults inside what an operator would assume
+      # is a production deployment. Operators who explicitly want
+      # dev compose (e.g. for live-reload testing) can override via
+      # `NODE_ENV=development` in .env.
+      NODE_ENV: ${NODE_ENV:-production}
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ${DB_NAME:-timetracker}


### PR DESCRIPTION
Closes #197.

## Summary

The migrate service set `NODE_ENV: production` but the api service didn't. Libraries that gate optimizations on `NODE_ENV === 'production'` (Express, Sequelize, pg, …) were running in dev mode inside what an operator would assume is a production deployment.

Add `NODE_ENV: ${NODE_ENV:-production}` to the api service. Operators who want dev compose can override via `NODE_ENV=development` in `.env`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 646 passed (compose-only change, no test surface)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/