### PR TITLE
docs(openapi): pin Customer schema field lengths to match the validators

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -38,16 +38,20 @@ const customerSchema = {
     type: 'object',
     properties: {
         custId: { type: 'integer', readOnly: true },
-        custCompanyName: { type: 'string' },
-        custFName: { type: 'string' },
-        custLName: { type: 'string' },
-        custAddress1: { type: 'string' },
-        custAddress2: { type: 'string' },
-        custCity: { type: 'string' },
-        custState: { type: 'string' },
-        custZip: { type: 'string' },
-        custPhone: { type: 'string' },
-        custEmail: { type: 'string', format: 'email' },
+        custCompanyName: { type: 'string', maxLength: 255 },
+        custFName: { type: 'string', maxLength: 255 },
+        custLName: { type: 'string', maxLength: 255 },
+        custAddress1: { type: 'string', maxLength: 255 },
+        custAddress2: { type: 'string', maxLength: 255 },
+        custCity: { type: 'string', maxLength: 255 },
+        // custState matches the DB column varchar(2) — US state codes
+        // (NE, CA) + Canadian province codes (AB, BC). Pinning the
+        // length here so SDK code-gen (openapi-typescript etc.) carries
+        // the constraint into client types. See #265.
+        custState: { type: 'string', minLength: 2, maxLength: 2 },
+        custZip: { type: 'string', maxLength: 32 },
+        custPhone: { type: 'string', maxLength: 64 },
+        custEmail: { type: 'string', format: 'email', maxLength: 255 },
         custCompId: { type: 'integer' },
         custArch: { type: 'boolean', readOnly: true },
     },


### PR DESCRIPTION
## Summary
The OpenAPI `Customer` component schema declared every string field as a bare `type: 'string'` with no length constraint. The actual zod validators in `customer.schema.js` have concrete max lengths — and as of #265 a fixed `.length(2)` on `custState`.

SDK generators (openapi-typescript et al.) consume the OpenAPI spec, so without these constraints client-side types miss the real bounds and a SDK-driven 400 surprises the caller.

## What changed
- `custState`: now `{ minLength: 2, maxLength: 2 }` to match the #265 zod fix.
- `custZip`, `custPhone`, `custEmail`: explicit `maxLength` matching the zod schema (32 / 64 / 255).
- `custCompanyName`, `FName`, `LName`, `Address1`, `Address2`, `City`: `maxLength: 255` each.

## Test plan
- `npm run lint && npm test` — 760 passing
- Pure spec metadata; no behavior change.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/