### PR TITLE
feat(timeentry): link time entries to a worker and a job (#385, #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Time entries can be linked to a Worker and a Job** (#385, #386).
+  `TimeEntry` gains nullable `teWorkerId` / `teJobId` columns (migration
+  `20260521000000`) so tracked time is attributable to the person who
+  logged it and the project it was worked against — the schema
+  foundation for rate resolution and the time→invoice roll-up. `POST`
+  and `PATCH /v1/timeentry` accept both fields (`PATCH` with `null`
+  unlinks), validated so the worker belongs to the caller's company and
+  the job belongs to the same company *and* the same customer as the
+  entry. Existing rows and quick ad-hoc time may leave either unset. Per
+  the increment-layer migration convention the columns carry no physical
+  FK constraint (enforced at the app layer); `setup/*.sql`, the frozen
+  original schema, is left untouched.
 - **OpenAPI: `Idempotency-Replay` response-header declaration on every
   single-create POST 201** (#245 sweep — landed across 16 PRs from
   #246 through #288). Every `/v1/*` POST that flows through the

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -117,6 +117,16 @@ db.CustomerPayment.belongsTo(db.Customer, { foreignKey: 'cpayCustId', as: 'custo
 db.BillingType.hasMany(db.Worker,    { foreignKey: 'workerDefaultBillType', as: 'workersWithDefault' });
 db.Worker.belongsTo(db.BillingType,  { foreignKey: 'workerDefaultBillType', as: 'defaultBillingType' });
 
+// TimeEntry → Worker (who logged it) and → Job (what it was worked
+// against). Both FKs are nullable. These links are the foundation of
+// the billing "money engine": rate resolution reads the worker's
+// default BillingType, and the time→invoice roll-up aggregates
+// billable minutes per Job.
+db.Worker.hasMany(db.TimeEntry,   { foreignKey: 'teWorkerId', as: 'timeEntries' });
+db.TimeEntry.belongsTo(db.Worker, { foreignKey: 'teWorkerId', as: 'worker' });
+db.Job.hasMany(db.TimeEntry,      { foreignKey: 'teJobId',    as: 'timeEntries' });
+db.TimeEntry.belongsTo(db.Job,    { foreignKey: 'teJobId',    as: 'job' });
+
 // Job has lines (InvoiceJob) and product entries.
 db.Job.hasMany(db.InvoiceJob,      { foreignKey: 'injbJobId', as: 'invoiceLines' });
 db.Job.hasMany(db.ProductEntry,    { foreignKey: 'pentJobId', as: 'productEntries' });

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -16,11 +16,12 @@ const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
-    'teCustId', 'teDescription', 'teStartedAt', 'teEndedAt',
-    'teBillable',
+    'teCustId', 'teWorkerId', 'teJobId', 'teDescription', 'teStartedAt',
+    'teEndedAt', 'teBillable',
 ];
 const ALLOWED_FIELDS_UPDATE = [
-    'teDescription', 'teStartedAt', 'teEndedAt', 'teBillable',
+    'teWorkerId', 'teJobId', 'teDescription', 'teStartedAt', 'teEndedAt',
+    'teBillable',
 ];
 
 function computeMinutes(startedAt, endedAt) {
@@ -71,6 +72,51 @@ function isInvertedRange(startedAt, endedAt) {
 }
 
 /**
+ * Validate an optional worker/job link against the entry's company and
+ * customer. Both are optional; a `null` value (update-only, to unlink)
+ * is skipped. Returns `null` when the links are legal, or a
+ * `{ status, message }` object the caller sends as-is.
+ *
+ *   - teWorkerId: must reference a Worker in `companyId`.
+ *   - teJobId:    must reference a Job whose customer sits in
+ *     `companyId` AND — when `custId` is known — whose customer IS
+ *     `custId`, so time for one client can't be booked against another
+ *     client's job. Archived workers/jobs are filtered by defaultScope
+ *     and therefore read as "not found" → 400.
+ */
+async function checkWorkerJobLinks({ teWorkerId, teJobId }, companyId, custId) {
+    if (teWorkerId !== undefined && teWorkerId !== null) {
+        const worker = await db.Worker.findByPk(Number(teWorkerId), {
+            attributes: ['workerCompId'],
+        });
+        if (!worker || worker.workerCompId !== companyId) {
+            return { status: 400, message: 'teWorkerId must reference a worker in your company.' };
+        }
+    }
+    if (teJobId !== undefined && teJobId !== null) {
+        const job = await db.Job.findByPk(Number(teJobId), {
+            attributes: ['jobCustId'],
+            include: [{
+                model: db.Customer,
+                as: 'customer',
+                attributes: ['custCompId'],
+                required: true,
+            }],
+        });
+        if (!job || !job.customer || job.customer.custCompId !== companyId) {
+            return { status: 400, message: 'teJobId must reference a job in your company.' };
+        }
+        if (custId !== undefined && custId !== null && job.jobCustId !== Number(custId)) {
+            return {
+                status: 400,
+                message: 'teJobId must belong to the same customer as the time entry (teCustId).',
+            };
+        }
+    }
+    return null;
+}
+
+/**
  * POST /v1/timeentry
  *
  * Create a new time entry for a customer in the auth'd company.
@@ -117,6 +163,17 @@ exports.create = async (req, res) => {
     payload.teCompId = companyId;
     payload.teArch = false;
     payload.teMinutes = computeMinutes(payload.teStartedAt, payload.teEndedAt);
+
+    let linkError;
+    try {
+        linkError = await checkWorkerJobLinks(payload, companyId, payload.teCustId);
+    } catch (error) {
+        log.error({ err: error }, 'TimeEntry worker/job link validation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (linkError) {
+        return res.status(linkError.status).json({ message: linkError.message });
+    }
 
     try {
         const created = await TimeEntry.create(payload);
@@ -307,6 +364,18 @@ exports.update = async (req, res) => {
         }
         updates.teMinutes = computeMinutes(mergedStart, mergedEnd);
     }
+
+    let linkError;
+    try {
+        linkError = await checkWorkerJobLinks(updates, entry.teCompId, entry.teCustId);
+    } catch (error) {
+        log.error({ err: error }, 'TimeEntry worker/job link validation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (linkError) {
+        return res.status(linkError.status).json({ message: linkError.message });
+    }
+
     try {
         await entry.update(updates);
         return res.status(200).json({ message: "Updated.", timeEntry: entry });

--- a/app/migrations/20260521000000-timeentry-worker-job-fks.js
+++ b/app/migrations/20260521000000-timeentry-worker-job-fks.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Links a TimeEntry to the Worker who logged it (teWorkerId) and the
+// Job it was worked against (teJobId). Both are nullable INTEGER: rows
+// created before this migration have neither, and quick ad-hoc time may
+// legitimately omit them. These columns are the schema foundation for
+// the billing "money engine" (backlog #385 / #386): rate resolution
+// reads the worker's default BillingType, and the time→invoice roll-up
+// aggregates billable minutes per Job.
+//
+// Following the increment-layer convention (see
+// 20260517000000-purchase-orders-and-archive-columns), the columns are
+// added WITHOUT a physical FK constraint — matching the other
+// migration-added link columns. The relationship is enforced at the
+// application layer (controller validation + the Sequelize association
+// wired in app/config/db.config.js). setup/*.sql is the frozen original
+// v1.0 schema and is intentionally left untouched; fresh installs pick
+// these columns up by running the migrations after the setup SQL.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'TimeEntry', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                TABLE, 'teWorkerId',
+                { type: Sequelize.INTEGER, allowNull: true },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                TABLE, 'teJobId',
+                { type: Sequelize.INTEGER, allowNull: true },
+                { transaction: t },
+            );
+            // Partial indexes for the "billable, unarchived time for a
+            // worker / a job" access paths the reporting + roll-up
+            // endpoints will use. Mirrors the WHERE "teArch" = FALSE
+            // partial-index style of TimeEntry_customer_started_idx in
+            // setup/TimeEntry.sql.
+            await queryInterface.addIndex(TABLE, {
+                name: 'TimeEntry_worker_idx',
+                fields: ['teWorkerId'],
+                where: { teArch: false },
+                transaction: t,
+            });
+            await queryInterface.addIndex(TABLE, {
+                name: 'TimeEntry_job_idx',
+                fields: ['teJobId'],
+                where: { teArch: false },
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeIndex(TABLE, 'TimeEntry_job_idx', { transaction: t });
+            await queryInterface.removeIndex(TABLE, 'TimeEntry_worker_idx', { transaction: t });
+            await queryInterface.removeColumn(TABLE, 'teJobId', { transaction: t });
+            await queryInterface.removeColumn(TABLE, 'teWorkerId', { transaction: t });
+        });
+    },
+};

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -33,6 +33,19 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.INTEGER,
             allowNull: false,
         },
+        teWorkerId: {
+            field: 'teWorkerId',
+            // Nullable: the Worker who logged the time. Pre-existing
+            // entries and quick ad-hoc time may have none. When set, it
+            // resolves the billable rate (Worker.defaultBillingType).
+            type: Sequelize.INTEGER,
+        },
+        teJobId: {
+            field: 'teJobId',
+            // Nullable: the Job this time was worked against. Lets
+            // billable minutes roll up to a project (and its invoice).
+            type: Sequelize.INTEGER,
+        },
         teDescription: {
             field: 'teDescription',
             type: Sequelize.TEXT,

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -31,12 +31,14 @@ const isoDatetime = z.string().datetime({
 const createTimeEntryBody = z.object({
     teCustId: z.coerce.number().int().positive(),
     teCompId: z.coerce.number().int().positive().optional(),
+    teWorkerId: z.coerce.number().int().positive().optional(),
+    teJobId: z.coerce.number().int().positive().optional(),
     teDescription: z.string().max(10000).optional(),
     teStartedAt: isoDatetime,
     teEndedAt: isoDatetime.optional(),
     teBillable: z.boolean().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teDescription, teStartedAt, teEndedAt, teBillable.',
+    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teDescription, teStartedAt, teEndedAt, teBillable.',
 }).refine(
     (data) => !data.teEndedAt || new Date(data.teEndedAt) >= new Date(data.teStartedAt),
     {
@@ -59,12 +61,15 @@ const createTimeEntryBody = z.object({
  * row; controller already returns `teMinutes = null` there.)
  */
 const updateTimeEntryBody = z.object({
+    // Nullable: pass null to unlink the worker / job from an entry.
+    teWorkerId: z.coerce.number().int().positive().nullable().optional(),
+    teJobId: z.coerce.number().int().positive().nullable().optional(),
     teDescription: z.string().max(10000).optional(),
     teStartedAt: isoDatetime.optional(),
     teEndedAt: isoDatetime.nullable().optional(),
     teBillable: z.boolean().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: teDescription, teStartedAt, teEndedAt, teBillable.',
+    message: 'Unexpected field in body. Whitelist: teWorkerId, teJobId, teDescription, teStartedAt, teEndedAt, teBillable.',
 }).refine(
     (data) => !(data.teStartedAt && data.teEndedAt) ||
         new Date(data.teEndedAt) >= new Date(data.teStartedAt),

--- a/tests/api/timeentry.test.js
+++ b/tests/api/timeentry.test.js
@@ -53,6 +53,20 @@ describe('/v1/timeentry routing', () => {
         expect(res.body.message).toBeDefined();
     });
 
+    test('POST /v1/timeentry rejects a non-integer teWorkerId at the schema', async () => {
+        const res = await request(app).post('/v1/timeentry')
+            .set('authKey', 'k')
+            .send({ teCustId: 1, teStartedAt: '2026-05-16T09:00:00Z', teWorkerId: 'abc' });
+        expect(res.status).toBe(400);
+    });
+
+    test('POST /v1/timeentry rejects a non-positive teJobId at the schema', async () => {
+        const res = await request(app).post('/v1/timeentry')
+            .set('authKey', 'k')
+            .send({ teCustId: 1, teStartedAt: '2026-05-16T09:00:00Z', teJobId: -5 });
+        expect(res.status).toBe(400);
+    });
+
     test('PATCH /v1/timeentry/:id route is mounted', async () => {
         const res = await request(app).patch('/v1/timeentry/1').send({});
         expect(res.body).toBeTypeOf('object');

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -113,6 +113,28 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(true).toBe(true);
     });
 
+    test('TimeEntry has teWorkerId / teJobId columns and worker/job includes resolve', async () => {
+        if (!connected) return;
+        // Selecting the new attributes proves the 20260521 migration
+        // added the columns (a missing column would throw here).
+        const rows = await db.TimeEntry.findAll({
+            attributes: ['teId', 'teWorkerId', 'teJobId'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        // Eager-loading through the new aliases proves the association
+        // wiring in db.config.js (a bad alias would throw). required:
+        // false so an empty table (or null FKs) is fine.
+        const withLinks = await db.TimeEntry.findAll({
+            limit: 1,
+            include: [
+                { model: db.Worker, as: 'worker', required: false },
+                { model: db.Job, as: 'job', required: false },
+            ],
+        });
+        expect(Array.isArray(withLinks)).toBe(true);
+    });
+
     test('/healthz reports a non-null migration name (dbo-qualified read)', async () => {
         // sequelize-cli writes the SequelizeMeta table into the `dbo`
         // schema (`migrationStorageTableSchema: 'dbo'` in

--- a/tests/unit/associations.test.js
+++ b/tests/unit/associations.test.js
@@ -99,3 +99,18 @@ describe('association graph: Worker.defaultBillingType', () => {
         assertAssoc('Worker', 'BelongsTo', 'workerDefaultBillType', 'BillingType');
     });
 });
+
+describe('association graph: TimeEntry worker + job links', () => {
+    test('TimeEntry belongsTo Worker via teWorkerId', () => {
+        assertAssoc('TimeEntry', 'BelongsTo', 'teWorkerId', 'Worker');
+    });
+    test('TimeEntry belongsTo Job via teJobId', () => {
+        assertAssoc('TimeEntry', 'BelongsTo', 'teJobId', 'Job');
+    });
+    test('Worker hasMany TimeEntry via teWorkerId', () => {
+        assertAssoc('Worker', 'HasMany', 'teWorkerId', 'TimeEntry');
+    });
+    test('Job hasMany TimeEntry via teJobId', () => {
+        assertAssoc('Job', 'HasMany', 'teJobId', 'TimeEntry');
+    });
+});


### PR DESCRIPTION
## Summary

First step of the v1.1 **billing core** — the schema foundation so tracked time can become billable revenue. Adds nullable `teWorkerId` / `teJobId` columns to `TimeEntry`, attributing time to the **Worker** who logged it and the **Job** it was worked against.

Closes #385, closes #386.

## Changes

- **Migration `20260521000000`** — adds `teWorkerId` / `teJobId` (+ partial indexes on unarchived rows). No physical FK, matching the increment-layer convention (the other migration-added link columns are the same); `setup/*.sql` (the frozen original schema) is left untouched — fresh installs pick the columns up by running migrations after the setup SQL.
- **Model + associations** — `TimeEntry belongsTo Worker` (`as: 'worker'`) / `Job` (`as: 'job'`); `Worker` / `Job hasMany TimeEntry`.
- **Controller** — `POST` / `PATCH /v1/timeentry` accept `teWorkerId` / `teJobId` (PATCH `null` unlinks), validated so the worker is in the caller's company and the job is in the **same company and the same customer** as the entry.
- **Zod schema** whitelists the new fields.
- **Tests** — association graph, api-level schema rejections, and a real-PG column/include check (CI exercises the migration end-to-end).

## Why nullable / no FK

Pre-existing rows and quick ad-hoc time may legitimately have neither link. The relationship is enforced at the app layer (controller validation + Sequelize association), consistent with the repo's other migration-added columns.

## Verification

`npm run lint` clean; `npm test` → 819 passing locally (the single failure is the pre-existing `Sequelize authenticates` connectivity check — no Postgres in the dev sandbox; CI runs the real migration + integration suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/