### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/customer 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -610,7 +610,17 @@ const spec = {
                     },
                 },
                 responses: {
-                    201: { description: 'Created', content: { 'application/json': { schema: { $ref: '#/components/schemas/Customer' } } } },
+                    201: {
+                        description: 'Created (or a replay of a previously-cached create)',
+                        // The single-create POST flows through the same
+                        // idempotency middleware as the bulk endpoints
+                        // (see #168 and #240), so it emits the same
+                        // Idempotency-Replay: true on a cached replay.
+                        // Declare it so SDK generators surface the field
+                        // on the client side.
+                        headers: idempotencyReplayResponseHeader,
+                        content: { 'application/json': { schema: { $ref: '#/components/schemas/Customer' } } },
+                    },
                     400: { description: 'Bad request' },
                     403: { description: 'Missing or invalid authKey' },
                 },

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -166,6 +166,20 @@ describe('OpenAPI spec', () => {
         expect(replay.schema.enum).toContain('true');
     });
 
+    test('single-create POST /v1/customer declares Idempotency-Replay on the 201', async () => {
+        // Single-create POSTs flow through the same idempotency
+        // middleware as the bulk endpoints. Without the response-header
+        // declaration on the 201, SDKs generated from the spec can't
+        // surface the replay flag for non-bulk creates.
+        const res = await request(app).get('/openapi.json');
+        const customer = res.body.paths['/v1/customer'];
+        const r201 = customer.post.responses['201'];
+        expect(r201.headers, 'POST /v1/customer 201 should declare headers').toBeDefined();
+        const replay = r201.headers['Idempotency-Replay'];
+        expect(replay, 'Idempotency-Replay should appear on POST /v1/customer 201').toBeDefined();
+        expect(replay.schema.enum).toContain('true');
+    });
+
     test('/metrics endpoint is documented', async () => {
         const res = await request(app).get('/openapi.json');
         const m = res.body.paths['/metrics'];


### PR DESCRIPTION
Closes #245 (partial — single-create POST /v1/customer; other 15 single-create POSTs follow in subsequent PRs).

## Summary

Start the single-create POST sweep with `POST /v1/customer`. Adds `headers: idempotencyReplayResponseHeader` to its 201 response so SDK generators surface the replay flag on non-bulk creates too.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 687 → 688 (+1 assertion)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/