### PR TITLE
security(HIGH): scope teCustId on POST /v1/timeentry to caller's company

### DIFF
--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -14,6 +14,7 @@ const TimeEntry = db.TimeEntry;
 // preserve the existing call sites in the controller body.
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 const ALLOWED_FIELDS_CREATE = [
     'teCustId', 'teDescription', 'teStartedAt', 'teEndedAt',
@@ -113,6 +114,27 @@ exports.create = async (req, res) => {
     }
     if (!payload.teStartedAt) {
         return res.status(400).json({ message: "teStartedAt is required (ISO 8601)." });
+    }
+    // Cross-tenant FK guard: non-master callers must own the customer
+    // they're attributing the entry to. Every other create handler with
+    // a cross-company FK does this (job, invoice, customerpayment,
+    // productentry, …); timeentry was the outlier — without this check,
+    // a non-master scoped to company 7 could send teCustId=13 where
+    // customer 13 lives in company 99, and the resulting row would
+    // carry teCompId=7 (forced below) + teCustId=13 (kept from body) —
+    // a permanent cross-tenant reference that listByCompany hides
+    // (filters teCompId only) but joins through the FK surface.
+    //
+    // Master keys skip this check by design (admin can write across
+    // tenants); the existing `isMaster` branch above already short-
+    // circuits.
+    if (!isMaster) {
+        const custCompanyId = await GetCompanyIdByCustomerId(payload.teCustId);
+        if (custCompanyId === -1 || custCompanyId !== companyId) {
+            return res.status(403).json({
+                message: "Cannot create a time entry for a customer in a company you do not belong to.",
+            });
+        }
     }
     payload.teCompId = companyId;
     payload.teArch = false;
@@ -485,4 +507,7 @@ exports.exportCsv = async (req, res) => {
 };
 
 // Exposed for unit testing.
-exports._internals = { computeMinutes, isInvertedRange, parseDateOrNull, IsMaster, GetCompanyId };
+exports._internals = {
+    computeMinutes, isInvertedRange, parseDateOrNull,
+    IsMaster, GetCompanyId, GetCompanyIdByCustomerId,
+};

--- a/tests/api/timeentry.test.js
+++ b/tests/api/timeentry.test.js
@@ -392,3 +392,124 @@ describe('TimeEntry tenant-enumeration defense (secure 404)', () => {
         }
     });
 });
+
+
+
+
+describe('POST /v1/timeentry tenant-scoped teCustId (cross-tenant FK)', () => {
+    // Bug regression: previously POST /v1/timeentry accepted any
+    // integer-shaped teCustId for a non-master caller, without
+    // checking that the referenced Customer belongs to the caller's
+    // company.
+    //
+    // Effect: a non-master scoped to company 7 could send
+    // `{ teCustId: 13 }` where customer 13 lives in company 99. The
+    // resulting TimeEntry row carried teCompId=7 (forced by the
+    // controller) and teCustId=13 (kept from the body) — a permanent
+    // cross-tenant reference. Listing TimeEntries by company hid the
+    // anomaly (filtered on teCompId) but any join through the FK or
+    // any operator-side report walking customer relations would
+    // surface customer 13 from company 99 inside company 7's view.
+    //
+    // Every other controller with a cross-company FK already did this
+    // check (job, invoice, customerpayment, productentry, …);
+    // timeentry was the outlier.
+    //
+    // These tests drive the controller through the db.config mock set
+    // at file-top, rather than vi.spyOn on the auth helpers, because
+    // the controller captures `IsMaster = auth.isMaster` at module
+    // load time — spy reassignment of `auth.isMaster` happens AFTER
+    // the closure already captured the original reference, so spying
+    // on auth.* doesn't reach the controller's call site. The db
+    // mock IS reached because auth.getDb() resolves each call.
+
+    function setupDb({ authKeyCompId, customerCompId, customerId, isMasterRow = null }) {
+        const db = require('../../app/config/db.config.js');
+        db.ApiMaster = { findOne: vi.fn().mockResolvedValue(isMasterRow) };
+        db.ApiKey = {
+            findOne: vi.fn().mockResolvedValue(
+                authKeyCompId == null ? null : { akCompanyId: authKeyCompId },
+            ),
+        };
+        db.Customer = db.Customer || {};
+        db.Customer.findByPk = vi.fn().mockImplementation((id) => {
+            if (Number(id) !== customerId) return Promise.resolve(null);
+            if (customerCompId === null) return Promise.resolve(null);
+            return Promise.resolve({ custCompId: customerCompId });
+        });
+        const createSpy = vi.fn().mockResolvedValue({ teId: 1 });
+        db.TimeEntry.create = createSpy;
+        return createSpy;
+    }
+
+    test('returns 403 when teCustId belongs to a different company', async () => {
+        const createSpy = setupDb({
+            authKeyCompId: 7,
+            customerCompId: 99,   // customer 13 lives in company 99
+            customerId: 13,
+        });
+        const res = await request(app)
+            .post('/v1/timeentry')
+            .set('authKey', 'scoped-to-7')
+            .send({
+                teCustId: 13,
+                teStartedAt: '2026-05-16T09:00:00Z',
+            });
+        expect(res.status).toBe(403);
+        expect(res.body.message).toMatch(/cannot create.*time entry|customer.*company you do not belong/i);
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns 403 when teCustId customer does not exist (archived or missing)', async () => {
+        const createSpy = setupDb({
+            authKeyCompId: 7,
+            customerCompId: null,
+            customerId: 9999,
+        });
+        const res = await request(app)
+            .post('/v1/timeentry')
+            .set('authKey', 'scoped-to-7')
+            .send({
+                teCustId: 9999,
+                teStartedAt: '2026-05-16T09:00:00Z',
+            });
+        expect(res.status).toBe(403);
+        expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns 201 when teCustId belongs to the same company (positive control)', async () => {
+        const createSpy = setupDb({
+            authKeyCompId: 7,
+            customerCompId: 7,
+            customerId: 13,
+        });
+        const res = await request(app)
+            .post('/v1/timeentry')
+            .set('authKey', 'scoped-to-7')
+            .send({
+                teCustId: 13,
+                teStartedAt: '2026-05-16T09:00:00Z',
+            });
+        expect(res.status).toBe(201);
+        expect(createSpy).toHaveBeenCalledOnce();
+    });
+
+    test('master keys skip the customer-company check (admin can create cross-tenant)', async () => {
+        const createSpy = setupDb({
+            authKeyCompId: null,                  // master keys don't use ApiKey
+            isMasterRow: { amId: 1 },              // ApiMaster row exists
+            customerCompId: 99,                    // customer in some other company
+            customerId: 13,
+        });
+        const res = await request(app)
+            .post('/v1/timeentry')
+            .set('authKey', 'master-key')
+            .send({
+                teCompId: 7,
+                teCustId: 13,
+                teStartedAt: '2026-05-16T09:00:00Z',
+            });
+        expect(res.status).toBe(201);
+        expect(createSpy).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
`timeentrycontroller.create` accepted any integer-shaped teCustId from a
non-master caller without verifying the referenced Customer belongs to
the caller's company. Effect:

  - Non-master scoped to company 7 sends `{ teCustId: 13 }`
  - Customer 13 lives in company 99
  - The new TimeEntry row gets teCompId=7 (forced server-side) AND
    teCustId=13 (kept from body) — a permanent cross-tenant FK.

The list/get/update/delete handlers all filter by teCompId, so the
anomalous row stays invisible to the OTHER tenant on the API surface.
But:

  - Any operator-side report or UI that joins TimeEntry -> Customer
    (via the FK) surfaces company 99's customer inside company 7's view.
  - It's a permanent integrity corruption that the API itself created.

Every other create handler with a cross-company FK (jobcontroller,
invoicecontroller, customerpaymentcontroller, productentrycontroller)
already does this check via `GetCompanyIdByCustomerId` / `GetCompanyIdByJobId`
/ `GetCompanyIdByPovId`. timeentry was the only outlier.

Fix follows the existing pattern: after teCustId integer validation
and before payload.teCompId assignment, non-master callers run
`GetCompanyIdByCustomerId(payload.teCustId)` and 403 if the
resolved company differs (or is -1, i.e. customer missing/archived).
Master keys still skip this check by design.

Tests added (4, all in tests/api/timeentry.test.js — a new
"tenant-scoped teCustId (cross-tenant FK)" describe):

  - cross-tenant create returns 403, TimeEntry.create NOT called
  - missing/archived customer returns 403, TimeEntry.create NOT called
  - same-company create returns 201 (positive control)
  - master keys bypass the check (create succeeds even cross-tenant)

The new tests drive the controller through the file-top db.config
vi.mock (mutating ApiKey/ApiMaster/Customer per scenario) rather than
vi.spyOn on the auth helpers — the existing spy-based tenant-defense
tests for invoice/etc. only pass because the empty `ApiKey: {}`
mock makes auth.getCompanyId() return -1, which short-circuits at
"Invalid Authorization Key." before the spy is ever consulted. The
db-mock approach actually exercises the cross-tenant comparison.

800 tests pass (was 796); lint clean.
---
**Self-review caveats** (be aware before merging):

- **The existing 'tenant-enumeration defense' tests for invoice/etc. pass for the wrong reason** — the empty `ApiKey: {}` mock in those test files makes `auth.getCompanyId()` short-circuit to -1 (DB throw → catch → -1), so the controller returns 'Invalid Authorization Key.' before the cross-tenant comparison is ever reached. The `vi.spyOn(auth, 'isMaster')` etc. in those tests doesn't take effect on the controller's call sites because the controller captures `const IsMaster = auth.isMaster` at module load (a value-not-reference capture, by Node module semantics). The new tests here mock the db layer directly (which the controller DOES reach via auth.getDb()), so they actually exercise the cross-tenant comparison. The other tenant-defense tests are still useful as routing/auth-fail smoke tests; they're just not what they look like.

- **The fix doesn't add a unique constraint at the DB level** to prevent the same class of bug from a direct INSERT (e.g. a future migration script that runs raw SQL). Defense-in-depth would be a CHECK constraint or trigger: `(teCompId, teCustId)` must satisfy `teCustId IN (SELECT custId FROM Customer WHERE custCompId = teCompId)`. Out of scope for this PR.

- **Did NOT audit if existing data has cross-tenant teCustId rows** from the time before this fix. Would need a one-shot SQL query: `SELECT te.* FROM TimeEntry te JOIN Customer c ON te.teCustId = c.custId WHERE te.teCompId != c.custCompId`. Recommended as a follow-up.