### PR TITLE
docs(openapi): pin Worker schema field lengths to match the validators

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -61,9 +61,14 @@ const workerSchema = {
     type: 'object',
     properties: {
         workerId: { type: 'integer', readOnly: true },
-        workerFName: { type: 'string' },
-        workerLName: { type: 'string' },
-        workerTitle: { type: 'string' },
+        // Lengths mirror worker.schema.js's zod validators
+        // (min(1).max(255) on the three name fields). Pinning them
+        // here lets openapi-typescript et al. carry the bounds into
+        // client-side types. Same pattern as Customer (#270) and
+        // Company (#272).
+        workerFName: { type: 'string', minLength: 1, maxLength: 255 },
+        workerLName: { type: 'string', minLength: 1, maxLength: 255 },
+        workerTitle: { type: 'string', minLength: 1, maxLength: 255 },
         workerDefaultBillType: { type: 'integer' },
         workerCompId: { type: 'integer' },
         workerArch: { type: 'boolean', readOnly: true },


### PR DESCRIPTION
## Summary
Same pattern as #270 (Customer) and #272 (Company).

`worker.schema.js` validates `workerFName`, `workerLName`, and `workerTitle` each as `z.string().min(1).max(255)`. The OpenAPI `Worker` component had them as bare `type: 'string'` with no bounds — SDK generators (openapi-typescript et al.) couldn't surface the constraint, so clients generated from the spec missed both the minimum-1 floor and the 255 ceiling.

## What changed
Set `minLength: 1, maxLength: 255` on each name field. No behavior change.

## Test plan
- `npm run lint && npm test` — 760 passing

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/