### PR TITLE
docs(env-example): add NODE_ENV — used by env.js's production hard-fail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@
 #
 # `.env` is gitignored; this `.env.example` file is the canonical reference.
 
+# ---- Mode ----
+
+# Set to `production` to enable strict startup checks (most importantly:
+# the server refuses to boot when DB_PASSWORD is empty instead of warning
+# and continuing). Leave unset / `development` for local + test runs that
+# don't need a real database. The Dockerfile and docker-compose.yml api
+# service both default this to `production` automatically.
+# NODE_ENV=production
+
 # ---- HTTP server ----
 
 # Port the API listens on. Use a non-privileged port (>1024) so the process


### PR DESCRIPTION
Closes #219.

## Summary

`.env.example` was missing `NODE_ENV` despite `env.js` reading it to gate the empty-DB_PASSWORD hard-fail. README env table already covers it (#176); this brings the example file into sync.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 669 passed (docs-only)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/