### PR TITLE
docs(openapi): pin TimeEntry.teDescription maxLength (#300)

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -277,7 +277,7 @@ const timeEntrySchema = {
         teId: { type: 'integer', readOnly: true },
         teCustId: { type: 'integer' },
         teCompId: { type: 'integer', readOnly: true },
-        teDescription: { type: 'string' },
+        teDescription: { type: 'string', maxLength: 10000 },
         teStartedAt: { type: 'string', format: 'date-time' },
         teEndedAt: { type: 'string', format: 'date-time', nullable: true },
         teMinutes: { type: 'integer', nullable: true, readOnly: true },

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -70,6 +70,19 @@ describe('OpenAPI spec', () => {
         expect(schemas.TimeEntry.properties.teStartedAt).toBeDefined();
     });
 
+    test('TimeEntry.teDescription pins the 10000-char bound from the validator', async () => {
+        // The zod schema (app/schemas/timeentry.schema.js) caps
+        // teDescription at 10000 chars. The OpenAPI component schema
+        // previously left the field unbounded, so SDK code-gen would
+        // expose a `string` with no maxLength — clients couldn't tell
+        // there was a server-side limit until they got a 400 back. Pin
+        // the bound here so a regression on either side fails CI.
+        const res = await request(app).get('/openapi.json');
+        const te = res.body.components.schemas.TimeEntry;
+        expect(te.properties.teDescription.type).toBe('string');
+        expect(te.properties.teDescription.maxLength).toBe(10000);
+    });
+
     test('spec documents all 13 bulk-create endpoints', async () => {
         const res = await request(app).get('/openapi.json');
         const paths = Object.keys(res.body.paths);


### PR DESCRIPTION
Closes #300.

## Summary
Zod caps `teDescription` at 10000 chars; the OpenAPI component schema left it unbounded. SDK code-gen had no way to surface the limit. This adds `maxLength: 10000` to the spec and pins it with a test.

## Test plan
- `npm run lint && npm test` — 768 passing (was 767), 1 new test in `tests/api/openapi.test.js`.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/