### PR TITLE
chore(spdx): add Apache-2.0 SPDX header to three missing CI / compose files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
 name: tests
 
 on:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,3 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
+#
+# Woodpecker CI configuration for the Codeberg mirror. Mirrors the
+# GitHub Actions workflow in .github/workflows/test.yml so both
+# forges run the same lint + test + audit gates on every PR.
+
 when:
   - event: [push, pull_request]
     branch: [master, main]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Aaron K. Clark
+#
 # Local-only override for integration testing. Exposes Postgres on
 # 127.0.0.1:5432 so the host-side vitest integration suite can reach
 # it. NOT for production / shared environments — leaving 5432 open


### PR DESCRIPTION
## Summary
Every other YAML / config file in the repo carries the `SPDX-License-Identifier: Apache-2.0` + copyright header on the first two lines (matching the policy `tests/unit/spdx-headers.test.js` enforces for `.js` files). Three files were missed:

- `.github/workflows/test.yml`
- `.woodpecker.yml`
- `docker-compose.override.yml`

## What changed
Added the standard 2-line header to each. `.woodpecker.yml` also picks up a one-line description (it was previously bare `when:` with no comment block at all) noting that it mirrors the GitHub Actions workflow.

## Test plan
- `npm run lint && npm test` — 760 passing
- No behavior change.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/