### PR TITLE
feat(docs): enable Swagger UI path filter + request-duration display

### DIFF
--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -87,7 +87,19 @@ router.get('/v1/whoami', whoami.whoami);
 router.get('/openapi.json', (req, res) => res.json(openapiSpec));
 router.use('/docs', swaggerUi.serve, swaggerUi.setup(openapiSpec, {
     customSiteTitle: 'TimeTrackerAPI · Swagger',
-    swaggerOptions: { persistAuthorization: true },
+    swaggerOptions: {
+        // Keep the authKey across page reloads so a "Try it out" flow
+        // doesn't lose the header on every refresh.
+        persistAuthorization: true,
+        // Path filter box — the API has ~50 path entries across 16
+        // entities, so a free-text filter ("invoice", "bulk", …) is
+        // a meaningful navigation aid for operators using /docs in
+        // a browser.
+        filter: true,
+        // Surface "Try it out" round-trip duration so latency-sensitive
+        // changes get a quick eyeball check without opening devtools.
+        displayRequestDuration: true,
+    },
 }));
 
 // v1 customer routes.


### PR DESCRIPTION
## Summary
Two small swagger-ui-express options that pull their weight on a ~50-path, 16-entity spec.

- **`filter: true`** — adds a free-text path filter at the top of the UI. Searching "invoice" / "bulk" / "company" jumps straight to the relevant block without scrolling. Real navigation aid for operators browsing the docs.
- **`displayRequestDuration: true`** — shows the round-trip duration on every "Try it out" response. Cheap latency eyeball check during exploration; matches the data shape already exposed at `/metrics`.

Both are swagger-ui-side; no server change, no test impact. The existing `persistAuthorization: true` (keep authKey across reloads) stays.

## Test plan
- `npm run lint && npm test` — 760 passing.
- The `tests/api/openapi.test.js` Swagger UI mount assertion (`expect(res.text).toContain('Swagger')`) still passes.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/