### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/company 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -869,7 +869,14 @@ const spec = {
                 security: [{ authKey: [] }],
                 parameters: [idempotencyKeyHeader],
                 requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/Company' } } } },
-                responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Non-master key' } },
+                responses: {
+                    201: {
+                        description: 'Created',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Non-master key' },
+                },
             },
             get: {
                 summary: 'List all companies (master keys only, paginated)',


### PR DESCRIPTION
Part of #245 — single-create POST OpenAPI Idempotency-Replay sweep.

## Summary
- Adds `Idempotency-Replay` response-header declaration to the 201 response on `POST /v1/company`
- Same pattern as customer / timeentry / worker / billingtype / inventoryitem already shipped

## Why
The Idempotency-Key middleware applies to every `/v1/*` POST, but only some of the single-create endpoints declared the `Idempotency-Replay` response header on their 201. SDK generators (openapi-typescript, etc.) couldn't see the replay flag for company creates without this declaration.

## Test plan
- `npm run lint && npm test` locally — 688 passing, no regressions
- Pure spec metadata; no behavior change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/