### PR TITLE
docs(readme): document the secure-404 cross-tenant pattern (#356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ The `/healthz` endpoint is intentionally unauthenticated so it can be
 hit by orchestrators (Docker `HEALTHCHECK`, Kubernetes liveness, uptime
 monitors) without sharing a credential.
 
+### Secure-404 on cross-tenant access
+
+Single-row GET / PATCH / DELETE endpoints return `404 Not Found` —
+not `403 Forbidden` — when a non-master key references a row in a
+different company's scope. The two outcomes look identical from the
+client's side so a scoped caller can't probe sequential IDs to
+enumerate the size of another tenant's table by status code. Master
+keys still see all rows. The same pattern applies across all 16
+single-row entity endpoints; the auth-scope check that produces it
+is the same `getCompanyId(...) !== row.<entity>CompId` comparison
+the controllers use for the 403 paths on other surfaces.
+
 ![example image](https://github.com/CryptoJones/TimeTrackerAPI/blob/master/setup/postman_example.PNG?raw=true)
 
 *(authKey example using Postman)*


### PR DESCRIPTION
Closes #356.

## Summary
Adds a "Secure-404 on cross-tenant access" subsection to the README's HTTP-conventions block. Documents that single-row GET/PATCH/DELETE endpoints collapse "exists but not yours" into 404 — same outcome an enumeration attacker sees for non-existent IDs.

## Test plan
- `npm run lint && npm test` — 794 passing (docs-only).

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/