### PR TITLE
docs(openapi): add Idempotency-Replay to /v1/customer/bulk too — 13-of-13 now

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -513,7 +513,15 @@ const spec = {
                     },
                 },
                 responses: {
-                    201: { description: 'All customers created' },
+                    201: {
+                        description: 'All customers created (or a replay of a previously-cached create)',
+                        // Customer/bulk predates the bulkPath() factory but
+                        // shares the same Idempotency-Key middleware path.
+                        // Declare the replay header here too so SDK generators
+                        // see it on all 13 bulk endpoints, not 12-of-13.
+                        // Matches the factory output from #168.
+                        headers: idempotencyReplayResponseHeader,
+                    },
                     400: { description: 'Validation failure (array empty / master without custCompId on some entry)' },
                     403: { description: 'Missing authKey or cross-tenant create attempt' },
                     500: { description: 'Transaction rolled back due to DB error' },

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -152,6 +152,20 @@ describe('OpenAPI spec', () => {
         expect(replay.schema.enum).toContain('true');
     });
 
+    test('customer/bulk also declares Idempotency-Replay on the 201 response', async () => {
+        // Customer/bulk predates the bulkPath() factory and has its
+        // own dedicated path entry in the spec. The factory got the
+        // header in #168; this assertion catches the inconsistent case
+        // where customer/bulk was missed.
+        const res = await request(app).get('/openapi.json');
+        const customer = res.body.paths['/v1/customer/bulk'];
+        const r201 = customer.post.responses['201'];
+        expect(r201.headers, 'customer/bulk 201 should declare response headers').toBeDefined();
+        const replay = r201.headers['Idempotency-Replay'];
+        expect(replay, 'Idempotency-Replay should appear on customer/bulk too').toBeDefined();
+        expect(replay.schema.enum).toContain('true');
+    });
+
     test('/metrics endpoint is documented', async () => {
         const res = await request(app).get('/openapi.json');
         const m = res.body.paths['/metrics'];


### PR DESCRIPTION
Closes #239.

`bulkPath()` factory got the Idempotency-Replay header in #168. Customer/bulk predates the factory and has its own path entry; it was missed. 12-of-13 bulk endpoints declared the header before this PR; now 13-of-13.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 685 → 686 (+1 assertion on customer/bulk 201 headers)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/