### PR TITLE
docs(openapi): pin PurchaseOrderHeader + Line field-length bounds (#304)

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -221,8 +221,12 @@ const purchaseOrderHeaderSchema = {
     properties: {
         pohId: { type: 'integer', readOnly: true },
         pohDate: { type: 'string', format: 'date-time' },
-        pohReference: { type: 'string' },
-        pohTerms: { type: 'string' },
+        // Lengths mirror purchaseorderheader.schema.js: pohReference is
+        // 1-255 chars, pohTerms is 1-1000 chars (the longer cap suits
+        // free-text "net 30, late fees per §2.3, …" payment-terms
+        // strings).
+        pohReference: { type: 'string', minLength: 1, maxLength: 255 },
+        pohTerms: { type: 'string', minLength: 1, maxLength: 1000 },
         pohPovId: { type: 'integer' },
         pohArch: { type: 'boolean', readOnly: true },
     },
@@ -233,7 +237,10 @@ const purchaseOrderLineSchema = {
     properties: {
         polId: { type: 'integer', readOnly: true },
         polpoh: { type: 'integer' },
-        polItemDesc: { type: 'string' },
+        // Mirrors purchaseorderline.schema.js: 1-1000 chars. Same
+        // free-text rationale as pohTerms above — line items often
+        // carry SKU + brief description on one line.
+        polItemDesc: { type: 'string', minLength: 1, maxLength: 1000 },
         polQty: { type: 'number' },
         polPrice: { type: 'number' },
         polInvtId: { type: 'integer' },

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -70,6 +70,26 @@ describe('OpenAPI spec', () => {
         expect(schemas.TimeEntry.properties.teStartedAt).toBeDefined();
     });
 
+    test('PurchaseOrderHeader pins the validator field-length bounds', async () => {
+        // Mirrors purchaseorderheader.schema.js. Without these, SDK
+        // generators expose pohReference/pohTerms as unbounded strings
+        // and miss the server-side caps.
+        const res = await request(app).get('/openapi.json');
+        const poh = res.body.components.schemas.PurchaseOrderHeader;
+        expect(poh.properties.pohReference.minLength).toBe(1);
+        expect(poh.properties.pohReference.maxLength).toBe(255);
+        expect(poh.properties.pohTerms.minLength).toBe(1);
+        expect(poh.properties.pohTerms.maxLength).toBe(1000);
+    });
+
+    test('PurchaseOrderLine.polItemDesc pins the validator field-length bound', async () => {
+        // Mirrors purchaseorderline.schema.js — 1..1000 chars.
+        const res = await request(app).get('/openapi.json');
+        const pol = res.body.components.schemas.PurchaseOrderLine;
+        expect(pol.properties.polItemDesc.minLength).toBe(1);
+        expect(pol.properties.polItemDesc.maxLength).toBe(1000);
+    });
+
     test('TimeEntry.teDescription pins the 10000-char bound from the validator', async () => {
         // The zod schema (app/schemas/timeentry.schema.js) caps
         // teDescription at 10000 chars. The OpenAPI component schema


### PR DESCRIPTION
Closes #304.

## Summary
Mirrors the zod field-length caps into the OpenAPI component schemas for `PurchaseOrderHeader` and `PurchaseOrderLine`:

- `pohReference`: 1..255
- `pohTerms`: 1..1000
- `polItemDesc`: 1..1000

## Test plan
- `npm run lint && npm test` — 772 passing (was 770), 2 new test cases in `tests/api/openapi.test.js`.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/