### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/timeentry 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -638,7 +638,14 @@ const spec = {
                     },
                 },
                 responses: {
-                    201: { description: 'Created' },
+                    201: {
+                        description: 'Created (or a replay of a previously-cached create)',
+                        // Same Idempotency-Key middleware path as /v1/customer
+                        // (#246) and the 13 bulk endpoints (#168 / #240).
+                        // Declare the replay header so SDK generators surface
+                        // the field on single-create writes.
+                        headers: idempotencyReplayResponseHeader,
+                    },
                     400: { description: 'Bad request — missing teCustId or teStartedAt' },
                     403: { description: 'Missing or invalid authKey' },
                 },


### PR DESCRIPTION
Part of #245. Adds the `Idempotency-Replay` response header to `POST /v1/timeentry`'s 201 — second of the 16 single-create POSTs after #246.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 688 passed (no test surface)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/