### PR TITLE
test(rate-limit): cover the req.socket.remoteAddress fallback branch

### DIFF
--- a/tests/unit/rate-limit-key.test.js
+++ b/tests/unit/rate-limit-key.test.js
@@ -78,4 +78,17 @@ describe('keyByAuthKeyOrIp', () => {
         const b = keyByAuthKeyOrIp(fakeReq({ ip: '2001:db8:1234:5700::1' }));
         expect(a).not.toBe(b);
     });
+
+    test('falls back to req.socket.remoteAddress when req.ip is missing', () => {
+        // #287 swapped the deprecated req.connection for req.socket.
+        // Exercise the fallback explicitly: no authKey, no req.ip, but
+        // req.socket.remoteAddress is set — the keygen should pick it
+        // up and route it through the IPv6/IPv4-aware helper.
+        const req = {
+            get: () => undefined,
+            socket: { remoteAddress: '10.20.30.40' },
+        };
+        const k = keyByAuthKeyOrIp(req);
+        expect(k).toBe('ip:10.20.30.40');
+    });
 });


### PR DESCRIPTION
## Summary
#287 swapped the deprecated `req.connection` for `req.socket` in the rate-limit key generator's fallback path. The existing unit tests inject a plain `{ ip }` object and never traverse the fallback, so the new accessor was technically untested.

This PR adds an explicit case that forces the fallback by passing `{ socket: { remoteAddress: ... } }` without `req.ip` — the keygen should pick the socket address up and route it through the IPv6-aware helper.

## Test plan
- `npm run lint && npm test` — **761 passing** (was 760).
- No production-code change; the regression-pin is the only addition.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/