### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/worker 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -722,7 +722,11 @@ const spec = {
                     },
                 },
                 responses: {
-                    201: { description: 'Created', content: { 'application/json': { schema: { $ref: '#/components/schemas/Worker' } } } },
+                    201: {
+                        description: 'Created (or a replay of a previously-cached create)',
+                        headers: idempotencyReplayResponseHeader,
+                        content: { 'application/json': { schema: { $ref: '#/components/schemas/Worker' } } },
+                    },
                     400: { description: 'Bad request' },
                     403: { description: 'Missing or invalid authKey' },
                 },


### PR DESCRIPTION
Part of #245. 3rd endpoint in the single-create POST sweep (after #246 customer, #249 timeentry).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 688 passed

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/