### PR TITLE
docs(openapi): pin Company schema field lengths to match the validators

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -96,14 +96,20 @@ const companySchema = {
     type: 'object',
     properties: {
         compId: { type: 'integer', readOnly: true },
-        compName: { type: 'string' },
-        compAddress1: { type: 'string' },
-        compAddress2: { type: 'string' },
-        compCity: { type: 'string' },
-        compState: { type: 'string', maxLength: 2 },
-        compZip: { type: 'string' },
-        compPhone: { type: 'string' },
-        compEmail: { type: 'string', format: 'email' },
+        // Field-length constraints mirror the zod validators in
+        // company.schema.js and the DB column widths in
+        // setup/TimeTracker.sql. Surfacing them here lets SDK
+        // generators (openapi-typescript et al.) carry the bounds
+        // into client-side types. Customer got the same treatment
+        // in #270.
+        compName: { type: 'string', minLength: 1, maxLength: 255 },
+        compAddress1: { type: 'string', maxLength: 255 },
+        compAddress2: { type: 'string', maxLength: 255 },
+        compCity: { type: 'string', maxLength: 255 },
+        compState: { type: 'string', minLength: 2, maxLength: 2 },
+        compZip: { type: 'string', maxLength: 32 },
+        compPhone: { type: 'string', maxLength: 32 },
+        compEmail: { type: 'string', format: 'email', maxLength: 255 },
         compArch: { type: 'boolean', readOnly: true },
     },
 };


### PR DESCRIPTION
## Summary
Mirror of the customer fix in #270.

The OpenAPI `Company` component schema had `compState` with `maxLength: 2` already, but the other fields were unbounded — even though `company.schema.js` validates them with concrete `.min`/`.max` constraints (and the DB columns underneath cap `compPhone` at `varchar(32)`).

## What changed
Aligned every string field with the runtime contract:
- `compName`: `minLength: 1, maxLength: 255` (per zod `min(1).max(255)`)
- `compAddress1/2`, `compCity`, `compEmail`: `maxLength: 255`
- `compState`: `minLength: 2, maxLength: 2`
- `compZip`, `compPhone`: `maxLength: 32`

SDK generators (openapi-typescript et al.) now carry the bounds into client types.

## Test plan
- `npm run lint && npm test` — 760 passing
- Pure spec metadata; no behavior change.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/