### PR TITLE
fix(customerpayment): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/customerpaymentcontroller.js
+++ b/app/controllers/customerpaymentcontroller.js
@@ -77,8 +77,14 @@ exports.getById = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which CustomerPayment ids are
+        // populated across the whole tenant table by status code.
+        // Same secure-404 pattern as the prior 10 entities (#174 /
+        // #188 / #192 / #196 / #200 / #204 / #210 / #214 / #218 /
+        // #222).
         if (authCompanyId === -1 || cpCompanyId === -1 || authCompanyId !== cpCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", customerPayment: payment });
@@ -152,8 +158,9 @@ exports.update = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
+        // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || cpCompanyId === -1 || authCompanyId !== cpCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -196,8 +203,9 @@ exports.remove = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || cpCompanyId === -1 || authCompanyId !== cpCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/customerpayment.test.js
+++ b/tests/api/customerpayment.test.js
@@ -77,3 +77,93 @@ describe('CustomerPayment body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('CustomerPayment tenant-enumeration defense (secure 404)', () => {
+    // Customer-cascade-scoped: cpayCustId → customer.custCompId.
+    // Spy on getCompanyIdByCustomerId so the cascade resolves to a
+    // different company than the caller's.
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/customerpaymentcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.CustomerPayment.findByPk = vi.fn().mockResolvedValue({
+                cpayId: 42, cpayCustId: 13, cpayArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/customerpaymentcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.CustomerPayment.findByPk = vi.fn().mockResolvedValue({
+                cpayId: 42, cpayCustId: 13, cpayArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 42 },
+                body: { cpayAmount: 50 },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/customerpaymentcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByCustomerIdSpy = vi.spyOn(auth, 'getCompanyIdByCustomerId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.CustomerPayment.findByPk = vi.fn().mockResolvedValue({
+                cpayId: 42, cpayCustId: 13, cpayArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByCustomerIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #225.

Same secure-404 pattern as the 10 prior fixes, now on customer-cascade-scoped CustomerPayment.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 672 → 675 (+3)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/