### PR TITLE
fix(job): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -85,8 +85,13 @@ exports.getById = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which Job ids are populated
+        // across the whole tenant table by status code. Same
+        // secure-404 pattern as the prior 9 entities (#174 / #188 /
+        // #192 / #196 / #200 / #204 / #210 / #214 / #218).
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", job });
@@ -161,8 +166,9 @@ exports.update = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
+        // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -205,8 +211,9 @@ exports.remove = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/job.test.js
+++ b/tests/api/job.test.js
@@ -57,3 +57,93 @@ describe('Job body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('Job tenant-enumeration defense (secure 404)', () => {
+    // Customer-cascade-scoped: jobCustId → customer.custCompId.
+    // Spy on getCompanyIdByCustomerId so the cascade resolves to a
+    // different company than the caller's.
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/jobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.Job.findByPk = vi.fn().mockResolvedValue({
+                jobId: 42, jobCustId: 13, jobArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/jobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.Job.findByPk = vi.fn().mockResolvedValue({
+                jobId: 42, jobCustId: 13, jobArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 42 },
+                body: { jobDesc: 'X' },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/jobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.Job.findByPk = vi.fn().mockResolvedValue({
+                jobId: 42, jobCustId: 13, jobArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #221.

## Summary

Same secure-404 pattern as the nine prior fixes, now on customer-cascade-scoped Job (`jobCustId → Customer.custCompId`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 669 → 672 (+3 controller-level tests)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/