### PR TITLE
feat(reporting): unbilled billable-time report (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Unbilled-time report** (#48) — `GET /v1/report/unbilled` (new
+  `report` controller). Surfaces billable, not-yet-invoiced, job-linked
+  time grouped customer → job, priced via the rate service and summed
+  exactly, with hours + amount per job/customer and a grand total — the
+  "money you haven't billed yet" view that drives the next roll-up.
+  Company-scoped; optional `customerId` and `from`/`to` filters.
 - **Accounts-receivable aging report** (#40) — `GET /v1/invoice/aging`.
   Buckets a company's outstanding invoice balances by how overdue they
   are (`current` / `d1_30` / `d31_60` / `d61_90` / `d90plus`), each with

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1287,6 +1287,23 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/report/unbilled': {
+            get: {
+                summary: 'Unbilled billable time, grouped customer → job',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Unbilled time — {totalMinutes, totalHours, totalAmount, customers[]} (each customer → jobs with hours + amount)' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/invoice/aging': {
             get: {
                 summary: 'Accounts-receivable aging for a company',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Report controller — read-only analytics over the tracked time and
+ * billing data. Company-scoped: master keys pass ?companyId; scoped
+ * keys use their own company.
+ */
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildUnbilled } = require('../services/report-unbilled.js');
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/** Parse a strict YYYY-MM-DD into a Date at UTC start/end of day, or null. */
+function parseDate(s, endOfDay) {
+    if (typeof s !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+    const d = new Date(s + (endOfDay ? 'T23:59:59.999Z' : 'T00:00:00.000Z'));
+    return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * Resolve the target company from the auth key, enforcing scope.
+ * Returns { companyId } or { error: { status, message } }.
+ */
+async function resolveCompany(req) {
+    const isMaster = await IsMaster(req.authKey);
+    if (isMaster) {
+        const companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return { error: { status: 400, message: "Master keys must specify companyId." } };
+        }
+        return { companyId };
+    }
+    const companyId = await GetCompanyId(req.authKey);
+    if (companyId === -1) {
+        return { error: { status: 403, message: "Invalid Authorization Key." } };
+    }
+    if (req.query.companyId !== undefined && Number(req.query.companyId) !== companyId) {
+        return { error: { status: 403, message: "Cannot report on a company you do not belong to." } };
+    }
+    return { companyId };
+}
+
+/**
+ * GET /v1/report/unbilled — billable time not yet invoiced, grouped
+ * customer → job, priced via the rate service. The "money you haven't
+ * billed" view that drives the next roll-up. Optional customerId filter
+ * and from/to (entry start date) bounds.
+ */
+exports.unbilled = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const where = {
+        teCompId: companyId,
+        teBillable: true,
+        teInvJobId: null,
+        teJobId: { [Op.ne]: null },
+    };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) where.teCustId = customerId;
+    const from = parseDate(req.query.from, false);
+    const to = parseDate(req.query.to, true);
+    if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+    if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where,
+            include: [
+                { model: db.BillingType, as: 'billingType', required: false },
+                {
+                    model: db.Worker, as: 'worker', required: false,
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc'] },
+                {
+                    model: db.Customer, as: 'customer', required: false,
+                    attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
+                },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'unbilled report: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const items = entries.map((e) => {
+        const c = e.customer;
+        return {
+            teId: e.teId,
+            teCustId: e.teCustId,
+            teJobId: e.teJobId,
+            teMinutes: e.teMinutes,
+            teBillable: e.teBillable,
+            billingType: e.billingType,
+            worker: e.worker,
+            custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
+            jobDesc: e.job ? e.job.jobDesc : null,
+        };
+    });
+
+    const report = buildUnbilled(items);
+    return res.status(200).json({
+        message: "Unbilled billable time.",
+        companyId,
+        totalMinutes: report.totalMinutes,
+        totalHours: report.totalHours,
+        totalAmount: report.totalAmount,
+        unresolvedRateEntries: report.unresolvedRate.length,
+        customers: report.customers,
+    });
+};
+
+exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -26,6 +26,7 @@ const purchaseOrderHeader = require('../controllers/purchaseorderheadercontrolle
 const purchaseOrderLine = require('../controllers/purchaseorderlinecontroller.js');
 const inventoryTransaction = require('../controllers/inventorytransactioncontroller.js');
 const whoami = require('../controllers/whoamicontroller.js');
+const report = require('../controllers/reportcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -43,6 +44,7 @@ const versionInfoSchemas = require('../schemas/versioninfo.schema.js');
 const purchaseOrderVendorSchemas = require('../schemas/purchaseordervendor.schema.js');
 const purchaseOrderHeaderSchemas = require('../schemas/purchaseorderheader.schema.js');
 const purchaseOrderLineSchemas = require('../schemas/purchaseorderline.schema.js');
+const reportSchemas = require('../schemas/report.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -655,6 +657,13 @@ router.delete(
     '/v1/inventorytransaction/:id',
     v.params(inventoryTransactionSchemas.intIdParam),
     inventoryTransaction.remove,
+);
+
+// v1 report routes (read-only analytics).
+router.get(
+    '/v1/report/unbilled',
+    v.query(reportSchemas.unbilledQuery),
+    report.unbilled,
 );
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'Must be an ISO 8601 date (YYYY-MM-DD).',
+});
+
+/**
+ * GET /v1/report/unbilled query. companyId required for master keys
+ * (controller enforces); scoped keys default to their own company.
+ * Optional customerId filter and from/to date bounds on entry start.
+ */
+const unbilledQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
+});
+
+module.exports = { unbilledQuery };

--- a/app/services/report-unbilled.js
+++ b/app/services/report-unbilled.js
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-unbilled.js — aggregate billable time that hasn't been invoiced
+ * yet, grouped customer → job (#48). This is the "money you haven't
+ * billed" view that drives the next roll-up.
+ *
+ * PURE: the caller loads billable, uninvoiced, job-linked time entries
+ * with their rate associations (and customer/job names); this prices
+ * each via rate.js and sums exactly via money.js. No DB.
+ */
+
+const money = require('./money.js');
+const rate = require('./rate.js');
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+
+/**
+ * @param entries array of { teId, teCustId, custName, teJobId, jobDesc,
+ *   teMinutes, teBillable } with eager-loaded rate associations.
+ * @returns { customers, totalMinutes, totalHours, totalAmount, unresolvedRate }
+ *   customers[] = { custId, custName, minutes, hours, amount, jobs[] };
+ *   jobs[] = { jobId, jobDesc, minutes, hours, amount, entryCount }.
+ *   unresolvedRate = ids of billable entries with no resolvable rate.
+ */
+function buildUnbilled(entries) {
+    const custMap = new Map();
+    const unresolvedRate = [];
+
+    for (const e of entries || []) {
+        if (!e.teBillable) continue;
+        if (e.teJobId == null) continue;
+        const amount = rate.billableAmount(e);
+        if (amount == null) { unresolvedRate.push(e.teId); continue; }
+
+        let c = custMap.get(e.teCustId);
+        if (!c) { c = { custId: e.teCustId, custName: e.custName || null, jobs: new Map() }; custMap.set(e.teCustId, c); }
+        let j = c.jobs.get(e.teJobId);
+        if (!j) { j = { jobId: e.teJobId, jobDesc: e.jobDesc || null, minutes: 0, amounts: [], count: 0 }; c.jobs.set(e.teJobId, j); }
+        j.minutes += Number(e.teMinutes) || 0;
+        j.amounts.push(amount);
+        j.count += 1;
+    }
+
+    const customers = [];
+    const allAmounts = [];
+    let totalMinutes = 0;
+    for (const c of custMap.values()) {
+        const jobs = [];
+        const custAmounts = [];
+        let custMinutes = 0;
+        for (const j of c.jobs.values()) {
+            const amount = money.sum(j.amounts);
+            jobs.push({ jobId: j.jobId, jobDesc: j.jobDesc, minutes: j.minutes, hours: round2(j.minutes / 60), amount, entryCount: j.count });
+            custAmounts.push(amount);
+            custMinutes += j.minutes;
+            allAmounts.push(amount);
+        }
+        jobs.sort((a, b) => a.jobId - b.jobId);
+        totalMinutes += custMinutes;
+        customers.push({
+            custId: c.custId, custName: c.custName,
+            minutes: custMinutes, hours: round2(custMinutes / 60),
+            amount: money.sum(custAmounts), jobs,
+        });
+    }
+    customers.sort((a, b) => a.custId - b.custId);
+
+    return {
+        customers,
+        totalMinutes,
+        totalHours: round2(totalMinutes / 60),
+        totalAmount: money.sum(allAmounts),
+        unresolvedRate,
+    };
+}
+
+module.exports = { buildUnbilled };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/report/*.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: { ne: Symbol('ne'), gte: Symbol('gte'), lte: Symbol('lte') } },
+    Customer: {}, TimeEntry: { findAll: vi.fn().mockResolvedValue([]) },
+    Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Report auth + schema contract', () => {
+    test('GET /v1/report/unbilled 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/unbilled')).status).toBe(403);
+    });
+    test('GET /v1/report/unbilled rejects an unknown query param (schema)', async () => {
+        const res = await request(app).get('/v1/report/unbilled?bogus=1').set('authKey', 'k');
+        expect(res.status).toBe(400);
+    });
+    test('GET /v1/report/unbilled rejects a non-integer companyId (schema)', async () => {
+        const res = await request(app).get('/v1/report/unbilled?companyId=abc').set('authKey', 'k');
+        expect(res.status).toBe(400);
+    });
+});

--- a/tests/unit/report-unbilled.test.js
+++ b/tests/unit/report-unbilled.test.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the unbilled-time report aggregation
+// (app/services/report-unbilled.js). Pure — plain objects.
+
+import { describe, test, expect } from 'vitest';
+
+const { buildUnbilled } = require('../../app/services/report-unbilled.js');
+
+// billable entry: minutes at a per-entry hourly rate, on a customer/job.
+const e = (teId, teCustId, custName, teJobId, jobDesc, teMinutes, hourly, teBillable = true) => ({
+    teId, teCustId, custName, teJobId, jobDesc, teMinutes, teBillable,
+    billingType: hourly == null ? null : { btHourlyRate: hourly },
+});
+
+describe('report-unbilled.buildUnbilled', () => {
+    test('groups customer → job, sums minutes/hours/amount exactly', () => {
+        const r = buildUnbilled([
+            e(1, 100, 'Acme', 10, 'Build', 60, 100),   // $100 / 1h
+            e(2, 100, 'Acme', 10, 'Build', 30, 100),   // $50 / 0.5h → job 10: $150 / 1.5h
+            e(3, 100, 'Acme', 11, 'Design', 90, 80),   // $120 / 1.5h
+            e(4, 200, 'Beta', 20, 'Audit', 120, 50),   // $100 / 2h
+        ]);
+        expect(r.totalAmount).toBe(370);
+        expect(r.totalMinutes).toBe(300);
+        expect(r.totalHours).toBe(5);
+        const acme = r.customers.find((c) => c.custId === 100);
+        expect(acme.amount).toBe(270);
+        expect(acme.hours).toBe(3);
+        expect(acme.jobs.map((j) => [j.jobId, j.amount, j.hours, j.entryCount])).toEqual([
+            [10, 150, 1.5, 2],
+            [11, 120, 1.5, 1],
+        ]);
+    });
+
+    test('skips non-billable, job-less, and unresolved-rate entries', () => {
+        const r = buildUnbilled([
+            e(1, 1, 'A', 5, 'J', 60, 100),
+            e(2, 1, 'A', 5, 'J', 60, 100, false), // non-billable
+            e(3, 1, 'A', null, null, 60, 100),    // no job
+            e(4, 1, 'A', 5, 'J', 60, null),       // no rate
+        ]);
+        expect(r.totalAmount).toBe(100);
+        expect(r.unresolvedRate).toEqual([4]);
+        expect(r.customers).toHaveLength(1);
+    });
+
+    test('empty input → zero totals', () => {
+        const r = buildUnbilled([]);
+        expect(r).toEqual({ customers: [], totalMinutes: 0, totalHours: 0, totalAmount: 0, unresolvedRate: [] });
+    });
+});


### PR DESCRIPTION
## Summary

Opens the **reporting** area with the report that pays for itself: what billable time is sitting uninvoiced. `GET /v1/report/unbilled`.

Closes #48.

## Changes

- **New `report` controller** (`/v1/report/*`) — the home for the reporting endpoints (#47/#49/#50 will extend it).
- **`app/services/report-unbilled.js`** (pure) — groups billable, **not-yet-invoiced** (`teInvJobId IS NULL`), job-linked time **customer → job**, prices each entry via `rate.js`, sums exactly via `money.js`, and reports hours + amount per job/customer plus grand totals. Billable entries with no resolvable rate are counted separately (so nothing is silently dropped).
- **`GET /v1/report/unbilled`** — company-scoped (master passes `?companyId`), with optional `customerId` and `from`/`to` (entry start date) filters.

## Verification

`npm run lint` clean; `npm test` → 922 passing (aggregation grouping/money/skip cases, route auth + schema rejection). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/