### PR TITLE
docs(openapi): pin Job schema jobDesc length to match the validator

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -132,7 +132,11 @@ const jobSchema = {
     properties: {
         jobId: { type: 'integer', readOnly: true },
         jobCustId: { type: 'integer' },
-        jobDesc: { type: 'string' },
+        // jobDesc mirrors job.schema.js: z.string().min(1).max(10000).
+        // 10000 chars is the same generous limit used for other
+        // free-text fields (teDescription, polItemDesc) — big enough
+        // for a paragraph or two without enabling unbounded payloads.
+        jobDesc: { type: 'string', minLength: 1, maxLength: 10000 },
         jobInvoiced: { type: 'boolean' },
         jobArch: { type: 'boolean', readOnly: true },
     },


### PR DESCRIPTION
## Summary
Extends the field-length pinning sweep (Customer #270, Company #272, Worker #276, BillingType+InventoryItem #290) to the Job component.

`jobDesc` is validated by zod as `z.string().min(1).max(10000)`. Pinning the same bounds in the OpenAPI spec lets SDK generators (openapi-typescript et al.) carry the constraint into client types.

Invoice's component is exclusively boolean/integer/date fields with no free-text columns, so no constraint additions are needed there.

## Test plan
- `npm run lint && npm test` — 761 passing.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/