### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/inventoryitem 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -820,7 +820,14 @@ const spec = {
                 security: [{ authKey: [] }],
                 parameters: [idempotencyKeyHeader],
                 requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/InventoryItem' } } } },
-                responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Auth failure' } },
+                responses: {
+                    201: {
+                        description: 'Created',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Auth failure' },
+                },
             },
         },
         '/v1/inventoryitem/{id}': {


### PR DESCRIPTION
Part of #245 — single-create POST OpenAPI Idempotency-Replay sweep.

## Summary
- Adds `Idempotency-Replay` response-header declaration to the 201 response on `POST /v1/inventoryitem`
- Same pattern as customer/timeentry/worker/billingtype already shipped

## Why
The Idempotency-Key middleware applies to every `/v1/*` POST, but until now only the bulk endpoints (and four single-create endpoints) declared the `Idempotency-Replay` response header on their 201. SDK generators (openapi-typescript, etc.) couldn't see the replay flag for inventoryitem creates without this declaration.

## Test plan
- `npm run lint && npm test` locally — 688 passing, no regressions
- Pure spec metadata; no behavior change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/