### PR TITLE
fix(cors): expose Retry-After so browser JS can honor 429 back-off (#322)

### DIFF
--- a/server.js
+++ b/server.js
@@ -140,6 +140,15 @@ app.use(cors({
         'RateLimit-Limit',
         'RateLimit-Remaining',
         'RateLimit-Reset',
+        // Retry-After is set on the 429 response by express-rate-limit
+        // (standardHeaders: true). It carries the seconds the client
+        // should wait before retrying — without exposing it across
+        // CORS, browser JS gets `undefined` and clients have to fall
+        // back to a fixed-delay retry instead of honoring the value
+        // the server intended. Retry-After is NOT on the CORS
+        // safelisted-response-headers list, so explicit exposure is
+        // required.
+        'Retry-After',
     ],
 }));
 

--- a/tests/api/cors-expose-headers.test.js
+++ b/tests/api/cors-expose-headers.test.js
@@ -39,6 +39,7 @@ beforeAll(() => {
             'RateLimit-Limit',
             'RateLimit-Remaining',
             'RateLimit-Reset',
+            'Retry-After',
         ],
     }));
     app.get('/ping', (req, res) => {
@@ -64,6 +65,10 @@ describe('CORS Access-Control-Expose-Headers', () => {
             'RateLimit-Limit',
             'RateLimit-Remaining',
             'RateLimit-Reset',
+            // Retry-After lands on the 429 response from express-rate-
+            // limit. Not on the CORS safelist, so browser JS clients
+            // can't read it without explicit exposure here.
+            'Retry-After',
         ]));
     });
 

--- a/tests/api/rate-limit.test.js
+++ b/tests/api/rate-limit.test.js
@@ -61,6 +61,14 @@ describe('rate limiting', () => {
         const r3 = await request(app).get('/v1/customer/1').set('authKey', 'k');
         expect(r3.status).toBe(429);
         expect(r3.body.message).toMatch(/too many requests/i);
+        // 429 must carry `Retry-After` so browser JS clients can
+        // honor the suggested back-off instead of falling back to a
+        // fixed-delay retry. server.js's CORS expose-headers list
+        // includes it (#322) — this asserts the server-side path
+        // actually emits it.
+        expect(r3.headers['retry-after']).toBeDefined();
+        // Value is a positive integer (seconds, RFC 7231 §7.1.3).
+        expect(/^\d+$/.test(r3.headers['retry-after'])).toBe(true);
     });
 
     test('does not apply to /healthz', async () => {


### PR DESCRIPTION
Closes #322.

## Summary
Adds `'Retry-After'` to server.js `exposedHeaders` and mirrors the entry in the CORS expose-headers test. Adds an assertion in the rate-limit test that the 429 response actually carries the header (positive-integer-seconds per RFC 7231 §7.1.3).

Without this, browser JS reading a cross-origin 429 sees `Retry-After` as null and can't honor the server's back-off.

## Test plan
- `npm run lint && npm test` — 782 passing (1 new assertion added to existing 429 test rather than a new test block).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/