### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/billingtype 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -771,7 +771,14 @@ const spec = {
                 security: [{ authKey: [] }],
                 parameters: [idempotencyKeyHeader],
                 requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/BillingType' } } } },
-                responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Auth failure' } },
+                responses: {
+                    201: {
+                        description: 'Created (or a replay of a previously-cached create)',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Auth failure' },
+                },
             },
         },
         '/v1/billingtype/{id}': {


### PR DESCRIPTION
Part of #245. 4th endpoint in the single-create POST sweep after #246 (customer), #249 (timeentry), #251 (worker).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 688 passed

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/