### PR TITLE
chore(docker): exclude CONTRIBUTING.md + SECURITY.md from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,7 +39,9 @@ Thumbs.db
 # §4(c) requires distributions of derivative works (including container
 # images) to include the License notice. Keep LICENSE in.
 CHANGELOG.md
+CONTRIBUTING.md
 README.md
+SECURITY.md
 docs
 
 # Env files — secrets should be passed via -e flags or compose, never


### PR DESCRIPTION
## Summary
`.dockerignore` already excluded `README.md`, `CHANGELOG.md`, and `docs/` on the rationale that repo-meta docs don't help the runtime image (only `LICENSE` has to ship — Apache-2.0 §4(c)).

`CONTRIBUTING.md` and `SECURITY.md` were missed; they're the same category and shouldn't bake into the deployed image either.

## Why
- Same comment block already explains the rule; this just makes it complete.
- Trivial reduction in build context.
- Future readers won't have to wonder why two of four root-level repo-meta docs are excluded but the other two aren't.

## Test plan
- `npm run lint && npm test` — 688 passing
- Behavioral change is image-only; tests don't observe it directly

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/