### PR TITLE
feat(billing): configurable per-company invoice numbering (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Configurable per-company invoice numbering** (#390). `Company` gains
+  a sequence — `compInvPrefix` / `compInvPad` / `compInvNextSeq`
+  (migration `20260526000000`, defaults `INV-` / `4` / `1`, settable via
+  company create/PATCH) — and `Invoice` gains `invNumber`. Every invoice
+  (manual create and the roll-up) is stamped with a human-facing number
+  like `INV-0001` at creation, allocated under a row lock so concurrent
+  creates never collide. `setup/*.sql` untouched.
 - **Invoice status + outstanding balance** (#389). `GET /v1/invoice/{id}`
   now returns a derived `billing` object — `{ status, total, amountPaid,
   balance }` — computed from the payments allocated to the invoice

--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -26,6 +26,7 @@ const GetCompanyId = auth.getCompanyId;
 const ALLOWED_FIELDS_CREATE = [
     'compName', 'compAddress1', 'compAddress2', 'compCity',
     'compState', 'compZip', 'compPhone', 'compEmail',
+    'compInvPrefix', 'compInvPad', 'compInvNextSeq',
 ];
 const ALLOWED_FIELDS_UPDATE = ALLOWED_FIELDS_CREATE;
 

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -10,6 +10,7 @@ const { makeBulkCreateIndirect } = require('./_bulk-helpers.js');
 const money = require('../services/money.js');
 const { buildRollup } = require('../services/invoice-rollup.js');
 const invoiceStatus = require('../services/invoice-status.js');
+const invoiceNumber = require('../services/invoice-number.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -45,13 +46,25 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "invCustId is required." });
     }
 
+    // The invoice's company is the customer's company — resolved once
+    // for both the scope check and invoice numbering.
     const isMaster = await IsMaster(authKey);
-    if (!isMaster) {
+    let custCompanyId;
+    try {
+        custCompanyId = await GetCompanyIdByCustomerId(payload.invCustId);
+    } catch (error) {
+        log.error({ err: error }, 'Invoice create: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (isMaster) {
+        if (custCompanyId === -1) {
+            return res.status(404).json({ message: "Customer not found." });
+        }
+    } else {
         const authCompanyId = await GetCompanyId(authKey);
         if (authCompanyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
-        const custCompanyId = await GetCompanyIdByCustomerId(payload.invCustId);
         if (custCompanyId === -1 || custCompanyId !== authCompanyId) {
             return res.status(403).json({
                 message: "Cannot create an invoice for a customer in a company you do not belong to.",
@@ -63,7 +76,12 @@ exports.create = async (req, res) => {
     payload.invArch = false;
 
     try {
-        const created = await Invoice.create(payload);
+        // Allocate the invoice number and create the row in one
+        // transaction so a concurrent create can't reuse the sequence.
+        const created = await db.sequelize.transaction(async (t) => {
+            payload.invNumber = await invoiceNumber.allocateNumber(db, custCompanyId, t);
+            return Invoice.create(payload, { transaction: t });
+        });
         return res.status(201).json({ message: "Invoice created.", invoice: created });
     } catch (error) {
         log.error({ err: error }, 'Invoice.create failed');
@@ -337,8 +355,10 @@ exports.rollup = async (req, res) => {
     let result;
     try {
         result = await db.sequelize.transaction(async (t) => {
+            const invNumber = await invoiceNumber.allocateNumber(db, custCompanyId, t);
             const invoice = await db.Invoice.create({
                 invCustId: custId,
+                invNumber,
                 invDate,
                 invDueDate,
                 invPaid: false,

--- a/app/migrations/20260526000000-invoice-numbering.js
+++ b/app/migrations/20260526000000-invoice-numbering.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Per-company invoice numbering (#390). Adds a configurable sequence to
+// Company — a prefix, a zero-pad width, and the next counter — and an
+// invNumber column on Invoice to hold the assigned human-facing number.
+//
+// The Company columns are NOT NULL with defaults so every existing
+// company starts numbering at INV-0001 without a backfill step.
+// invNumber is nullable: invoices created before this migration have no
+// number. setup/*.sql (frozen original schema) is left untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const COMPANY = { tableName: 'Company', schema: SCHEMA };
+const INVOICE = { tableName: 'Invoice', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                COMPANY, 'compInvPrefix',
+                { type: Sequelize.TEXT, allowNull: false, defaultValue: 'INV-' },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                COMPANY, 'compInvPad',
+                { type: Sequelize.INTEGER, allowNull: false, defaultValue: 4 },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                COMPANY, 'compInvNextSeq',
+                { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                INVOICE, 'invNumber',
+                { type: Sequelize.TEXT, allowNull: true },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(INVOICE, {
+                name: 'Invoice_number_idx',
+                fields: ['invNumber'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeIndex(INVOICE, 'Invoice_number_idx', { transaction: t });
+            await queryInterface.removeColumn(INVOICE, 'invNumber', { transaction: t });
+            await queryInterface.removeColumn(COMPANY, 'compInvNextSeq', { transaction: t });
+            await queryInterface.removeColumn(COMPANY, 'compInvPad', { transaction: t });
+            await queryInterface.removeColumn(COMPANY, 'compInvPrefix', { transaction: t });
+        });
+    },
+};

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -30,6 +30,12 @@ module.exports = (sequelize, Sequelize) => {
         compZip:      { field: 'compZip',      type: Sequelize.TEXT },
         compPhone:    { field: 'compPhone',    type: Sequelize.STRING(32) },
         compEmail:    { field: 'compEmail',    type: Sequelize.TEXT },
+        // Invoice numbering config (#390): prefix + zero-pad width +
+        // next counter. Assigned at invoice creation via the
+        // row-locked allocator in app/services/invoice-number.js.
+        compInvPrefix:  { field: 'compInvPrefix',  type: Sequelize.TEXT,    allowNull: false, defaultValue: 'INV-' },
+        compInvPad:     { field: 'compInvPad',     type: Sequelize.INTEGER, allowNull: false, defaultValue: 4 },
+        compInvNextSeq: { field: 'compInvNextSeq', type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
         compArch: {
             field: 'compArch',
             type: Sequelize.BOOLEAN,

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -72,6 +72,13 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.INTEGER,
             allowNull: false,
         },
+        invNumber: {
+            field: 'invNumber',
+            // Human-facing invoice number (e.g. "INV-0001"), assigned per
+            // company at creation (#390). Null on invoices created before
+            // numbering existed.
+            type: Sequelize.TEXT,
+        },
     }, {
         tableName: 'Invoice',
         timestamps: true,

--- a/app/schemas/company.schema.js
+++ b/app/schemas/company.schema.js
@@ -8,6 +8,15 @@ const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
 });
 
+// Invoice-numbering config (#390): a bounded prefix, a zero-pad width,
+// and an operator-settable next counter (to start/reset the sequence).
+const invNumberingFields = {
+    compInvPrefix: z.string().max(16).optional(),
+    compInvPad: z.coerce.number().int().min(0).max(12).optional(),
+    compInvNextSeq: z.coerce.number().int().positive().optional(),
+};
+const NUMBERING_WHITELIST = ', compInvPrefix, compInvPad, compInvNextSeq';
+
 const createCompanyBody = z.object({
     compName: z.string().min(1).max(255),
     compAddress1: z.string().max(255).optional(),
@@ -17,8 +26,9 @@ const createCompanyBody = z.object({
     compZip: z.string().max(32).optional(),
     compPhone: z.string().max(32).optional(),
     compEmail: z.string().email().max(255).optional(),
+    ...invNumberingFields,
 }).strict({
-    message: 'Unexpected field in body. Whitelist: compName, compAddress1, compAddress2, compCity, compState, compZip, compPhone, compEmail.',
+    message: 'Unexpected field in body. Whitelist: compName, compAddress1, compAddress2, compCity, compState, compZip, compPhone, compEmail' + NUMBERING_WHITELIST + '.',
 });
 
 const updateCompanyBody = z.object({
@@ -30,8 +40,9 @@ const updateCompanyBody = z.object({
     compZip: z.string().max(32).optional(),
     compPhone: z.string().max(32).optional(),
     compEmail: z.string().email().max(255).optional(),
+    ...invNumberingFields,
 }).strict({
-    message: 'Unexpected field in body. Whitelist: compName, compAddress1, compAddress2, compCity, compState, compZip, compPhone, compEmail.',
+    message: 'Unexpected field in body. Whitelist: compName, compAddress1, compAddress2, compCity, compState, compZip, compPhone, compEmail' + NUMBERING_WHITELIST + '.',
 });
 
 const listQuery = z.object({

--- a/app/services/invoice-number.js
+++ b/app/services/invoice-number.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invoice-number.js — per-company invoice numbering (#390).
+ *
+ * Each Company carries a configurable sequence: a prefix, a zero-pad
+ * width, and the next counter value. An invoice is stamped with a
+ * human-facing number (e.g. "INV-0001") at creation.
+ *
+ * `formatNumber` is pure. `allocateNumber` reserves the next value under
+ * a row lock (SELECT … FOR UPDATE) inside the caller's transaction, so
+ * two invoices created concurrently for the same company can never share
+ * a number — the second waits for the first to commit.
+ */
+
+/**
+ * Format a sequence value as `${prefix}${zero-padded seq}`.
+ * Padding only widens; a seq longer than `pad` is printed in full.
+ * @param {string|null} prefix
+ * @param {number} seq
+ * @param {number} pad zero-pad width
+ * @returns {string}
+ */
+function formatNumber(prefix, seq, pad) {
+    const p = prefix == null ? '' : String(prefix);
+    const n = Number.isFinite(Number(seq)) ? Math.max(Math.trunc(Number(seq)), 0) : 0;
+    const width = Number.isFinite(Number(pad)) && Number(pad) > 0 ? Math.trunc(Number(pad)) : 0;
+    return p + String(n).padStart(width, '0');
+}
+
+/**
+ * Reserve and return the next invoice number for a company, advancing
+ * its counter. Must be called inside a transaction `t`; takes a row lock
+ * on the Company so concurrent allocations serialize. Returns null when
+ * the company isn't found (e.g. archived).
+ * @param {object} db the db.config module
+ * @param {number} companyId
+ * @param {import('sequelize').Transaction} t
+ * @returns {Promise<string|null>}
+ */
+async function allocateNumber(db, companyId, t) {
+    const company = await db.Company.findByPk(companyId, {
+        attributes: ['compId', 'compInvPrefix', 'compInvPad', 'compInvNextSeq'],
+        transaction: t,
+        lock: t.LOCK.UPDATE,
+    });
+    if (!company) return null;
+    const seq = Number.isFinite(Number(company.compInvNextSeq))
+        ? Math.trunc(Number(company.compInvNextSeq))
+        : 1;
+    const number = formatNumber(company.compInvPrefix, seq, company.compInvPad);
+    await company.update({ compInvNextSeq: seq + 1 }, { transaction: t });
+    return number;
+}
+
+module.exports = { formatNumber, allocateNumber };

--- a/tests/api/company.test.js
+++ b/tests/api/company.test.js
@@ -34,6 +34,12 @@ beforeAll(async () => {
 });
 
 describe('Company auth contract', () => {
+    test('POST rejects an out-of-range compInvPad at the schema', async () => {
+        const res = await request(app).post('/v1/company')
+            .set('authKey', 'k')
+            .send({ compName: 'X', compInvPad: 99 });
+        expect(res.status).toBe(400);
+    });
     test('GET /v1/company/:id returns 403 when authKey missing', async () => {
         expect((await request(app).get('/v1/company/1')).status).toBe(403);
     });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -161,6 +161,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(withInvoice)).toBe(true);
     });
 
+    test('invoice-numbering columns exist (Company config + Invoice.invNumber)', async () => {
+        if (!connected) return;
+        const companies = await db.Company.findAll({
+            attributes: ['compId', 'compInvPrefix', 'compInvPad', 'compInvNextSeq'],
+            limit: 1,
+        });
+        expect(Array.isArray(companies)).toBe(true);
+        const invoices = await db.Invoice.findAll({
+            attributes: ['invId', 'invNumber'],
+            limit: 1,
+        });
+        expect(Array.isArray(invoices)).toBe(true);
+    });
+
     test('/healthz reports a non-null migration name (dbo-qualified read)', async () => {
         // sequelize-cli writes the SequelizeMeta table into the `dbo`
         // schema (`migrationStorageTableSchema: 'dbo'` in

--- a/tests/unit/invoice-number.test.js
+++ b/tests/unit/invoice-number.test.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for invoice-number formatting (app/services/invoice-number.js).
+// allocateNumber touches the DB (row lock) and is covered by the invoice
+// create/roll-up flows in CI; formatNumber is pure and tested here.
+
+import { describe, test, expect } from 'vitest';
+
+const { formatNumber } = require('../../app/services/invoice-number.js');
+
+describe('invoice-number.formatNumber', () => {
+    test('prefix + zero-padded sequence', () => {
+        expect(formatNumber('INV-', 1, 4)).toBe('INV-0001');
+        expect(formatNumber('INV-', 42, 4)).toBe('INV-0042');
+        expect(formatNumber('INV-', 1000, 4)).toBe('INV-1000');
+    });
+
+    test('padding only widens — a longer sequence prints in full', () => {
+        expect(formatNumber('INV-', 12345, 4)).toBe('INV-12345');
+    });
+
+    test('empty / null prefix and zero pad', () => {
+        expect(formatNumber('', 5, 0)).toBe('5');
+        expect(formatNumber(null, 7, 3)).toBe('007');
+    });
+
+    test('arbitrary prefix strings pass through verbatim', () => {
+        expect(formatNumber('2026/', 3, 5)).toBe('2026/00003');
+    });
+
+    test('non-finite / negative inputs degrade safely', () => {
+        expect(formatNumber('INV-', NaN, 4)).toBe('INV-0000');
+        expect(formatNumber('INV-', -3, 4)).toBe('INV-0000');
+        expect(formatNumber('INV-', 5, NaN)).toBe('INV-5');
+    });
+});


### PR DESCRIPTION
## Summary

Invoices had no human-facing number. This adds a **configurable per-company sequence** that stamps each invoice at creation.

Closes #390.

## Changes

- **Migration `20260526000000`** — `Company` gains `compInvPrefix` / `compInvPad` / `compInvNextSeq` (NOT NULL, defaults `INV-` / `4` / `1`), and `Invoice` gains `invNumber` (nullable + index). `setup/*.sql` untouched.
- **`app/services/invoice-number.js`** — pure `formatNumber(prefix, seq, pad)` → e.g. `INV-0001`; `allocateNumber(db, companyId, t)` reserves the next value under a **row lock** (`SELECT … FOR UPDATE`) inside the transaction, so two concurrent invoice creates for the same company can never share a number.
- **Assignment** — both manual `POST /v1/invoice` (now transactional) and `POST /v1/invoice/rollup` allocate + stamp `invNumber`.
- **Configurable** — `compInvPrefix` / `compInvPad` / `compInvNextSeq` are settable on company create/PATCH (pad bounded 0–12; next-seq lets an operator start/reset the counter).

## Verification

`npm run lint` clean; `npm test` → 897 passing (`formatNumber` padding + edge cases, company schema rejection, integration column checks). Lone failure is the pre-existing `Sequelize authenticates` connectivity check — CI runs the real migration + the row-locked allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/