### PR TITLE
docs(openapi): declare Idempotency-Replay on POST /v1/inventorytransaction 201

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1219,7 +1219,20 @@ const spec = {
             },
         },
         '/v1/inventorytransaction': {
-            post: { summary: 'Create an inventory transaction', security: [{ authKey: [] }], parameters: [idempotencyKeyHeader], requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/InventoryTransaction' } } } }, responses: { 201: { description: 'Created' }, 400: { description: 'Bad request' }, 403: { description: 'Auth failure' } } },
+            post: {
+                summary: 'Create an inventory transaction',
+                security: [{ authKey: [] }],
+                parameters: [idempotencyKeyHeader],
+                requestBody: { required: true, content: { 'application/json': { schema: { $ref: '#/components/schemas/InventoryTransaction' } } } },
+                responses: {
+                    201: {
+                        description: 'Created',
+                        headers: idempotencyReplayResponseHeader,
+                    },
+                    400: { description: 'Bad request' },
+                    403: { description: 'Auth failure' },
+                },
+            },
         },
         '/v1/inventorytransaction/{id}': {
             get: { summary: 'Get one inventory transaction', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Found' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },


### PR DESCRIPTION
Final entity in the #245 single-create POST OpenAPI Idempotency-Replay sweep.

## Summary
With this PR, **every** `/v1/*` POST that flows through the Idempotency-Key middleware declares the `Idempotency-Replay` response header on its 201. SDK generators (openapi-typescript et al.) can now surface the replay flag in client-facing types across the whole API surface.

## What changed
- Adds `Idempotency-Replay` response-header declaration to the 201 response on `POST /v1/inventorytransaction`.
- Also tidies the previously single-line POST entry to match the multi-line shape used by all other paths so future field-level edits diff cleanly.

## Test plan
- `npm run lint && npm test` — 760 passing.
- Pure spec metadata; no behavior change.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/