### PR TITLE
feat(customer): add singular customer key on GET /v1/customer/:id

### DIFF
--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -560,8 +560,16 @@ async function findAndRespond(customerId, res) {
             // customers — soft-deletes correctly surface as 404 too.
             return res.status(404).json({ message: "Not found." });
         }
+        // The historical key is `customers` (plural) wrapping a single
+        // customer — a wart from before the codebase standardized on
+        // singular-for-single-row across the other 15 entities. Add
+        // the consistent `customer` key alongside it so SDK clients
+        // can read the same shape they get from /v1/worker/:id et al.
+        // The `customers` key stays for backward compat; remove in a
+        // future major version.
         return res.status(200).json({
             message: "Successfully retrieved the customer with CustomerId " + customerId,
+            customer,
             customers: customer,
         });
     } catch (error) {


### PR DESCRIPTION
## Summary
The 200 response for `GET /v1/customer/:id` historically wrapped the single customer object under a plural `customers` key — a wart from before the codebase standardized on singular-for-single-row across the other 15 entities (`worker`, `billingtype`, `job`, ...). SDK clients generating typed accessors had to special-case Customer against every other entity.

Surface the singular `customer` key in the same response, alongside the existing `customers` key. Existing clients reading `customers` keep working unchanged; new code can use `customer` and match the rest of the API.

## Backward compatibility
- `customers` stays in the response for now — a future major version can drop it.
- Both keys reference the same object, so the wire-size delta is negligible (one extra JSON pointer).

## Test plan
- `npm run lint && npm test` — 761 passing.
- Existing customer tests don't assert the response shape body fields, so no test updates needed; the change is additive.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/