### PR TITLE
feat(reporting): accounts-receivable aging report (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Accounts-receivable aging report** (#40) — `GET /v1/invoice/aging`.
+  Buckets a company's outstanding invoice balances by how overdue they
+  are (`current` / `d1_30` / `d31_60` / `d61_90` / `d90plus`), each with
+  a count + exact total, plus the outstanding invoices (most overdue
+  first) and a grand total. Balances come from the payment-driven
+  derivation (`invoice-status`) and settled invoices are excluded.
+  Company-scoped (master keys pass `?companyId`).
 - **Invoice PDF** (#391) — `GET /v1/invoice/{id}/pdf` streams a branded
   PDF (company header, bill-to, line items, subtotal/tax/total, amount
   paid + balance due, status) built by `app/services/invoice-pdf.js`.

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1287,6 +1287,18 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/invoice/aging': {
+            get: {
+                summary: 'Accounts-receivable aging for a company',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys; scoped keys use their own company.' }],
+                responses: {
+                    200: { description: 'AR aging — {buckets, totalOutstanding, invoices}; buckets = current / d1_30 / d31_60 / d61_90 / d90plus with {count, amount}' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/invoice/{id}/pdf': {
             get: {
                 summary: 'Download an invoice as a branded PDF',

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -12,6 +12,7 @@ const { buildRollup } = require('../services/invoice-rollup.js');
 const invoiceStatus = require('../services/invoice-status.js');
 const invoiceNumber = require('../services/invoice-number.js');
 const { renderInvoicePdf } = require('../services/invoice-pdf.js');
+const { buildAging } = require('../services/invoice-aging.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -407,6 +408,85 @@ exports.rollup = async (req, res) => {
         tax,
         total,
         skipped: skippedCounts,
+    });
+};
+
+/**
+ * GET /v1/invoice/aging — accounts-receivable aging for a company.
+ * Buckets outstanding invoice balances by days overdue (current /
+ * 1-30 / 31-60 / 61-90 / 90+). Master keys must pass ?companyId; scoped
+ * keys use their own company.
+ */
+exports.aging = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master keys must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (req.query.companyId !== undefined && Number(req.query.companyId) !== companyId) {
+            return res.status(403).json({
+                message: "Cannot view AR aging for a company you do not belong to.",
+            });
+        }
+    }
+
+    let invoices;
+    try {
+        // Invoice scopes through Customer (no compId column), so join the
+        // customer and filter by company. defaultScope hides archived
+        // invoices / customers / payments.
+        invoices = await Invoice.findAll({
+            include: [
+                {
+                    model: db.Customer, as: 'customer', required: true,
+                    where: { custCompId: companyId },
+                    attributes: ['custCompanyName', 'custFName', 'custLName'],
+                },
+                { model: db.CustomerPayment, as: 'payments', required: false },
+            ],
+            order: [['invDueDate', 'ASC']],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'AR aging: Invoice.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const today = todayISO();
+    const items = invoices.map((inv) => {
+        const summary = invoiceStatus.summarize(inv, inv.payments, today);
+        const c = inv.customer;
+        const custName = c
+            ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null)
+            : null;
+        return {
+            invId: inv.invId,
+            invNumber: inv.invNumber,
+            custName,
+            dueDate: inv.invDueDate,
+            balance: summary.balance,
+        };
+    });
+
+    const aging = buildAging(items, today);
+    return res.status(200).json({
+        message: "AR aging.",
+        companyId,
+        asOf: today,
+        buckets: aging.buckets,
+        totalOutstanding: aging.totalOutstanding,
+        invoices: aging.invoices,
     });
 };
 

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -358,6 +358,11 @@ router.post(
     invoice.rollup,
 );
 router.get(
+    '/v1/invoice/aging',
+    v.query(invoiceSchemas.agingQuery),
+    invoice.aging,
+);
+router.get(
     '/v1/invoice/bycustomer/:id',
     v.params(invoiceSchemas.intIdParam),
     v.query(invoiceSchemas.listByCustomerQuery),

--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -86,6 +86,14 @@ const rollupInvoiceBody = z.object({
     message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, from, to.',
 }).refine(refineDueDateAfterIssue, DUE_BEFORE_ISSUE);
 
+// GET /v1/invoice/aging query. companyId required for master keys
+// (controller enforces); scoped keys default to their own company.
+const agingQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId.',
+});
+
 module.exports = {
     intIdParam,
     createInvoiceBody,
@@ -93,4 +101,5 @@ module.exports = {
     listByCustomerQuery,
     bulkInvoiceBody,
     rollupInvoiceBody,
+    agingQuery,
 };

--- a/app/services/invoice-aging.js
+++ b/app/services/invoice-aging.js
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invoice-aging.js — accounts-receivable aging (#40).
+ *
+ * Buckets outstanding invoice balances by how overdue they are:
+ *   current  — not yet due (or due today)
+ *   d1_30    — 1–30 days overdue
+ *   d31_60   — 31–60 days overdue
+ *   d61_90   — 61–90 days overdue
+ *   d90plus  — more than 90 days overdue
+ *
+ * PURE: the caller resolves each invoice's outstanding balance (via
+ * invoice-status.summarize) and passes plain items; this does date math
+ * and exact-money bucketing. No DB.
+ */
+
+const money = require('./money.js');
+
+const BUCKETS = ['current', 'd1_30', 'd31_60', 'd61_90', 'd90plus'];
+
+/** Whole days from dueDate to today (positive = overdue). Both 'YYYY-MM-DD'. */
+function daysOverdue(dueDate, today) {
+    const due = Date.parse(dueDate + 'T00:00:00Z');
+    const now = Date.parse(today + 'T00:00:00Z');
+    if (!Number.isFinite(due) || !Number.isFinite(now)) return 0;
+    return Math.round((now - due) / 86400000);
+}
+
+function bucketFor(days) {
+    if (days <= 0) return 'current';
+    if (days <= 30) return 'd1_30';
+    if (days <= 60) return 'd31_60';
+    if (days <= 90) return 'd61_90';
+    return 'd90plus';
+}
+
+/**
+ * @param items array of { invId, invNumber, custName, dueDate, balance }.
+ *   Items with a null / non-positive balance (settled or credit) are
+ *   skipped — an aging report is about what's still owed.
+ * @param today 'YYYY-MM-DD'
+ * @returns { buckets, totalOutstanding, invoices }
+ *   buckets[name] = { count, amount }; invoices carry their bucket + daysOverdue.
+ */
+function buildAging(items, today) {
+    const amounts = {};
+    const counts = {};
+    for (const b of BUCKETS) { amounts[b] = []; counts[b] = 0; }
+    const invoices = [];
+
+    for (const it of items || []) {
+        if (it.balance == null || it.balance <= 0) continue;
+        const days = daysOverdue(it.dueDate, today);
+        const bucket = bucketFor(days);
+        counts[bucket] += 1;
+        amounts[bucket].push(it.balance);
+        invoices.push({
+            invId: it.invId,
+            invNumber: it.invNumber,
+            custName: it.custName,
+            dueDate: it.dueDate,
+            balance: it.balance,
+            daysOverdue: days,
+            bucket,
+        });
+    }
+
+    const buckets = {};
+    for (const b of BUCKETS) buckets[b] = { count: counts[b], amount: money.sum(amounts[b]) };
+    const totalOutstanding = money.sum(BUCKETS.map((b) => buckets[b].amount));
+    // Most overdue first, then by due date.
+    invoices.sort((a, b) => b.daysOverdue - a.daysOverdue);
+
+    return { buckets, totalOutstanding, invoices };
+}
+
+module.exports = { buildAging, daysOverdue, bucketFor, BUCKETS };

--- a/tests/api/invoice.test.js
+++ b/tests/api/invoice.test.js
@@ -46,6 +46,9 @@ describe('Invoice auth contract', () => {
     test('GET /:id/pdf 403 without authKey', async () => {
         expect((await request(app).get('/v1/invoice/1/pdf')).status).toBe(403);
     });
+    test('GET /aging 403 without authKey', async () => {
+        expect((await request(app).get('/v1/invoice/aging')).status).toBe(403);
+    });
 });
 
 describe('Invoice route mounting', () => {

--- a/tests/unit/invoice-aging.test.js
+++ b/tests/unit/invoice-aging.test.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for AR aging (app/services/invoice-aging.js). Pure — no DB.
+
+import { describe, test, expect } from 'vitest';
+
+const { buildAging, daysOverdue, bucketFor } = require('../../app/services/invoice-aging.js');
+
+const TODAY = '2026-07-05';
+
+describe('invoice-aging.daysOverdue / bucketFor', () => {
+    test('days overdue is today − due (positive when past due)', () => {
+        expect(daysOverdue('2026-07-05', TODAY)).toBe(0);
+        expect(daysOverdue('2026-07-04', TODAY)).toBe(1);
+        expect(daysOverdue('2026-06-05', TODAY)).toBe(30);
+        expect(daysOverdue('2026-08-01', TODAY)).toBe(-27); // not yet due
+    });
+    test('bucket boundaries', () => {
+        expect(bucketFor(0)).toBe('current');
+        expect(bucketFor(-5)).toBe('current');
+        expect(bucketFor(1)).toBe('d1_30');
+        expect(bucketFor(30)).toBe('d1_30');
+        expect(bucketFor(31)).toBe('d31_60');
+        expect(bucketFor(60)).toBe('d31_60');
+        expect(bucketFor(61)).toBe('d61_90');
+        expect(bucketFor(90)).toBe('d61_90');
+        expect(bucketFor(91)).toBe('d90plus');
+    });
+});
+
+describe('invoice-aging.buildAging', () => {
+    test('buckets outstanding balances and totals each bucket exactly', () => {
+        const items = [
+            { invId: 1, invNumber: 'INV-0001', custName: 'A', dueDate: '2026-08-01', balance: 100 }, // current
+            { invId: 2, invNumber: 'INV-0002', custName: 'B', dueDate: '2026-06-20', balance: 50 },  // 15d → d1_30
+            { invId: 3, invNumber: 'INV-0003', custName: 'C', dueDate: '2026-06-01', balance: 25.5 },// 34d → d31_60
+            { invId: 4, invNumber: 'INV-0004', custName: 'D', dueDate: '2026-01-01', balance: 200 }, // 90+ → d90plus
+        ];
+        const { buckets, totalOutstanding, invoices } = buildAging(items, TODAY);
+        expect(buckets.current).toEqual({ count: 1, amount: 100 });
+        expect(buckets.d1_30).toEqual({ count: 1, amount: 50 });
+        expect(buckets.d31_60).toEqual({ count: 1, amount: 25.5 });
+        expect(buckets.d61_90).toEqual({ count: 0, amount: 0 });
+        expect(buckets.d90plus).toEqual({ count: 1, amount: 200 });
+        expect(totalOutstanding).toBe(375.5);
+        // most overdue first
+        expect(invoices.map((i) => i.invId)).toEqual([4, 3, 2, 1]);
+    });
+
+    test('skips settled (null / <= 0 balance) invoices', () => {
+        const items = [
+            { invId: 1, dueDate: '2026-06-01', balance: 0 },
+            { invId: 2, dueDate: '2026-06-01', balance: null },
+            { invId: 3, dueDate: '2026-06-01', balance: -10 },
+            { invId: 4, dueDate: '2026-06-01', balance: 40 },
+        ];
+        const { totalOutstanding, invoices } = buildAging(items, TODAY);
+        expect(totalOutstanding).toBe(40);
+        expect(invoices).toHaveLength(1);
+        expect(invoices[0].invId).toBe(4);
+    });
+
+    test('empty input → zeroed buckets', () => {
+        const { buckets, totalOutstanding } = buildAging([], TODAY);
+        expect(totalOutstanding).toBe(0);
+        expect(buckets.current).toEqual({ count: 0, amount: 0 });
+    });
+});


### PR DESCRIPTION
## Summary

First reporting endpoint, and it falls straight out of the billing core just shipped: `GET /v1/invoice/aging` shows what a company is owed, aged.

Closes #40.

## Changes

- **`app/services/invoice-aging.js`** (pure) — buckets outstanding balances by days overdue: `current` / `d1_30` / `d31_60` / `d61_90` / `d90plus`, each `{ count, amount }`, plus a grand `totalOutstanding` and the invoices (most overdue first). Settled (`≤ 0` / null balance) invoices are excluded; sums are exact-cent.
- **`GET /v1/invoice/aging`** — loads the company's invoices (joined through Customer, since Invoice scopes via the customer), derives each balance with `invoice-status.summarize` (allocated payments + due date), and returns the buckets. Company-scoped; master keys pass `?companyId`.

## Verification

`npm run lint` clean; `npm test` → 910 passing (aging bucket boundaries, date math, exact-money totals, settled-exclusion; route auth). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/