### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/purchaseorderheader 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1153,7 +1153,20 @@ const spec = {
             },
         },
         '/v1/purchaseorderheader': {
-            post: { summary: 'Create a PO header', security: [{ authKey: [] }], parameters: [idempotencyKeyHeader], requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/PurchaseOrderHeader' } } } }, responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Auth failure' } } },
+            post: {
+                summary: 'Create a PO header',
+                security: [{ authKey: [] }],
+                parameters: [idempotencyKeyHeader],
+                requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/PurchaseOrderHeader' } } } },
+                responses: {
+                    201: {
+                        description: 'Created',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Auth failure' },
+                },
+            },
         },
         '/v1/purchaseorderheader/{id}': {
             get: { summary: 'Get one PO header', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Found' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },


### PR DESCRIPTION
Part of #245 — single-create POST OpenAPI Idempotency-Replay sweep.

## Summary
- Adds `Idempotency-Replay` response-header declaration to the 201 response on `POST /v1/purchaseorderheader`
- Same pattern as the prior 13 entities
- Also tidies the previously single-line POST entry into the same multi-line shape as its siblings so future field-level edits diff cleanly

## Test plan
- `npm run lint && npm test` — 760 passing
- Pure spec metadata; no behavior change

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/