### PR TITLE
docs(changelog): note completion of the OpenAPI Idempotency-Replay sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **OpenAPI: `Idempotency-Replay` response-header declaration on every
+  single-create POST 201** (#245 sweep — landed across 16 PRs from
+  #246 through #288). Every `/v1/*` POST that flows through the
+  `Idempotency-Key` middleware now advertises the `Idempotency-Replay`
+  header on its 201 response in the spec — SDK generators
+  (openapi-typescript, etc.) carry the replay flag into client-facing
+  types instead of having callers infer it from prose in the request
+  header's description. The bulk endpoints picked this up in #168;
+  this sweep extends it to single-create symmetry.
 - **Real-PG integration coverage for the cascade auth helpers**
   (#121, follow-up to #117). Six new test cases against
   `postgres:16-alpine` for the four `getCompanyIdBy*` helpers in


### PR DESCRIPTION
## Summary
The 16-PR sweep tracked by #245 just landed (PRs #246–#288). Every `/v1/*` single-create POST 201 in the spec now declares the `Idempotency-Replay` response header — SDK generators (openapi-typescript et al.) carry the replay flag into client-facing types across the whole API surface, not just the bulk paths (#168 picked that up earlier).

Single `[Unreleased]` entry under **Added** so the release notes capture the work without flooding the section with one bullet per PR.

## Test plan
- `npm run lint && npm test` — 760 passing (docs-only).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/