### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/purchaseordervendor 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1125,7 +1125,14 @@ const spec = {
                 security: [{ authKey: [] }],
                 parameters: [idempotencyKeyHeader],
                 requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/PurchaseOrderVendor' } } } },
-                responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Auth failure' } },
+                responses: {
+                    201: {
+                        description: 'Created',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Auth failure' },
+                },
             },
         },
         '/v1/purchaseordervendor/{id}': {


### PR DESCRIPTION
Part of #245 — single-create POST OpenAPI Idempotency-Replay sweep.

## Summary
- Adds `Idempotency-Replay` response-header declaration to the 201 response on `POST /v1/purchaseordervendor`
- Same pattern as the prior 12 entities

## Test plan
- `npm run lint && npm test` — 760 passing
- Pure spec metadata; no behavior change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/