### PR TITLE
feat(payments): allocate payments to a specific invoice (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Payments can be allocated to a specific invoice** (#392). New
+  nullable `cpayInvId` on `CustomerPayment` (migration `20260525000000`)
+  links a payment to the invoice it pays — `NULL` leaves it "on account"
+  against the customer. Accepted on create/PATCH (validated so the
+  invoice belongs to the same customer as the payment; PATCH `null`
+  de-allocates). This is the input the upcoming invoice balance/status
+  derivation (#389) reads. `setup/*.sql` untouched.
 - **Time→invoice roll-up** (#382) — `POST /v1/invoice/rollup`. Generates
   an invoice from a customer's billable, uninvoiced, job-linked time:
   each entry is priced via the rate service, summed exactly through

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -113,6 +113,11 @@ db.Job.belongsTo(db.Customer,             { foreignKey: 'jobCustId',  as: 'custo
 db.Invoice.belongsTo(db.Customer,         { foreignKey: 'invCustId',  as: 'customer' });
 db.CustomerPayment.belongsTo(db.Customer, { foreignKey: 'cpayCustId', as: 'customer' });
 
+// CustomerPayment → Invoice (cpayInvId): the invoice a payment is
+// allocated to; NULL = on-account. Drives invoice balance/status (#389).
+db.Invoice.hasMany(db.CustomerPayment,   { foreignKey: 'cpayInvId', as: 'payments' });
+db.CustomerPayment.belongsTo(db.Invoice, { foreignKey: 'cpayInvId', as: 'invoice' });
+
 // Worker → BillingType (default rate).
 db.BillingType.hasMany(db.Worker,    { foreignKey: 'workerDefaultBillType', as: 'workersWithDefault' });
 db.Worker.belongsTo(db.BillingType,  { foreignKey: 'workerDefaultBillType', as: 'defaultBillingType' });

--- a/app/controllers/customerpaymentcontroller.js
+++ b/app/controllers/customerpaymentcontroller.js
@@ -13,8 +13,30 @@ const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
-const ALLOWED_FIELDS_CREATE = ['cpayCustId', 'cpayDescription', 'cpayDate', 'cpayAmount'];
-const ALLOWED_FIELDS_UPDATE = ['cpayDescription', 'cpayDate', 'cpayAmount'];
+const ALLOWED_FIELDS_CREATE = ['cpayCustId', 'cpayInvId', 'cpayDescription', 'cpayDate', 'cpayAmount'];
+const ALLOWED_FIELDS_UPDATE = ['cpayInvId', 'cpayDescription', 'cpayDate', 'cpayAmount'];
+
+/**
+ * When a payment is allocated (cpayInvId set, non-null), the invoice
+ * must belong to the same customer as the payment (cpayCustId) — a
+ * payment can't be booked against another customer's invoice. Archived
+ * invoices are hidden by defaultScope and therefore read as "not found"
+ * → 400. `null` (update-only, to de-allocate) is skipped. Returns null
+ * when legal, or a { status, message } object the caller sends as-is.
+ */
+async function checkInvoiceAllocation(cpayInvId, custId) {
+    if (cpayInvId === undefined || cpayInvId === null) return null;
+    const invoice = await db.Invoice.findByPk(Number(cpayInvId), {
+        attributes: ['invCustId'],
+    });
+    if (!invoice || invoice.invCustId !== Number(custId)) {
+        return {
+            status: 400,
+            message: 'cpayInvId must reference an invoice for the same customer (cpayCustId).',
+        };
+    }
+    return null;
+}
 
 exports.create = async (req, res) => {
     const authKey = req.get('authKey');
@@ -46,6 +68,17 @@ exports.create = async (req, res) => {
     }
 
     payload.cpayArch = false;
+
+    let allocError;
+    try {
+        allocError = await checkInvoiceAllocation(payload.cpayInvId, payload.cpayCustId);
+    } catch (error) {
+        log.error({ err: error }, 'CustomerPayment invoice-allocation validation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (allocError) {
+        return res.status(allocError.status).json({ message: allocError.message });
+    }
 
     try {
         const created = await CustomerPayment.create(payload);
@@ -171,6 +204,17 @@ exports.update = async (req, res) => {
     }
     if (Object.keys(updates).length === 0) {
         return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    let allocError;
+    try {
+        allocError = await checkInvoiceAllocation(updates.cpayInvId, payment.cpayCustId);
+    } catch (error) {
+        log.error({ err: error }, 'CustomerPayment invoice-allocation validation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (allocError) {
+        return res.status(allocError.status).json({ message: allocError.message });
     }
 
     try {

--- a/app/migrations/20260525000000-customerpayment-invoice-link.js
+++ b/app/migrations/20260525000000-customerpayment-invoice-link.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Adds cpayInvId to CustomerPayment: the Invoice a payment is allocated
+// to (backlog #392). Until now a payment linked only to a Customer, so
+// it could not reduce a specific invoice's balance. NULL means the
+// payment sits "on account" against the customer (unallocated). This is
+// the input the invoice balance/status derivation (#389) reads.
+//
+// Same increment-layer convention as the earlier link columns
+// (20260521000000): plain nullable INTEGER + a partial index on the
+// unarchived rows, no physical FK (enforced at the app layer), and
+// setup/*.sql left untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'CustomerPayment', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                TABLE, 'cpayInvId',
+                { type: Sequelize.INTEGER, allowNull: true },
+                { transaction: t },
+            );
+            // The balance query is "payments allocated to this invoice".
+            await queryInterface.addIndex(TABLE, {
+                name: 'CustomerPayment_invoice_idx',
+                fields: ['cpayInvId'],
+                where: { cpayArch: false },
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeIndex(TABLE, 'CustomerPayment_invoice_idx', { transaction: t });
+            await queryInterface.removeColumn(TABLE, 'cpayInvId', { transaction: t });
+        });
+    },
+};

--- a/app/models/customerpayment.model.js
+++ b/app/models/customerpayment.model.js
@@ -20,6 +20,12 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.INTEGER,
             allowNull: false,
         },
+        cpayInvId: {
+            field: 'cpayInvId',
+            // Nullable: the Invoice this payment is allocated to. NULL =
+            // on-account (unallocated). Drives invoice balance/status.
+            type: Sequelize.INTEGER,
+        },
         cpayDescription: {
             field: 'cpayDescription',
             type: Sequelize.TEXT,

--- a/app/schemas/customerpayment.schema.js
+++ b/app/schemas/customerpayment.schema.js
@@ -26,19 +26,22 @@ const cpayAmountField = z.coerce.number().finite({
 
 const createCustomerPaymentBody = z.object({
     cpayCustId: z.coerce.number().int().positive(),
+    cpayInvId: z.coerce.number().int().positive().optional(),
     cpayDescription: z.string().max(10000).optional(),
     cpayDate: isoDate,
     cpayAmount: cpayAmountField,
 }).strict({
-    message: 'Unexpected field in body. Whitelist: cpayCustId, cpayDescription, cpayDate, cpayAmount.',
+    message: 'Unexpected field in body. Whitelist: cpayCustId, cpayInvId, cpayDescription, cpayDate, cpayAmount.',
 });
 
 const updateCustomerPaymentBody = z.object({
+    // Nullable: pass null to de-allocate a payment (move it on-account).
+    cpayInvId: z.coerce.number().int().positive().nullable().optional(),
     cpayDescription: z.string().max(10000).optional(),
     cpayDate: isoDate.optional(),
     cpayAmount: cpayAmountField.optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: cpayDescription, cpayDate, cpayAmount.',
+    message: 'Unexpected field in body. Whitelist: cpayInvId, cpayDescription, cpayDate, cpayAmount.',
 });
 
 const listByCustomerQuery = z.object({

--- a/tests/api/customerpayment.test.js
+++ b/tests/api/customerpayment.test.js
@@ -36,6 +36,12 @@ describe('CustomerPayment auth contract', () => {
     test('GET /bycustomer/:id 403 without authKey', async () => { expect((await request(app).get('/v1/customerpayment/bycustomer/1')).status).toBe(403); });
     test('PATCH 403 without authKey', async () => { expect((await request(app).patch('/v1/customerpayment/1').send({ cpayAmount: 50 })).status).toBe(403); });
     test('DELETE 403 without authKey', async () => { expect((await request(app).delete('/v1/customerpayment/1')).status).toBe(403); });
+    test('POST rejects a non-integer cpayInvId at the schema', async () => {
+        const res = await request(app).post('/v1/customerpayment')
+            .set('authKey', 'k')
+            .send({ cpayCustId: 1, cpayDate: '2026-01-01', cpayAmount: 100, cpayInvId: 'abc' });
+        expect(res.status).toBe(400);
+    });
 });
 
 describe('CustomerPayment route mounting', () => {

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -147,6 +147,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('CustomerPayment has the cpayInvId allocation column + invoice include', async () => {
+        if (!connected) return;
+        const rows = await db.CustomerPayment.findAll({
+            attributes: ['cpayId', 'cpayInvId'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withInvoice = await db.CustomerPayment.findAll({
+            limit: 1,
+            include: [{ model: db.Invoice, as: 'invoice', required: false }],
+        });
+        expect(Array.isArray(withInvoice)).toBe(true);
+    });
+
     test('/healthz reports a non-null migration name (dbo-qualified read)', async () => {
         // sequelize-cli writes the SequelizeMeta table into the `dbo`
         // schema (`migrationStorageTableSchema: 'dbo'` in

--- a/tests/unit/associations.test.js
+++ b/tests/unit/associations.test.js
@@ -126,3 +126,12 @@ describe('association graph: TimeEntry worker + job links', () => {
         assertAssoc('InvoiceJob', 'HasMany', 'teInvJobId', 'TimeEntry');
     });
 });
+
+describe('association graph: CustomerPayment → Invoice allocation', () => {
+    test('CustomerPayment belongsTo Invoice via cpayInvId', () => {
+        assertAssoc('CustomerPayment', 'BelongsTo', 'cpayInvId', 'Invoice');
+    });
+    test('Invoice hasMany CustomerPayment via cpayInvId', () => {
+        assertAssoc('Invoice', 'HasMany', 'cpayInvId', 'CustomerPayment');
+    });
+});


### PR DESCRIPTION
## Summary

A `CustomerPayment` linked only to a customer, so payments couldn't reduce a specific invoice's balance. This adds a nullable **`cpayInvId`** allocation link — the prerequisite for deriving invoice status/balance (#389).

Closes #392.

## Changes

- **Migration `20260525000000`** — nullable `cpayInvId` on `CustomerPayment` (+ partial index). `NULL` = the payment sits **on-account** (unallocated); set = it pays that invoice. `setup/*.sql` untouched.
- **Model + association** — `CustomerPayment belongsTo Invoice` (`as: 'invoice'`), `Invoice hasMany CustomerPayment` (`as: 'payments'`).
- **Create / PATCH** accept `cpayInvId`, validated so the invoice belongs to the **same customer** as the payment (can't book a payment against another customer's invoice); PATCH `null` de-allocates.

## Verification

`npm run lint` clean; `npm test` → 874 passing (association graph, schema rejection, integration column + include check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check — CI runs the real migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/