### PR TITLE
chore: improve package.json description + keywords (#334)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "TimeTrackerAPI",
   "version": "1.0.0",
-  "description": "Nodejs version of TimeTrackerAPI",
+  "description": "Open-source Node.js + PostgreSQL time-tracking REST API with customer/company-scoped auth, OpenAPI spec, idempotency, and CSV export.",
   "main": "server.js",
   "keywords": [
     "nodejs",
-    "crud",
+    "express",
     "postgresql",
-    "TimeTracker"
+    "sequelize",
+    "rest-api",
+    "time-tracking",
+    "openapi",
+    "swagger"
   ],
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Closes #334.

## Summary
Updates the npm manifest's `description` to mirror the GitHub repo description (runtime, shape, domain, key features) and swaps the four-keyword stale list with a more npm-search-friendly set (express, sequelize, rest-api, time-tracking, openapi, swagger).

## Test plan
- `npm run lint && npm test` — 784 passing (metadata-only change).
- `npm install` re-run; lockfile unchanged (description/keywords don't propagate to package-lock.json).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/