### PR TITLE
chore(dependabot): group github-actions + docker bumps like npm does

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,16 @@ updates:
       - ci
     commit-message:
       prefix: "chore(actions)"
+    groups:
+      # Same rationale as the npm group: bundle non-major action
+      # bumps into a single weekly PR so the queue doesn't fragment.
+      # Majors stay separate (e.g. actions/checkout v4 → v5 deserves
+      # a focused review).
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: docker
     directory: "/"
@@ -62,3 +72,13 @@ updates:
       - docker
     commit-message:
       prefix: "chore(docker)"
+    groups:
+      # Base-image patch/minor bumps (node:26-bookworm-slim point
+      # releases, postgres:16-alpine point releases) bundle so we
+      # get one weekly Docker PR. Major-version base-image bumps
+      # remain isolated.
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
The npm ecosystem in `.github/dependabot.yml` already bundles minor+patch dependency bumps into a single weekly PR via a `minor-and-patch` group. The github-actions and docker ecosystems didn't have the same group, so every action / base-image patch landed as its own PR — fragmenting the queue.

## What changed
Added the same `minor-and-patch` group to both:
- `github-actions`: bundles action patch/minor bumps weekly.
- `docker`: bundles base-image patch/minor bumps (node:26-bookworm-slim point releases, postgres:16-alpine point releases).

Majors still land as separate PRs in both ecosystems, because a base-image major (node:26 → 28) or a `actions/checkout` major can carry a breaking change worth focused review.

## Test plan
- `npm run lint && npm test` — 760 passing (config-only change).
- Dependabot itself will validate the YAML when it next runs; the syntax mirrors the working npm block one ecosystem above.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/