### PR TITLE
fix(invoicejob): return 404 on cross-tenant access — close tenant enumeration leak

### DIFF
--- a/app/controllers/invoicejobcontroller.js
+++ b/app/controllers/invoicejobcontroller.js
@@ -79,8 +79,13 @@ exports.getById = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
+        // Cross-tenant access is reported as 404, not 403 — otherwise
+        // a scoped caller can enumerate which InvoiceJob ids are
+        // populated across the whole tenant table by status code.
+        // Same secure-404 pattern as the prior 12 entities (#174
+        // through #230).
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
     return res.status(200).json({ message: "Found.", invoiceJob });
@@ -171,8 +176,9 @@ exports.update = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
+        // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 
@@ -215,8 +221,9 @@ exports.remove = async (req, res) => {
     if (!isMaster) {
         const authCompanyId = await GetCompanyId(authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
+        // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
-            return res.status(403).json({ message: "Invalid Authorization Key." });
+            return res.status(404).json({ message: "Not found." });
         }
     }
 

--- a/tests/api/invoicejob.test.js
+++ b/tests/api/invoicejob.test.js
@@ -87,3 +87,92 @@ describe('InvoiceJob body validation', () => {
         expect(res.status).toBe(400);
     });
 });
+
+describe('InvoiceJob tenant-enumeration defense (secure 404)', () => {
+    // Job-cascade-scoped: injbJobId → Job.jobCustId → Customer.custCompId.
+    // Spy on getCompanyIdByJobId (the helper walks job→customer→company).
+    test('controller getById: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/invoicejobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InvoiceJob.findByPk = vi.fn().mockResolvedValue({
+                injbId: 42, injbJobId: 13, injbArch: false,
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.getById(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+
+    test('controller update: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/invoicejobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InvoiceJob.findByPk = vi.fn().mockResolvedValue({
+                injbId: 42, injbJobId: 13, injbArch: false, update: vi.fn(),
+            });
+            const req = {
+                get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined),
+                params: { id: 42 },
+                body: { injbAmount: 50 },
+            };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.update(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+
+    test('controller remove: existing-but-not-yours returns 404 to non-master', async () => {
+        const auth = require('../../app/middleware/auth.js');
+        const controller = require('../../app/controllers/invoicejobcontroller.js');
+        const isMasterSpy = vi.spyOn(auth, 'isMaster').mockResolvedValue(false);
+        const getCompanyIdSpy = vi.spyOn(auth, 'getCompanyId').mockResolvedValue(7);
+        const getCompanyIdByJobIdSpy = vi.spyOn(auth, 'getCompanyIdByJobId').mockResolvedValue(99);
+        try {
+            const db = require('../../app/config/db.config.js');
+            db.InvoiceJob.findByPk = vi.fn().mockResolvedValue({
+                injbId: 42, injbJobId: 13, injbArch: false, update: vi.fn(),
+            });
+            const req = { get: (h) => (h === 'authKey' ? 'scoped-to-7' : undefined), params: { id: 42 } };
+            let captured = null;
+            const res = {
+                status(code) { this._code = code; return this; },
+                json(body) { captured = { code: this._code, body }; return this; },
+            };
+            await controller.remove(req, res);
+            expect(captured.code).toBe(404);
+            expect(captured.body.message).toMatch(/not found/i);
+        } finally {
+            isMasterSpy.mockRestore();
+            getCompanyIdSpy.mockRestore();
+            getCompanyIdByJobIdSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #233.

Same secure-404 pattern as the 12 prior fixes, now on job-cascade-scoped InvoiceJob.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 678 → 681 (+3)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/