### PR TITLE
docs(contributing): replace stale test-count numbers with rot-proof language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ npm start                                  # serves on PORT (default 3000)
 npm run dev                                # same, but auto-reloads on app/ + server.js edits
 ```
 
-`npm test` runs the full vitest suite (45+ files, 479+ cases at this
-writing). The integration suite (`tests/integration/`) auto-skips when
-no Postgres is reachable, so a fresh `npm test` without docker still
-passes the unit + api tiers.
+`npm test` runs the full vitest suite — unit + api + integration
+tiers across `tests/`. The integration suite (`tests/integration/`)
+auto-skips when no Postgres is reachable, so a fresh `npm test`
+without docker still passes the unit + api tiers.
 
 ## Before you open a PR
 


### PR DESCRIPTION
Closes #215.

## Summary

`CONTRIBUTING.md` said "45+ files, 479+ cases at this writing" — reality at master is 51 files, 666 cases. Swap the hard-coded counts for tier names so the line stops rotting every time the suite grows.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 666 passed (docs-only change)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/