### PR TITLE
chore(eslint): drop dead scripts/** rule block (#344)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,17 +104,4 @@ module.exports = [
         },
     },
 
-    // Standalone helper scripts in /tmp or one-shots — pull from
-    // the same config-less defaults but don't enforce as strictly.
-    {
-        files: ['scripts/**/*.js'],
-        languageOptions: {
-            ecmaVersion: 2023,
-            sourceType: 'commonjs',
-            globals: { ...globals.node },
-        },
-        rules: {
-            ...js.configs.recommended.rules,
-        },
-    },
 ];


### PR DESCRIPTION
Closes #344.

## Summary
Drops 14 lines from `eslint.config.js`. No runtime or test-suite impact.

## Test plan
- `npm run lint && npm test` — 790 passing (config-only change).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/