### PR TITLE
chore(redact-url): add OAuth2 token names to the sensitive-param set

### DIFF
--- a/app/middleware/redact-url.js
+++ b/app/middleware/redact-url.js
@@ -23,6 +23,15 @@ const SENSITIVE_PARAM_NAMES = new Set([
     'api_key',
     'token',
     'access_token',
+    // OAuth2 token-exchange flow puts these on the query string in
+    // some misuses; defense-in-depth for operators fronting this
+    // API with an OAuth proxy whose redirect / error paths might
+    // bounce through a /v1/* URL. We don't issue OAuth tokens
+    // ourselves, but if a leaked log line contains one we shouldn't
+    // be the source.
+    'refresh_token',
+    'id_token',
+    'client_secret',
     'password',
     'secret',
 ]);


### PR DESCRIPTION
## Summary
The redact-url middleware (used by the pino-http request serializer) strips known-sensitive query-parameter values before the URL hits the structured log. The existing set covered `authkey`, `apikey`, `api_key`, `token`, `access_token`, `password`, and `secret`.

This API doesn't issue OAuth2 tokens itself, but operators sometimes front the service with an OAuth proxy whose redirect / error paths bounce a `?refresh_token=…` or `?id_token=…` through one of our URLs. Adding these and `client_secret` as **defense in depth** means a log line captured during that flow doesn't become the leak vector — even though we're not the original token issuer.

## Test plan
- `npm run lint && npm test` — 760 passing.
- The existing test in `tests/unit/redact-url.test.js` iterates over `SENSITIVE_PARAM_NAMES` and asserts each one redacts, so coverage extends automatically.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/