### PR TITLE
fix(models): ApiKey.akKEY + ApiMaster.amKEY are TEXT, not STRING (#318)

### DIFF
--- a/app/models/apikey.model.js
+++ b/app/models/apikey.model.js
@@ -11,7 +11,14 @@ module.exports = (sequelize, Sequelize) => {
         },
         akKEY: {
             field: 'akKEY',
-            type: Sequelize.STRING
+            // Migration 20260518000000-hash-api-keys.js changed the DB
+            // column from `uuid` to `text` so it can hold a SHA-256
+            // hex digest (64 chars) without a length cap. The model
+            // had been left at `Sequelize.STRING` (varchar(255)),
+            // which doesn't break runtime — hashes fit comfortably
+            // — but `sequelize.sync()` and any schema-introspection
+            // tooling would disagree with the DB. Use TEXT to match.
+            type: Sequelize.TEXT
         },
         akCompanyId: {
             field: 'akCompanyId',

--- a/app/models/apimaster.model.js
+++ b/app/models/apimaster.model.js
@@ -11,7 +11,12 @@ module.exports = (sequelize, Sequelize) => {
         },
         amKEY: {
             field: 'amKEY',
-            type: Sequelize.STRING
+            // Same DB column-type change as ApiKey.akKEY — see
+            // migration 20260518000000-hash-api-keys.js. The column
+            // is TEXT in PG; the model previously declared STRING
+            // (varchar(255)) which still works at runtime but drifts
+            // from the DB schema. Aligned to TEXT for parity.
+            type: Sequelize.TEXT
         },
         amArchive: {
             field: 'amArchive',


### PR DESCRIPTION
Closes #318.

## Summary
Aligns both auth-key models to the DB column type changed by `20260518000000-hash-api-keys.js`. Runtime-safe; this just keeps `sequelize.sync()` and schema-introspection tooling in agreement with the DB.

## Test plan
- `npm run lint && npm test` — 781 passing (unchanged; runtime-equivalent change).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/