### PR TITLE
chore(router): hoist inline metricsHandler require to module-top imports

### DIFF
--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -6,6 +6,7 @@ const router = express.Router();
 const swaggerUi = require('swagger-ui-express');
 const { attachAuth } = require('../middleware/auth.js');
 const { idempotency } = require('../middleware/idempotency.js');
+const { metricsHandler } = require('../middleware/metrics.js');
 
 const customer = require('../controllers/customercontroller.js');
 const health = require('../controllers/healthcontroller.js');
@@ -51,7 +52,6 @@ router.get('/healthz', health.healthz);
 // Prometheus scrape endpoint. Auth is optional, gated by
 // METRICS_BEARER_TOKEN env var; unset => unauthenticated, the
 // usual private-network deployment pattern.
-const { metricsHandler } = require('../middleware/metrics.js');
 router.get('/metrics', metricsHandler);
 
 // attachAuth runs on every /v1/* request and populates


### PR DESCRIPTION
Closes #207.

## Summary

One inline `require(metricsHandler)` in `app/routers/router.js` disagreed with the 46+ other requires that are hoisted to the top of the file. Pure style cleanup. Mirrors the iter-40 hoist of server.js's inline pino-http requires (#202).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 656 passed (no behavior change)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/