### PR TITLE
docs(healthz): correct stale 2s timeout comment — no timeout is set

### DIFF
--- a/app/controllers/healthcontroller.js
+++ b/app/controllers/healthcontroller.js
@@ -62,12 +62,14 @@ exports.healthz = async (req, res) => {
     try {
         // Cheapest possible DB-roundtrip: `SELECT 1`. Confirms the
         // pool can hand us a connection AND that Postgres responds.
+        // NOTE: there's no per-query timeout here — Sequelize doesn't
+        // expose one for postgres at this layer. A hung backend will
+        // hang the probe until the orchestrator's own probe timeout
+        // (typically 5–10s) fires. If that turns out to be a problem
+        // in practice, set pg's statement_timeout via dialectOptions
+        // in db.config.js so it applies pool-wide.
         await db.sequelize.query('SELECT 1 AS ok;', {
             type: db.sequelize.QueryTypes.SELECT,
-            // Short timeout so a hung DB doesn't drag the probe out.
-            // Sequelize uses pg's `query_timeout` for this on Postgres.
-            // 2s is well over the expected sub-ms response, well under
-            // a typical orchestrator probe timeout (usually 5–10s).
             raw: true,
         });
         dbOk = true;


### PR DESCRIPTION
## Summary
Comment-only fix in `app/controllers/healthcontroller.js`.

The inline comment on the `SELECT 1` probe claimed "Sequelize uses pg's `query_timeout` for this on Postgres. 2s is well over the expected sub-ms response..." but **no `timeout` / `query_timeout` option is actually passed** to `sequelize.query()` — and the Sequelize options bag at the call site doesn't expose a per-query timeout for postgres anyway.

The comment has been wrong since the original /healthz PR (#4) and likely misled operators looking for a tunable.

## What changed
Replaced the misleading comment with:
- An accurate description of current behavior (probe hangs until orchestrator's own probe timeout fires, typically 5–10s)
- A pointer to where a real timeout could be added (`dialectOptions.statement_timeout` in `db.config.js`) if it ever matters in practice

## Test plan
- `npm run lint && npm test` — 688 passing
- Comment-only change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/