### PR TITLE
docs(openapi): pin CustomerPayment cpayDescription length to match the validator

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -159,8 +159,15 @@ const customerPaymentSchema = {
     properties: {
         cpayId: { type: 'integer', readOnly: true },
         cpayCustId: { type: 'integer' },
-        cpayDescription: { type: 'string' },
+        // customerpayment.schema.js: cpayDescription is optional and
+        // capped at 10000 chars (the same ceiling used for other free-
+        // text fields). Pinning maxLength here matches the validator.
+        cpayDescription: { type: 'string', maxLength: 10000 },
         cpayDate: { type: 'string', format: 'date' },
+        // cpayAmount must be finite + non-zero (a $0 ledger entry is
+        // operator error). The non-zero rule isn't expressible in
+        // OpenAPI's standard vocabulary, but operators can read the
+        // zod source for the full contract.
         cpayAmount: { type: 'number' },
         cpayArch: { type: 'boolean', readOnly: true },
     },


### PR DESCRIPTION
## Summary
Extends the field-length pinning sweep (Customer #270, Company #272, Worker #276, BillingType+InventoryItem #290, Job #294).

`cpayDescription` is validated by zod as `z.string().max(10000)`. Pinning the same `maxLength` in the OpenAPI spec lets SDK generators surface the constraint to client types.

## Notes
- `cpayAmount` has zod refinements (finite + non-zero) that don't have direct OpenAPI primitives; documented inline so future readers know to consult the validator for the full contract.
- PurchaseOrderVendor / Header / Line still have unpinned components — separate follow-up PRs to keep this one tight.

## Test plan
- `npm run lint && npm test` — 761 passing.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/