### PR TITLE
feat(billing): invoice PDF download (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Invoice PDF** (#391) — `GET /v1/invoice/{id}/pdf` streams a branded
+  PDF (company header, bill-to, line items, subtotal/tax/total, amount
+  paid + balance due, status) built by `app/services/invoice-pdf.js`.
+  `pdfkit` is a new dependency, required lazily so it only loads on the
+  PDF path. Same secure-404 tenant scoping as the JSON endpoint.
 - **Configurable per-company invoice numbering** (#390). `Company` gains
   a sequence — `compInvPrefix` / `compInvPad` / `compInvNextSeq`
   (migration `20260526000000`, defaults `INV-` / `4` / `1`, settable via

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1287,6 +1287,21 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/invoice/{id}/pdf': {
+            get: {
+                summary: 'Download an invoice as a branded PDF',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: {
+                        description: 'PDF document (attachment)',
+                        content: { 'application/pdf': { schema: { type: 'string', format: 'binary' } } },
+                    },
+                    404: { description: 'Not found' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/invoice/bycustomer/{id}': {
             get: {
                 summary: 'List invoices for a customer (paginated)',

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -11,6 +11,7 @@ const money = require('../services/money.js');
 const { buildRollup } = require('../services/invoice-rollup.js');
 const invoiceStatus = require('../services/invoice-status.js');
 const invoiceNumber = require('../services/invoice-number.js');
+const { renderInvoicePdf } = require('../services/invoice-pdf.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -407,6 +408,87 @@ exports.rollup = async (req, res) => {
         total,
         skipped: skippedCounts,
     });
+};
+
+/**
+ * GET /v1/invoice/:id/pdf — stream a branded PDF of the invoice
+ * (company header, bill-to, line items, totals, balance). Same
+ * secure-404 scoping as getById.
+ */
+exports.pdf = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let invoice;
+    try {
+        invoice = await Invoice.findByPk(req.params.id, {
+            include: [
+                {
+                    model: db.InvoiceJob, as: 'lines', required: false,
+                    include: [{ model: db.Job, as: 'job', required: false }],
+                },
+                { model: db.CustomerPayment, as: 'payments', required: false },
+                {
+                    model: db.Customer, as: 'customer', required: false,
+                    include: [{ model: db.Company, as: 'company', required: false }],
+                },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'Invoice.findByPk (pdf) failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!invoice || invoice.invArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const authCompanyId = await GetCompanyId(authKey);
+        const invCompanyId = await GetCompanyIdByCustomerId(invoice.invCustId);
+        // Secure-404 on cross-tenant, same rationale as getById.
+        if (authCompanyId === -1 || invCompanyId === -1 || authCompanyId !== invCompanyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const billing = invoiceStatus.summarize(invoice, invoice.payments, todayISO());
+    const cust = invoice.customer || null;
+    const company = cust && cust.company ? cust.company : null;
+    const custName = cust
+        ? (cust.custCompanyName || [cust.custFName, cust.custLName].filter(Boolean).join(' ') || null)
+        : null;
+    const data = {
+        company: company ? {
+            name: company.compName,
+            address1: company.compAddress1, address2: company.compAddress2,
+            city: company.compCity, state: company.compState, zip: company.compZip,
+            phone: company.compPhone, email: company.compEmail,
+        } : null,
+        customer: { name: custName },
+        invoice: { number: invoice.invNumber, date: invoice.invDate, dueDate: invoice.invDueDate },
+        lines: (invoice.lines || []).map((l) => ({
+            description: (l.job && l.job.jobDesc) || `Job #${l.injbJobId}`,
+            amount: l.injbAmount == null ? null : Number(l.injbAmount),
+        })),
+        totals: { subtotal: invoice.invSubtotal, tax: invoice.invTax, total: invoice.invTotal },
+        payment: billing,
+    };
+
+    let pdf;
+    try {
+        pdf = await renderInvoicePdf(data);
+    } catch (error) {
+        log.error({ err: error }, 'Invoice PDF render failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const safeName = String(invoice.invNumber || invoice.invId).replace(/[^A-Za-z0-9._-]/g, '-');
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="invoice-${safeName}.pdf"`);
+    return res.status(200).send(pdf);
 };
 
 exports.bulkCreate = makeBulkCreateIndirect({

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -368,6 +368,11 @@ router.get(
     v.params(invoiceSchemas.intIdParam),
     invoice.getById,
 );
+router.get(
+    '/v1/invoice/:id/pdf',
+    v.params(invoiceSchemas.intIdParam),
+    invoice.pdf,
+);
 router.patch(
     '/v1/invoice/:id',
     v.params(invoiceSchemas.intIdParam),

--- a/app/services/invoice-pdf.js
+++ b/app/services/invoice-pdf.js
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invoice-pdf.js — render an invoice to a branded PDF (#391).
+ *
+ * `pdfkit` is required lazily inside renderInvoicePdf so the dependency
+ * only loads on the PDF path (it pulls in font machinery); the rest of
+ * the API never pays for it. Amounts are formatted through money.js so
+ * the printed figures match the stored NUMERIC exactly.
+ *
+ * Input is a plain data object (see the `data` shape in
+ * invoicecontroller.pdf), so this stays decoupled from Sequelize models
+ * and easy to unit test.
+ */
+
+const money = require('./money.js');
+
+const usd = (n) => (n == null ? '—' : '$' + money.toFixedString(n));
+
+function drawInvoice(doc, data) {
+    const company = data.company || {};
+    const customer = data.customer || {};
+    const invoice = data.invoice || {};
+    const lines = Array.isArray(data.lines) ? data.lines : [];
+    const totals = data.totals || {};
+    const payment = data.payment || {};
+
+    // ---- Header: company (left), INVOICE meta (right) ----
+    doc.fontSize(20).font('Helvetica-Bold').text(company.name || 'Company', 50, 50);
+    doc.fontSize(9).font('Helvetica');
+    const addr = [
+        company.address1, company.address2,
+        [company.city, company.state, company.zip].filter(Boolean).join(' '),
+        company.phone, company.email,
+    ].filter(Boolean);
+    doc.text(addr.join('\n'), 50, 74);
+
+    doc.fontSize(24).font('Helvetica-Bold').text('INVOICE', 380, 50, { align: 'right', width: 165 });
+    doc.fontSize(10).font('Helvetica');
+    const meta = [
+        invoice.number ? `No. ${invoice.number}` : null,
+        invoice.date ? `Date: ${invoice.date}` : null,
+        invoice.dueDate ? `Due: ${invoice.dueDate}` : null,
+        payment.status ? `Status: ${String(payment.status).toUpperCase()}` : null,
+    ].filter(Boolean);
+    doc.text(meta.join('\n'), 380, 82, { align: 'right', width: 165 });
+
+    // ---- Bill to ----
+    doc.moveTo(50, 150).lineTo(545, 150).stroke();
+    doc.fontSize(9).font('Helvetica-Bold').text('BILL TO', 50, 162);
+    doc.fontSize(11).font('Helvetica').text(customer.name || 'Customer', 50, 176);
+
+    // ---- Line items table ----
+    let y = 220;
+    doc.fontSize(9).font('Helvetica-Bold');
+    doc.text('DESCRIPTION', 50, y);
+    doc.text('AMOUNT', 380, y, { align: 'right', width: 165 });
+    doc.moveTo(50, y + 14).lineTo(545, y + 14).stroke();
+    y += 24;
+    doc.fontSize(10).font('Helvetica');
+    if (lines.length === 0) {
+        doc.text('No billable line items.', 50, y);
+        y += 18;
+    }
+    for (const line of lines) {
+        doc.text(String(line.description || ''), 50, y, { width: 320 });
+        doc.text(usd(line.amount), 380, y, { align: 'right', width: 165 });
+        y += 18;
+    }
+
+    // ---- Totals ----
+    y += 10;
+    doc.moveTo(330, y).lineTo(545, y).stroke();
+    y += 10;
+    const totalRow = (label, value, bold) => {
+        doc.font(bold ? 'Helvetica-Bold' : 'Helvetica').fontSize(10);
+        doc.text(label, 330, y, { width: 100 });
+        doc.text(value, 430, y, { align: 'right', width: 115 });
+        y += 16;
+    };
+    totalRow('Subtotal', usd(totals.subtotal));
+    totalRow('Tax', usd(totals.tax));
+    totalRow('Total', usd(totals.total), true);
+    if (payment.amountPaid != null && payment.amountPaid !== 0) {
+        totalRow('Paid', usd(payment.amountPaid));
+    }
+    totalRow('Balance Due', usd(payment.balance != null ? payment.balance : totals.total), true);
+
+    // ---- Footer ----
+    doc.fontSize(8).font('Helvetica').fillColor('#666')
+        .text('Thank you for your business.', 50, 780, { align: 'center', width: 495 });
+}
+
+/**
+ * Render invoice `data` to a PDF Buffer.
+ * @returns {Promise<Buffer>}
+ */
+function renderInvoicePdf(data) {
+    // Lazy — keep pdfkit off the hot path for every other endpoint.
+    const PDFDocument = require('pdfkit');
+    return new Promise((resolve, reject) => {
+        const doc = new PDFDocument({ size: 'A4', margin: 50 });
+        const chunks = [];
+        doc.on('data', (c) => chunks.push(c));
+        doc.on('end', () => resolve(Buffer.concat(chunks)));
+        doc.on('error', reject);
+        try {
+            drawInvoice(doc, data || {});
+            doc.end();
+        } catch (err) {
+            reject(err);
+        }
+    });
+}
+
+module.exports = { renderInvoicePdf };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.22.2",
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
+        "pdfkit": "^0.19.1",
         "pg": "^8.22.0",
         "pg-hstore": "^2.3.4",
         "pino": "^10.3.1",
@@ -370,11 +371,21 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -527,9 +538,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -547,9 +555,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +572,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +589,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -607,9 +606,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -627,9 +623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,6 +722,14 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -1061,6 +1062,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -1133,6 +1153,22 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/bytes": {
@@ -1265,6 +1301,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1467,6 +1511,11 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -1938,7 +1987,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2047,6 +2095,22 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2497,6 +2561,11 @@
         "node": ">=20"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2697,9 +2766,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2721,9 +2787,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2745,9 +2808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2769,9 +2829,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2825,6 +2882,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/locate-path": {
@@ -3144,6 +3218,11 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3205,6 +3284,19 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.1.0"
+      }
     },
     "node_modules/pg": {
       "version": "8.22.0",
@@ -3371,6 +3463,14 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",
@@ -3614,6 +3714,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="
     },
     "node_modules/retry-as-promised": {
       "version": "7.1.1",
@@ -4277,6 +4382,11 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4338,9 +4448,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4391,6 +4499,29 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express": "^4.22.2",
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
+    "pdfkit": "^0.19.1",
     "pg": "^8.22.0",
     "pg-hstore": "^2.3.4",
     "pino": "^10.3.1",

--- a/tests/api/invoice.test.js
+++ b/tests/api/invoice.test.js
@@ -43,6 +43,9 @@ describe('Invoice auth contract', () => {
     test('POST /rollup 400 on missing invCustId (schema)', async () => {
         expect((await request(app).post('/v1/invoice/rollup').set('authKey', 'k').send({})).status).toBe(400);
     });
+    test('GET /:id/pdf 403 without authKey', async () => {
+        expect((await request(app).get('/v1/invoice/1/pdf')).status).toBe(403);
+    });
 });
 
 describe('Invoice route mounting', () => {

--- a/tests/unit/invoice-pdf.test.js
+++ b/tests/unit/invoice-pdf.test.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the invoice PDF renderer (app/services/invoice-pdf.js).
+// Exercises pdfkit for real — asserts we get a well-formed PDF Buffer and
+// that null/empty data degrades gracefully instead of throwing.
+
+import { describe, test, expect } from 'vitest';
+
+const { renderInvoicePdf } = require('../../app/services/invoice-pdf.js');
+
+const isPdf = (buf) => Buffer.isBuffer(buf) && buf.slice(0, 5).toString('latin1') === '%PDF-';
+
+describe('invoice-pdf.renderInvoicePdf', () => {
+    test('renders a full invoice to a PDF Buffer', async () => {
+        const buf = await renderInvoicePdf({
+            company: { name: 'Acme LLC', city: 'Omaha', state: 'NE', zip: '68101' },
+            customer: { name: 'Wile E. Coyote' },
+            invoice: { number: 'INV-0001', date: '2026-07-01', dueDate: '2026-07-31' },
+            lines: [
+                { description: 'Consulting — July', amount: 150 },
+                { description: 'Design review', amount: 42.5 },
+            ],
+            totals: { subtotal: 192.5, tax: 0, total: 192.5 },
+            payment: { status: 'partial', amountPaid: 100, balance: 92.5 },
+        });
+        expect(isPdf(buf)).toBe(true);
+        expect(buf.length).toBeGreaterThan(500);
+    });
+
+    test('degrades gracefully with empty / null data (no throw)', async () => {
+        expect(isPdf(await renderInvoicePdf({}))).toBe(true);
+        expect(isPdf(await renderInvoicePdf({ lines: [], totals: {}, payment: {} }))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

The last piece of the v1.1 billing core: a downloadable invoice document. `GET /v1/invoice/{id}/pdf` streams a branded PDF.

Closes #391.

## Changes

- **`app/services/invoice-pdf.js`** — renders a company header, bill-to, line-item table, subtotal/tax/total, amount-paid + balance-due, and status. Amounts formatted via `money.js`. Returns a `Buffer`.
- **`pdfkit`** (new dependency) is **required lazily** inside the renderer, so it only loads on the PDF path — every other endpoint is unaffected.
- **`GET /v1/invoice/{id}/pdf`** — loads the invoice with its lines (+ jobs), customer (+ company for branding), and payments; applies the same secure-404 tenant scoping as the JSON `getById`; streams `application/pdf` as an attachment (`invoice-INV-0001.pdf`).

## Dependency note

`pdfkit@0.19.1`. `npm run audit` (the CI gate, `--omit=dev --audit-level=high`) still exits 0 — no new high-severity production advisory.

## Verification

`npm run lint` clean; `npm test` → 902 passing. The PDF unit test drives **pdfkit for real** — asserts a `%PDF-` Buffer and that null/empty data renders without throwing. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/