### PR TITLE
fix(schema): default invPaid to false so bulk-create doesn't trip NOT NULL

### DIFF
--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -35,7 +35,16 @@ const createInvoiceBody = z.object({
     invCustId: z.coerce.number().int().positive(),
     invDate: isoDate,
     invDueDate: isoDate,
-    invPaid: z.boolean().optional(),
+    // invPaid is `boolean NOT NULL` in the DB (no DB-level default).
+    // The single-create controller already short-circuits a missing
+    // value to `false`, but the bulk-create path (`makeBulkCreateIndirect`)
+    // doesn't know to do that, so a bulk POST without invPaid landed
+    // as "null value in column invPaid violates not-null constraint"
+    // at the postgres layer — surfacing as a 500 instead of a clean
+    // accepted row. Switching from `.optional()` to `.default(false)`
+    // fills the value at the validator boundary, which both paths
+    // consume via `validate.body()` (see app/middleware/validate.js).
+    invPaid: z.boolean().default(false),
 }).strict({
     message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, invPaid.',
 }).refine(refineDueDateAfterIssue, DUE_BEFORE_ISSUE);


### PR DESCRIPTION
## Summary
Same drift class as #265 (custState) and #277 (custCompanyName et al.), but with a twist: the **single**-create invoice controller already short-circuited a missing `invPaid` to `false` inline, so the bug only manifested in the **bulk** path (`makeBulkCreateIndirect`), which doesn't apply entity-specific defaults.

A bulk POST like
```json
{ "invoices": [{ "invCustId": 5, "invDate": "2026-01-01", "invDueDate": "2026-02-01" }] }
```
passed the zod schema (`invPaid` was `.optional()`) and then tripped `"null value in column invPaid violates not-null constraint"` at the postgres INSERT — surfacing as a 500 instead of a clean accepted row.

## What changed
Switched the schema to `z.boolean().default(false)`. The validator now fills the value at the request boundary, so both paths (single + bulk) get `invPaid: false` for free. The single-create controller's explicit default-to-false line is now dead defense but stays harmless.

## Test plan
- `npm run lint && npm test` — 760 passing.
- No new tests added; the existing bulk-create coverage and the invoice-controller tests both exercise the now-defaulted shape.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/