### PR TITLE
feat(reporting): hours by customer, job, and worker (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
-- **Unbilled-time report** (#48) — `GET /v1/report/unbilled` (new
+- **Hours summary report** (#431) — `GET /v1/report/hours`. Groups all
+  closed time for a company by customer, job, and worker, each with a
+  billable / non-billable split (minutes + hours), plus company-wide
+  totals. Company-scoped; optional `customerId` / `workerId` / `from` /
+  `to` filters. New pure `app/services/report-hours.js`.
+- **Unbilled-time report** (#430) — `GET /v1/report/unbilled` (new
   `report` controller). Surfaces billable, not-yet-invoiced, job-linked
   time grouped customer → job, priced via the rate service and summed
   exactly, with hours + amount per job/customer and a grand total — the
   "money you haven't billed yet" view that drives the next roll-up.
   Company-scoped; optional `customerId` and `from`/`to` filters.
-- **Accounts-receivable aging report** (#40) — `GET /v1/invoice/aging`.
+- **Accounts-receivable aging report** (#422) — `GET /v1/invoice/aging`.
   Buckets a company's outstanding invoice balances by how overdue they
   are (`current` / `d1_30` / `d31_60` / `d61_90` / `d90plus`), each with
   a count + exact total, plus the outstanding invoices (most overdue

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1287,6 +1287,24 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/report/hours': {
+            get: {
+                summary: 'Hours summary grouped by customer, job, and worker',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'workerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Hours — {totalHours, billableHours, nonBillableHours, byCustomer[], byJob[], byWorker[]}' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/unbilled': {
             get: {
                 summary: 'Unbilled billable time, grouped customer → job',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -12,6 +12,7 @@ const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildUnbilled } = require('../services/report-unbilled.js');
+const { buildHours } = require('../services/report-hours.js');
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
@@ -126,6 +127,76 @@ exports.unbilled = async (req, res) => {
         unresolvedRateEntries: report.unresolvedRate.length,
         customers: report.customers,
     });
+};
+
+/**
+ * GET /v1/report/hours — hours summary grouped by customer, job, and
+ * worker, each with its billable / non-billable split. Covers all
+ * closed time for the company; optional customerId / workerId / from /
+ * to filters.
+ */
+exports.hours = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const where = { teCompId: companyId };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) where.teCustId = customerId;
+    const workerId = Number(req.query.workerId);
+    if (Number.isInteger(workerId) && workerId > 0) where.teWorkerId = workerId;
+    const from = parseDate(req.query.from, false);
+    const to = parseDate(req.query.to, true);
+    if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+    if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where,
+            include: [
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc'] },
+                {
+                    model: db.Customer, as: 'customer', required: false,
+                    attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
+                },
+                {
+                    model: db.Worker, as: 'worker', required: false,
+                    attributes: ['workerId', 'workerFName', 'workerLName'],
+                },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'hours report: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const items = entries.map((e) => {
+        const c = e.customer;
+        const w = e.worker;
+        return {
+            teMinutes: e.teMinutes,
+            teBillable: e.teBillable,
+            teCustId: e.teCustId,
+            custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
+            teJobId: e.teJobId,
+            jobDesc: e.job ? e.job.jobDesc : null,
+            teWorkerId: e.teWorkerId,
+            workerName: w ? ([w.workerFName, w.workerLName].filter(Boolean).join(' ') || null) : null,
+        };
+    });
+
+    const report = buildHours(items);
+    return res.status(200).json({ message: "Hours summary.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -665,5 +665,10 @@ router.get(
     v.query(reportSchemas.unbilledQuery),
     report.unbilled,
 );
+router.get(
+    '/v1/report/hours',
+    v.query(reportSchemas.hoursQuery),
+    report.hours,
+);
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -22,4 +22,18 @@ const unbilledQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
 });
 
-module.exports = { unbilledQuery };
+/**
+ * GET /v1/report/hours query. companyId required for master keys.
+ * Optional customerId / workerId filters and from/to date bounds.
+ */
+const hoursQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    workerId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, workerId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery };

--- a/app/services/report-hours.js
+++ b/app/services/report-hours.js
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-hours.js — hours summary grouped by customer, job, and worker
+ * (#431), each with its billable / non-billable split.
+ *
+ * PURE: the caller loads closed time entries (with customer/job/worker
+ * names) and this aggregates minutes in memory. No DB, no rate lookup —
+ * this is an hours report, not a money report.
+ */
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+
+function addTo(map, key, label, minutes, billable) {
+    if (key == null) return; // entries with no job/worker don't appear in that dimension
+    let g = map.get(key);
+    if (!g) { g = { key, label: label || null, minutes: 0, billableMinutes: 0 }; map.set(key, g); }
+    g.minutes += minutes;
+    if (billable) g.billableMinutes += minutes;
+}
+
+function toRows(map, idKey, labelKey) {
+    return Array.from(map.values()).map((g) => ({
+        [idKey]: g.key,
+        [labelKey]: g.label,
+        minutes: g.minutes,
+        hours: round2(g.minutes / 60),
+        billableMinutes: g.billableMinutes,
+        billableHours: round2(g.billableMinutes / 60),
+    })).sort((a, b) => a[idKey] - b[idKey]);
+}
+
+/**
+ * @param entries array of { teMinutes, teBillable, teCustId, custName,
+ *   teJobId, jobDesc, teWorkerId, workerName }. In-flight entries
+ *   (teMinutes null) are skipped — they have no duration yet.
+ * @returns totals + byCustomer / byJob / byWorker breakdowns.
+ */
+function buildHours(entries) {
+    const byCustomer = new Map();
+    const byJob = new Map();
+    const byWorker = new Map();
+    let totalMinutes = 0;
+    let billableMinutes = 0;
+
+    for (const e of entries || []) {
+        // Skip in-flight entries — no duration yet. Guard null explicitly:
+        // Number(null) is 0 (finite), which would otherwise count them.
+        if (e.teMinutes == null) continue;
+        const min = Number(e.teMinutes);
+        if (!Number.isFinite(min)) continue;
+        totalMinutes += min;
+        if (e.teBillable) billableMinutes += min;
+        addTo(byCustomer, e.teCustId, e.custName, min, e.teBillable);
+        addTo(byJob, e.teJobId, e.jobDesc, min, e.teBillable);
+        addTo(byWorker, e.teWorkerId, e.workerName, min, e.teBillable);
+    }
+
+    const nonBillableMinutes = totalMinutes - billableMinutes;
+    return {
+        totalMinutes,
+        totalHours: round2(totalMinutes / 60),
+        billableMinutes,
+        billableHours: round2(billableMinutes / 60),
+        nonBillableMinutes,
+        nonBillableHours: round2(nonBillableMinutes / 60),
+        byCustomer: toRows(byCustomer, 'custId', 'custName'),
+        byJob: toRows(byJob, 'jobId', 'jobDesc'),
+        byWorker: toRows(byWorker, 'workerId', 'workerName'),
+    };
+}
+
+module.exports = { buildHours };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -37,4 +37,10 @@ describe('Report auth + schema contract', () => {
         const res = await request(app).get('/v1/report/unbilled?companyId=abc').set('authKey', 'k');
         expect(res.status).toBe(400);
     });
+    test('GET /v1/report/hours 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/hours')).status).toBe(403);
+    });
+    test('GET /v1/report/hours rejects an unknown query param (schema)', async () => {
+        expect((await request(app).get('/v1/report/hours?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/unit/report-hours.test.js
+++ b/tests/unit/report-hours.test.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the hours-summary report (app/services/report-hours.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildHours } = require('../../app/services/report-hours.js');
+
+const e = (teMinutes, teBillable, teCustId, custName, teJobId, jobDesc, teWorkerId, workerName) =>
+    ({ teMinutes, teBillable, teCustId, custName, teJobId, jobDesc, teWorkerId, workerName });
+
+describe('report-hours.buildHours', () => {
+    test('totals + billable/non-billable split', () => {
+        const r = buildHours([
+            e(60, true, 1, 'A', 10, 'J1', 5, 'Wanda'),
+            e(30, false, 1, 'A', 10, 'J1', 5, 'Wanda'),
+            e(120, true, 2, 'B', 20, 'J2', 6, 'Vic'),
+        ]);
+        expect(r.totalMinutes).toBe(210);
+        expect(r.totalHours).toBe(3.5);
+        expect(r.billableMinutes).toBe(180);
+        expect(r.nonBillableMinutes).toBe(30);
+        expect(r.nonBillableHours).toBe(0.5);
+    });
+
+    test('groups by customer, job, and worker with per-group hours', () => {
+        const r = buildHours([
+            e(60, true, 1, 'A', 10, 'J1', 5, 'Wanda'),
+            e(60, false, 1, 'A', 11, 'J2', 5, 'Wanda'),
+            e(30, true, 2, 'B', 10, 'J1', 6, 'Vic'),
+        ]);
+        expect(r.byCustomer).toEqual([
+            { custId: 1, custName: 'A', minutes: 120, hours: 2, billableMinutes: 60, billableHours: 1 },
+            { custId: 2, custName: 'B', minutes: 30, hours: 0.5, billableMinutes: 30, billableHours: 0.5 },
+        ]);
+        expect(r.byWorker.find((w) => w.workerId === 5)).toEqual({
+            workerId: 5, workerName: 'Wanda', minutes: 120, hours: 2, billableMinutes: 60, billableHours: 1,
+        });
+        expect(r.byJob.find((j) => j.jobId === 10)).toEqual({
+            jobId: 10, jobDesc: 'J1', minutes: 90, hours: 1.5, billableMinutes: 90, billableHours: 1.5,
+        });
+    });
+
+    test('skips in-flight entries (null minutes) and null-dimension keys', () => {
+        const r = buildHours([
+            e(null, true, 1, 'A', 10, 'J1', 5, 'W'), // in-flight → skipped
+            e(60, true, 1, 'A', null, null, null, null), // counts in totals + customer, not job/worker
+        ]);
+        expect(r.totalMinutes).toBe(60);
+        expect(r.byCustomer).toHaveLength(1);
+        expect(r.byJob).toHaveLength(0);
+        expect(r.byWorker).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

`GET /v1/report/hours` — an hours summary grouped three ways.

Closes #431.

## Changes

- **`app/services/report-hours.js`** (pure) — groups all **closed** time (in-flight entries skipped) by **customer**, **job**, and **worker**, each row carrying minutes + hours and a **billable / non-billable split**, plus company-wide totals.
- **`GET /v1/report/hours`** on the `report` controller — company-scoped (master passes `?companyId`), with optional `customerId` / `workerId` / `from` / `to` filters.
- Corrects two prior CHANGELOG entries that referenced backlog item numbers (`#40`/`#48`) to the real issues (`#422`/`#430`).

## Verification

`npm run lint` clean; `npm test` → 929 passing (grouping across all three dimensions, billable split, in-flight-null skip; route auth + schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

Note: caught a real bug pre-merge — `Number(null) === 0` would have counted in-flight entries; guarded explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/