### PR TITLE
chore(env): drop dead dialect + define fields from env.js exports

### DIFF
--- a/app/config/env.js
+++ b/app/config/env.js
@@ -15,10 +15,6 @@ const env = {
     password: process.env.DB_PASSWORD || '',
     host: process.env.DB_HOST || 'localhost',
     port: parseInt(process.env.DB_PORT, 10) || 5432,
-    dialect: 'postgres',
-    define: {
-        timestamps: false,
-    },
 };
 
 if (!env.password) {


### PR DESCRIPTION
## Summary
Drop two dead/misleading fields from `app/config/env.js`:

- `dialect: 'postgres'` — neither consumer reads it. `db.config.js` and `sequelize-cli.config.js` both hardcode `'postgres'` inline.
- `define: { timestamps: false }` — both consumers override with `define: { schema: 'dbo', timestamps: true }`. The `false` was both dead AND misleading: a reader scanning env.js could conclude the runtime has timestamps disabled when in fact PR #148 flipped them on everywhere.

## Verification
- `grep -rn "env\.dialect\|env\.define" app/ server.js tests/` returns nothing.
- `npm run lint && npm test` — 688 passing, no regressions

## Test plan
- Local lint + test pass
- Migration runner and runtime both unaffected (they construct their own Sequelize configs)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/