### PR TITLE
fix(purchaseorderline): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/purchaseorderlinecontroller.js
+++ b/app/controllers/purchaseorderlinecontroller.js
@@ -79,8 +79,13 @@ exports.getById = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which PurchaseOrderLine ids
+        // are populated across the whole tenant table by status code.
+        // Same secure-404 pattern as the prior 7 entities (#174 / #188
+        // / #192 / #196 / #200 / #204 / #210).
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", purchaseOrderLine: line });
@@ -152,8 +157,9 @@ exports.update = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
+        // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -196,8 +202,9 @@ exports.remove = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/purchaseorderline.test.js
+++ b/tests/api/purchaseorderline.test.js
@@ -102,3 +102,93 @@ describe('PurchaseOrderLine body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('PurchaseOrderLine tenant-enumeration defense (secure 404)', () => {
+    // Two-level cascade: polpoh → header.pohPovId → vendor.povCompId.
+    // Spy on getCompanyIdByPohId (which itself walks header→vendor)
+    // so the cascade resolves to a different company than the caller.
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/purchaseorderlinecontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByPohIdSpy = vi.spyOn(auth, 'getCompanyIdByPohId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.PurchaseOrderLine.findByPk = vi.fn().mockResolvedValue({
+                polId: 42, polpoh: 13, polArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByPohIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/purchaseorderlinecontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByPohIdSpy = vi.spyOn(auth, 'getCompanyIdByPohId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.PurchaseOrderLine.findByPk = vi.fn().mockResolvedValue({
+                polId: 42, polpoh: 13, polArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 42 },
+                body: { polItemDesc: 'X' },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByPohIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/purchaseorderlinecontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByPohIdSpy = vi.spyOn(auth, 'getCompanyIdByPohId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.PurchaseOrderLine.findByPk = vi.fn().mockResolvedValue({
+                polId: 42, polpoh: 13, polArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByPohIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #213.

## Summary

Same secure-404 pattern as #174 / #188 / #192 / #196 / #200 / #204 / #210, now on the two-level cascade-scoped PurchaseOrderLine (`polpoh → header.pohPovId → vendor.povCompId`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 663 → 666 (+3 controller-level tests)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/