### PR TITLE
docs(tests-readme): swap stale count + audit-cycle phrase for rot-proof line

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,11 +6,10 @@ npm run test:watch  # rerun on file changes
 ```
 
 The suite uses [vitest](https://vitest.dev/) + [supertest](https://github.com/ladjs/supertest).
-At this writing: ~480 cases across 47 files, sub-2-second wall-clock,
-0 net regressions across the audit cycle. The integration suite
-auto-skips locally when no real Postgres is reachable; CI runs a
-live `postgres:16-alpine` service alongside the matrix so the full
-suite runs on every PR.
+Runs in sub-two-second wall-clock across the unit + api tiers. The
+integration suite auto-skips locally when no real Postgres is
+reachable; CI runs a live `postgres:16-alpine` service alongside the
+matrix so the full suite runs on every PR.
 
 ## Three tiers
 


### PR DESCRIPTION
Closes #231.

Same pattern as #216 on CONTRIBUTING.md. Drops "~480 cases across 47 files" (reality: 678 / 51) and the no-longer-meaningful "audit cycle" anchor.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 678 passed (docs-only)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/