### PR TITLE
docs(idempotency): correct misleading Awaited prune comment

### DIFF
--- a/app/middleware/idempotency.js
+++ b/app/middleware/idempotency.js
@@ -137,8 +137,9 @@ async function idempotency(req, res, next) {
     const scope = buildScope(req);
     const bodyHash = hashBody(req.body);
 
-    // Best-effort prune. Awaited so we don't pile up overlapping
-    // DELETEs under load; cheap because the index covers it.
+    // Best-effort prune. Fire-and-forget so the request path never
+    // waits on DELETE; errors are swallowed via the .catch(). Cheap
+    // because the index on ikExpiresAt covers it.
     pruneExpired(getDb().sequelize).catch(() => {});
 
     let existing;


### PR DESCRIPTION
## Summary
Comment-only fix in `app/middleware/idempotency.js`.

The inline comment on the prune call claimed "Awaited so we don't pile up overlapping DELETEs under load" — but the call has always been fire-and-forget (`.catch(() => {})` with no `await`). That phrasing has misled readers since the original P3-G commit; one could reasonably read it as either "we ARE awaiting" or "we DON'T await", but neither matches the actual code clearly.

Rephrase to describe the actual behavior: fire-and-forget, errors swallowed in the `.catch`, indexed lookup makes it cheap. No behavior change.

## Test plan
- `npm run lint && npm test` — 688 passing
- Comment-only change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/