### PR TITLE
chore(versioninfo): natural-case the create-success message

### DIFF
--- a/app/controllers/versioninfocontroller.js
+++ b/app/controllers/versioninfocontroller.js
@@ -75,7 +75,7 @@ exports.create = async (req, res) => {
     }
     try {
         const created = await VersionInfo.create(payload);
-        return res.status(201).json({ message: "VersionInfo created.", versionInfo: created });
+        return res.status(201).json({ message: "Version info created.", versionInfo: created });
     } catch (error) {
         log.error({ err: error }, 'VersionInfo.create failed');
         return res.status(500).json({ message: "Error!" });


### PR DESCRIPTION
## Summary
`versioninfocontroller.create` returned `message: "VersionInfo created."` — the CamelCase model name. Every other entity's create handler uses natural English (`"Customer created."`, `"Time entry created."`, `"PO vendor created."`, etc.). VersionInfo was the only outlier.

Switch to `"Version info created."` to match the rest of the API surface.

## Test plan
- `grep -rn "VersionInfo created"` in `tests/` returned no hits — no test asserts on the literal old string.
- `npm run lint && npm test` — 761 passing.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/