### PR TITLE
fix(productentry): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/productentrycontroller.js
+++ b/app/controllers/productentrycontroller.js
@@ -74,8 +74,13 @@ exports.getById = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which ProductEntry ids are
+        // populated across the whole tenant table by status code.
+        // Same secure-404 pattern as the prior 8 entities (#174 / #188
+        // / #192 / #196 / #200 / #204 / #210 / #214).
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", productEntry });
@@ -149,8 +154,9 @@ exports.update = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
+        // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -193,8 +199,9 @@ exports.remove = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/productentry.test.js
+++ b/tests/api/productentry.test.js
@@ -57,3 +57,93 @@ describe('ProductEntry body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('ProductEntry tenant-enumeration defense (secure 404)', () => {
+    // Job-cascade-scoped: pentJobId → job.jobCustId → customer.custCompId.
+    // Spy on getCompanyIdByJobId so the cascade resolves to a different
+    // company than the caller's (the helper itself walks job→customer).
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/productentrycontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.ProductEntry.findByPk = vi.fn().mockResolvedValue({
+                pentId: 42, pentJobId: 13, penArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/productentrycontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.ProductEntry.findByPk = vi.fn().mockResolvedValue({
+                pentId: 42, pentJobId: 13, penArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 42 },
+                body: { pentQty: 5 },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/productentrycontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.ProductEntry.findByPk = vi.fn().mockResolvedValue({
+                pentId: 42, pentJobId: 13, penArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #217.

## Summary

Same secure-404 pattern as the eight prior fixes, now on the job-cascade-scoped ProductEntry (`pentJobId → Job.jobCustId → Customer.custCompId`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 666 → 669 (+3 controller-level tests)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/