### PR TITLE
chore(timeentry): drop stale customer-not-migrated CSV comment (#306)

### DIFF
--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -439,9 +439,10 @@ exports.exportCsv = async (req, res) => {
         'teBillable', 'teDescription',
     ];
     // CSV-formula-injection mitigation lives in the shared helper —
-    // see app/controllers/_csv-escape.js. Pinning it there means
-    // future export endpoints get the same guardrail by default
-    // (customer/export.csv hasn't been migrated yet — separate PR).
+    // see app/controllers/_csv-escape.js. Both export endpoints
+    // (timeentry + customer) call into it, so the OWASP mitigation
+    // stays in lockstep across the API; future export endpoints
+    // get the same guardrail by default.
     const escape = escapeCsvCell;
     const lines = [];
     lines.push(FIELDS.join(','));


### PR DESCRIPTION
Closes #306.

## Summary
Replaces a parenthetical in `timeentrycontroller.js`'s `exportCsv` that claimed `customer/export.csv` hadn't been migrated to the shared `_csv-escape.js` helper yet. It has — `customercontroller.js` imports and uses `escapeCsvCell` in its own `exportCsv`. The comment was actively misleading future readers.

## Test plan
- `npm run lint && npm test` — 772 passing (unchanged; comment-only edit).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/