### PR TITLE
docs(openapi): pin VersionInfo.viVersion length to match the validator (#308)

### DIFF
--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -200,7 +200,11 @@ const versionInfoSchema = {
     type: 'object',
     properties: {
         viId: { type: 'integer', readOnly: true },
-        viVersion: { type: 'string' },
+        // viVersion mirrors versioninfo.schema.js: 1..255 chars. SemVer
+        // is much shorter than 255 in practice, but the cap matches
+        // every other free-text "name/identifier" column in the API
+        // for consistency.
+        viVersion: { type: 'string', minLength: 1, maxLength: 255 },
         viDate: { type: 'string', format: 'date-time' },
     },
 };

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -70,6 +70,17 @@ describe('OpenAPI spec', () => {
         expect(schemas.TimeEntry.properties.teStartedAt).toBeDefined();
     });
 
+    test('VersionInfo.viVersion pins the 1..255 bound from the validator', async () => {
+        // Mirrors versioninfo.schema.js. SDK generators expose viVersion
+        // as `string`; without minLength/maxLength they can't catch a
+        // client sending a 10k-char "version" string before the server
+        // does.
+        const res = await request(app).get('/openapi.json');
+        const vi = res.body.components.schemas.VersionInfo;
+        expect(vi.properties.viVersion.minLength).toBe(1);
+        expect(vi.properties.viVersion.maxLength).toBe(255);
+    });
+
     test('PurchaseOrderHeader pins the validator field-length bounds', async () => {
         // Mirrors purchaseorderheader.schema.js. Without these, SDK
         // generators expose pohReference/pohTerms as unbounded strings


### PR DESCRIPTION
Closes #308.

## Summary
versioninfo.schema.js caps `viVersion` at 1..255 chars. The OpenAPI component schema left it unbounded. Adds `minLength: 1, maxLength: 255` and pins it with a test.

## Test plan
- `npm run lint && npm test` — 773 passing (was 772).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/