### PR TITLE
feat(billing): derive invoice status + outstanding balance (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Invoice status + outstanding balance** (#389). `GET /v1/invoice/{id}`
+  now returns a derived `billing` object — `{ status, total, amountPaid,
+  balance }` — computed from the payments allocated to the invoice
+  (#392's `cpayInvId`) and its due date via the new
+  `app/services/invoice-status.js`. Status is `draft` (no total yet) →
+  `sent` → `partial` → `overdue` (past due, not settled) → `paid`;
+  amounts are summed exactly through `money.js`. Derivation only — the
+  stored `invPaid` flag is untouched.
 - **Payments can be allocated to a specific invoice** (#392). New
   nullable `cpayInvId` on `CustomerPayment` (migration `20260525000000`)
   links a payment to the invoice it pays — `NULL` leaves it "on account"

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1283,7 +1283,7 @@ const spec = {
             },
         },
         '/v1/invoice/{id}': {
-            get: { summary: 'Get one invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Found' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
+            get: { summary: 'Get one invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Found — {message, invoice, billing} envelope; billing = derived {status, total, amountPaid, balance} from allocated payments + due date' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -9,6 +9,7 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { makeBulkCreateIndirect } = require('./_bulk-helpers.js');
 const money = require('../services/money.js');
 const { buildRollup } = require('../services/invoice-rollup.js');
+const invoiceStatus = require('../services/invoice-status.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -78,7 +79,12 @@ exports.getById = async (req, res) => {
 
     let invoice;
     try {
-        invoice = await Invoice.findByPk(req.params.id);
+        // Eager-load the allocated, unarchived payments (defaultScope
+        // hides cpayArch) so the response can carry a derived status +
+        // outstanding balance without extra round-trips.
+        invoice = await Invoice.findByPk(req.params.id, {
+            include: [{ model: db.CustomerPayment, as: 'payments', required: false }],
+        });
     } catch (error) {
         log.error({ err: error }, 'Invoice.findByPk failed');
         return res.status(500).json({ message: "Error!" });
@@ -101,7 +107,9 @@ exports.getById = async (req, res) => {
             return res.status(404).json({ message: "Not found." });
         }
     }
-    return res.status(200).json({ message: "Found.", invoice });
+    // Derived (not stored) payment position: status + outstanding balance.
+    const billing = invoiceStatus.summarize(invoice, invoice.payments, todayISO());
+    return res.status(200).json({ message: "Found.", invoice, billing });
 };
 
 exports.listByCustomer = async (req, res) => {

--- a/app/services/invoice-status.js
+++ b/app/services/invoice-status.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invoice-status.js — derive an invoice's lifecycle status and
+ * outstanding balance from the payments allocated to it (#392's
+ * cpayInvId) and its due date.
+ *
+ * Derivation only — nothing here mutates the invoice. The stored
+ * `invPaid` boolean stays a manual operator flag; this is the
+ * authoritative, payment-driven view for display.
+ *
+ * PURE: the caller loads the invoice and its allocated, unarchived
+ * payments; this does exact-money summation (money.js) and string
+ * comparison. No DB.
+ */
+
+const money = require('./money.js');
+
+/**
+ * @param {{ total:(number|null), amountPaid:number, dueDate:(string|null), today:(string|null) }} p
+ * @returns {'draft'|'sent'|'partial'|'overdue'|'paid'}
+ *
+ * dueDate / today are 'YYYY-MM-DD' strings — lexicographic order equals
+ * chronological order for that fixed shape.
+ */
+function deriveStatus({ total, amountPaid, dueDate, today }) {
+    if (total == null) return 'draft';            // not yet totalled
+    if (amountPaid >= total) return 'paid';       // settled (incl. overpaid)
+    if (dueDate != null && today != null && dueDate < today) return 'overdue';
+    if (amountPaid > 0) return 'partial';
+    return 'sent';                                // issued, unpaid, not yet due
+}
+
+/**
+ * Summarize an invoice's payment position.
+ * @param invoice { invTotal:(number|null), invDueDate:(string|null) }
+ * @param payments array of allocated, unarchived payments { cpayAmount }
+ * @param today 'YYYY-MM-DD'
+ * @returns { status, total, amountPaid, balance }
+ *   balance is total − amountPaid (null when the invoice has no total).
+ */
+function summarize(invoice, payments, today) {
+    const total = invoice && invoice.invTotal != null ? Number(invoice.invTotal) : null;
+    const amountPaid = money.sum((payments || []).map((p) => p.cpayAmount));
+    const balance = total == null ? null : money.subtract(total, amountPaid);
+    const status = deriveStatus({
+        total,
+        amountPaid,
+        dueDate: invoice ? invoice.invDueDate : null,
+        today,
+    });
+    return { status, total, amountPaid, balance };
+}
+
+module.exports = { deriveStatus, summarize };

--- a/tests/unit/invoice-status.test.js
+++ b/tests/unit/invoice-status.test.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for invoice status/balance derivation
+// (app/services/invoice-status.js). Pure — no DB.
+
+import { describe, test, expect } from 'vitest';
+
+const { deriveStatus, summarize } = require('../../app/services/invoice-status.js');
+
+const TODAY = '2026-07-05';
+
+describe('invoice-status.deriveStatus', () => {
+    test("'draft' when the invoice has no total yet", () => {
+        expect(deriveStatus({ total: null, amountPaid: 0, dueDate: '2026-08-01', today: TODAY })).toBe('draft');
+    });
+    test("'paid' when amountPaid meets or exceeds the total", () => {
+        expect(deriveStatus({ total: 100, amountPaid: 100, dueDate: '2026-08-01', today: TODAY })).toBe('paid');
+        expect(deriveStatus({ total: 100, amountPaid: 120, dueDate: '2026-01-01', today: TODAY })).toBe('paid');
+    });
+    test("'sent' when totalled, unpaid, and not yet due", () => {
+        expect(deriveStatus({ total: 100, amountPaid: 0, dueDate: '2026-08-01', today: TODAY })).toBe('sent');
+    });
+    test("'partial' when partly paid and not overdue", () => {
+        expect(deriveStatus({ total: 100, amountPaid: 40, dueDate: '2026-08-01', today: TODAY })).toBe('partial');
+    });
+    test("'overdue' when unpaid/partly paid and past the due date", () => {
+        expect(deriveStatus({ total: 100, amountPaid: 0, dueDate: '2026-06-01', today: TODAY })).toBe('overdue');
+        expect(deriveStatus({ total: 100, amountPaid: 40, dueDate: '2026-06-01', today: TODAY })).toBe('overdue');
+    });
+    test("due today is not yet overdue", () => {
+        expect(deriveStatus({ total: 100, amountPaid: 0, dueDate: TODAY, today: TODAY })).toBe('sent');
+    });
+});
+
+describe('invoice-status.summarize', () => {
+    test('sums allocated payments and computes an exact balance', () => {
+        const invoice = { invTotal: 150, invDueDate: '2026-08-01' };
+        const payments = [{ cpayAmount: 50 }, { cpayAmount: 25.5 }];
+        expect(summarize(invoice, payments, TODAY)).toEqual({
+            status: 'partial', total: 150, amountPaid: 75.5, balance: 74.5,
+        });
+    });
+    test('no payments → full balance, status sent', () => {
+        expect(summarize({ invTotal: 100, invDueDate: '2026-08-01' }, [], TODAY)).toEqual({
+            status: 'sent', total: 100, amountPaid: 0, balance: 100,
+        });
+    });
+    test('fully paid → zero balance, status paid', () => {
+        const r = summarize({ invTotal: 100, invDueDate: '2026-08-01' }, [{ cpayAmount: 100 }], TODAY);
+        expect(r).toEqual({ status: 'paid', total: 100, amountPaid: 100, balance: 0 });
+    });
+    test('untotalled invoice → null total/balance, draft', () => {
+        const r = summarize({ invTotal: null, invDueDate: '2026-08-01' }, [{ cpayAmount: 10 }], TODAY);
+        expect(r).toEqual({ status: 'draft', total: null, amountPaid: 10, balance: null });
+    });
+    test('no float drift summing many payments', () => {
+        const payments = Array.from({ length: 3 }, () => ({ cpayAmount: 0.1 }));
+        expect(summarize({ invTotal: 1, invDueDate: '2026-08-01' }, payments, TODAY).amountPaid).toBe(0.3);
+    });
+});


### PR DESCRIPTION
## Summary

Now that payments allocate to invoices (#392), an invoice can report where it stands. `GET /v1/invoice/{id}` returns a derived **`billing`** object.

Closes #389.

## Changes

- **`app/services/invoice-status.js`** — `summarize(invoice, payments, today)` → `{ status, total, amountPaid, balance }`. `amountPaid` sums the allocated, unarchived payments via `money.js`; `balance = total − amountPaid`.
- **Status** ladder: `draft` (no total yet) → `sent` (issued, unpaid, not due) → `partial` (partly paid) → `overdue` (past due, not settled) → `paid` (met/exceeded).
- **`GET /v1/invoice/{id}`** eager-loads the allocated payments and adds `billing` to the response.

## Notes

Derivation only — no migration, and the stored `invPaid` boolean flag is left untouched (this is the authoritative, payment-driven view for display). No float drift (exact-cent math).

## Verification

`npm run lint` clean; `npm test` → 887 passing (status-derivation cases across every branch + `summarize` money rounding; invoice + openapi suites green). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/