### PR TITLE
chore(rate-limit): use req.socket instead of deprecated req.connection

### DIFF
--- a/app/middleware/rate-limit-key.js
+++ b/app/middleware/rate-limit-key.js
@@ -43,7 +43,11 @@ function keyByAuthKeyOrIp(req /*, res */) {
     // /56 network prefix (the helper's default). Fall back to
     // 'unknown' when no source IP is available (e.g. unit-test
     // fixtures or non-IP transports).
-    const ip = req.ip || (req.connection && req.connection.remoteAddress);
+    //
+    // `req.socket.remoteAddress` is the modern accessor — Node has
+    // marked `req.connection` deprecated (legacy alias for socket)
+    // since 13.x. Same value, future-proof name.
+    const ip = req.ip || (req.socket && req.socket.remoteAddress);
     if (!ip) return 'ip:unknown';
     return 'ip:' + ipKeyGenerator(ip);
 }


### PR DESCRIPTION
## Summary
The fallback IP lookup in `keyByAuthKeyOrIp` reached for `req.connection.remoteAddress` when `req.ip` was unset. Node has marked `request.connection` deprecated since 13.x as a legacy alias for `request.socket` — same value, different name. Switch to `req.socket.remoteAddress` so the keygen doesn't carry a warning-class accessor.

## Impact
- Behavior identical (`request.connection` is literally `request.socket` per the Node deprecation note).
- The existing unit tests inject `{ ip }` directly and don't traverse the fallback branch, so they pass unmodified.

## Test plan
- `npm run lint && npm test` — 760 passing.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/