### PR TITLE
test(spdx): extend SPDX-header scan to tests/ to match documented intent

### DIFF
--- a/tests/unit/spdx-headers.test.js
+++ b/tests/unit/spdx-headers.test.js
@@ -19,13 +19,15 @@ import { resolve, join } from 'node:path';
 
 const REPO_ROOT = resolve(__dirname, '../..');
 
-// Files / directories we deliberately don't scan:
-//   - tests/integration/ test files: already covered via the
-//     same pattern but skipped here to keep the per-file count
-//     focused on production code's contract.
+// Both production code AND the test suite carry the header per the
+// project convention documented above. Scan both so a future test file
+// copy-pasted from a header-less template fails CI immediately
+// alongside the production-code path.
+//
+// server.js gets covered via the single-file fallback below.
 const SCAN_ROOTS = [
     'app',
-    // server.js gets covered via the single-file fallback below.
+    'tests',
 ];
 
 function walk(absDir, acc = []) {


### PR DESCRIPTION
## Summary
The header comment on `tests/unit/spdx-headers.test.js` claims "every JS file in app/, server.js, and tests/ carries the Apache-2.0 SPDX header" — but `SCAN_ROOTS` only included `'app'`. `tests/` was named in the comment but never actually walked. The regression net had a real gap: a future test file copy-pasted from a header-less template would slip past CI.

## What changed
- Added `'tests'` to `SCAN_ROOTS`.
- Rewrote the surrounding comment to describe the actual scope (the old comment talked about "tests/integration/ skipped" which was confusing given no tests dir was scanned at all).

## Impact
- All current test files already have the header — no false positives.
- Test count jumps from **688 → 742** (+54 new per-file checks, all passing).
- Going forward, a missing SPDX header in any `tests/**/*.js` file will fail CI alongside the same check for `app/`.

## Test plan
- `npm run lint && npm test` — 742 passing locally (was 688)

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/