### PR TITLE
chore(auth): drop dead attachOk guard in resolveAuth

### DIFF
--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -326,11 +326,9 @@ function requireAuth(req, res, next) {
  * out of the strict 403 (like /v1/whoami).
  */
 async function resolveAuth(req, res, next) {
-    let attachOk = false;
     await new Promise((resolve) => {
-        attachAuth(req, res, () => { attachOk = true; resolve(); });
+        attachAuth(req, res, () => resolve());
     });
-    if (!attachOk) return; // attachAuth already sent a 500
     return requireAuth(req, res, next);
 }
 


### PR DESCRIPTION
## Summary
Cleanup follow-up to #162, which removed the outer try/catch around `isMaster` + `getCompanyId` in `attachAuth`.

Since that change, `attachAuth` no longer has any 500-emitting path — its callees swallow DB-infrastructure errors into sentinels (`false` / `-1`) and always invoke `next()`. The `attachOk` boolean in `resolveAuth` was therefore guaranteed true after the awaited Promise resolved, and the comment "attachAuth already sent a 500" misled readers into thinking there was still a divergent error path.

Drop the dead conditional and its stale comment. Behavior unchanged.

## Test plan
- `npm run lint && npm test` — 688 passing, no regressions
- Unit + integration auth tests still cover both attach paths and the strict 403 in requireAuth

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/