### PR TITLE
ci(github): scope workflow GITHUB_TOKEN to contents:read (#330)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,17 @@ on:
   pull_request:
     branches: [master, main]
 
+# Least-privilege GITHUB_TOKEN. Without an explicit permissions
+# block the token gets the repository default — usually read+write
+# on contents/issues/PRs — which means a compromised dependency or
+# action in this workflow could push to master, open issues, or
+# manipulate PRs. The test workflow only needs to clone the repo
+# and report status, so `contents: read` is the entire required
+# scope. Per the GitHub Actions hardening guide:
+# https://docs.github.com/actions/security-guides/automatic-token-authentication
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #330.

## Summary
Adds an explicit `permissions: contents: read` block to `.github/workflows/test.yml` so the auto-provisioned GITHUB_TOKEN can't be coerced into pushing to master / opening issues / manipulating PRs if a dependency or action in the workflow is compromised.

The test workflow only needs to clone the repo and report status — no write surface required.

## Test plan
- `npm run lint && npm test` — 783 passing (CI config change, no app-side impact).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/