### PR TITLE
docs(caddy): drop the misleading skip /openapi.json comment

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -35,8 +35,11 @@
         header_up Host {host}
     }
 
-    # Compress responses. Skip for /openapi.json since it's already
-    # small and aggressive compression on JSON adds a few ms.
+    # Compress responses. Applies to everything Caddy serves — the
+    # JSON payloads in this API are mostly small list bodies where
+    # gzip's wins still beat the negligible CPU cost, and /openapi.json
+    # is rare enough not to matter. (An earlier comment here implied
+    # we skipped /openapi.json; the config never actually did that.)
     encode gzip
 
     # Structured access logs to stdout in JSON. Matches the app's


### PR DESCRIPTION
## Summary
Comment-only fix in `caddy/Caddyfile`.

The `encode` block claimed "Skip for /openapi.json since it's already small and aggressive compression on JSON adds a few ms" — but the actual directive is a bare `encode gzip` with no path matcher, so `/openapi.json` gets gzipped along with everything else. The phantom skip has been there since the original TLS-reverse-proxy PR.

## What changed
Replaced the misleading reasoning with an accurate note: we compress everything, the JSON payload sizes make that a clear win, and `/openapi.json` CPU cost is negligible at the rate it's hit. Mentioned the historical inaccuracy so a future reader doesn't re-derive the same false conclusion from a stale comment.

## Test plan
- `npm run lint && npm test` — 760 passing
- Caddy config only; no app behavior change.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/