### PR TITLE
feat(reporting): revenue & earnings summary (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Revenue & earnings summary** (#429) — `GET /v1/report/revenue`.
+  Revenue (invoiced total) and collected (payments allocated) grouped by
+  customer and by month, with outstanding per group and company totals,
+  all exact-cent. Company-scoped; optional `customerId` and `from`/`to`
+  (invoice date) filters. New pure `app/services/report-revenue.js`.
 - **Hours summary report** (#431) — `GET /v1/report/hours`. Groups all
   closed time for a company by customer, job, and worker, each with a
   billable / non-billable split (minutes + hours), plus company-wide

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1287,6 +1287,23 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/report/revenue': {
+            get: {
+                summary: 'Revenue & earnings summary (by customer and month)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' }, description: 'Invoice date lower bound.' },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Revenue — {totalRevenue, totalCollected, totalOutstanding, byCustomer[], byPeriod[]}' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/hours': {
             get: {
                 summary: 'Hours summary grouped by customer, job, and worker',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -11,8 +11,10 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
+const money = require('../services/money.js');
 const { buildUnbilled } = require('../services/report-unbilled.js');
 const { buildHours } = require('../services/report-hours.js');
+const { buildRevenue } = require('../services/report-revenue.js');
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
@@ -197,6 +199,68 @@ exports.hours = async (req, res) => {
 
     const report = buildHours(items);
     return res.status(200).json({ message: "Hours summary.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/revenue — revenue (invoiced) and collected (paid)
+ * summary, grouped by customer and by month, with outstanding. Covers
+ * the company's invoices; optional customerId and from/to (invoice
+ * date) filters.
+ */
+exports.revenue = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const invWhere = {};
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) invWhere.invCustId = customerId;
+    const from = String(req.query.from || '');
+    const to = String(req.query.to || '');
+    if (Op && /^\d{4}-\d{2}-\d{2}$/.test(from)) invWhere.invDate = Object.assign(invWhere.invDate || {}, { [Op.gte]: from });
+    if (Op && /^\d{4}-\d{2}-\d{2}$/.test(to)) invWhere.invDate = Object.assign(invWhere.invDate || {}, { [Op.lte]: to });
+
+    let invoices;
+    try {
+        invoices = await db.Invoice.findAll({
+            where: invWhere,
+            include: [
+                {
+                    model: db.Customer, as: 'customer', required: true,
+                    where: { custCompId: companyId },
+                    attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
+                },
+                { model: db.CustomerPayment, as: 'payments', required: false },
+            ],
+            order: [['invDate', 'ASC']],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'revenue report: Invoice.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const items = invoices.map((inv) => {
+        const c = inv.customer;
+        return {
+            custId: inv.invCustId,
+            custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
+            invDate: inv.invDate,
+            total: inv.invTotal,
+            collected: money.sum((inv.payments || []).map((p) => p.cpayAmount)),
+        };
+    });
+
+    const report = buildRevenue(items);
+    return res.status(200).json({ message: "Revenue summary.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -670,5 +670,10 @@ router.get(
     v.query(reportSchemas.hoursQuery),
     report.hours,
 );
+router.get(
+    '/v1/report/revenue',
+    v.query(reportSchemas.revenueQuery),
+    report.revenue,
+);
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -36,4 +36,17 @@ const hoursQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, workerId, from, to.',
 });
 
-module.exports = { unbilledQuery, hoursQuery };
+/**
+ * GET /v1/report/revenue query. companyId required for master keys.
+ * Optional customerId filter and from/to (invoice date) bounds.
+ */
+const revenueQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery };

--- a/app/services/report-revenue.js
+++ b/app/services/report-revenue.js
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-revenue.js — revenue & earnings summary (#429). Revenue is
+ * what's been invoiced (invoice total); "collected" is what's been paid
+ * against those invoices; outstanding is the difference. Grouped by
+ * customer and by month.
+ *
+ * PURE: the caller loads the invoices (with each invoice's total and the
+ * sum of its allocated payments); this does exact-money aggregation. No
+ * DB.
+ */
+
+const money = require('./money.js');
+
+/** 'YYYY-MM' period from a 'YYYY-MM-DD' invoice date. */
+function periodOf(invDate) {
+    return typeof invDate === 'string' && /^\d{4}-\d{2}/.test(invDate) ? invDate.slice(0, 7) : 'unknown';
+}
+
+/**
+ * @param invoices array of { custId, custName, invDate, total, collected }.
+ *   total / collected may be null (treated as 0).
+ * @returns totals + byCustomer / byPeriod breakdowns.
+ */
+function buildRevenue(invoices) {
+    const byCust = new Map();
+    const byPeriod = new Map();
+    const allRevenue = [];
+    const allCollected = [];
+
+    for (const inv of invoices || []) {
+        const revenue = inv.total == null ? 0 : Number(inv.total);
+        const collected = inv.collected == null ? 0 : Number(inv.collected);
+        allRevenue.push(revenue);
+        allCollected.push(collected);
+
+        let c = byCust.get(inv.custId);
+        if (!c) { c = { custId: inv.custId, custName: inv.custName || null, count: 0, revenue: [], collected: [] }; byCust.set(inv.custId, c); }
+        c.count += 1; c.revenue.push(revenue); c.collected.push(collected);
+
+        const p = periodOf(inv.invDate);
+        let g = byPeriod.get(p);
+        if (!g) { g = { period: p, count: 0, revenue: [], collected: [] }; byPeriod.set(p, g); }
+        g.count += 1; g.revenue.push(revenue); g.collected.push(collected);
+    }
+
+    const byCustomer = Array.from(byCust.values()).map((c) => {
+        const revenue = money.sum(c.revenue);
+        const collected = money.sum(c.collected);
+        return {
+            custId: c.custId, custName: c.custName, invoiceCount: c.count,
+            revenue, collected, outstanding: money.subtract(revenue, collected),
+        };
+    }).sort((a, b) => a.custId - b.custId);
+
+    const byPeriodRows = Array.from(byPeriod.values()).map((g) => ({
+        period: g.period, invoiceCount: g.count,
+        revenue: money.sum(g.revenue), collected: money.sum(g.collected),
+    })).sort((a, b) => (a.period < b.period ? -1 : a.period > b.period ? 1 : 0));
+
+    const totalRevenue = money.sum(allRevenue);
+    const totalCollected = money.sum(allCollected);
+    return {
+        invoiceCount: (invoices || []).length,
+        totalRevenue,
+        totalCollected,
+        totalOutstanding: money.subtract(totalRevenue, totalCollected),
+        byCustomer,
+        byPeriod: byPeriodRows,
+    };
+}
+
+module.exports = { buildRevenue, periodOf };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -43,4 +43,10 @@ describe('Report auth + schema contract', () => {
     test('GET /v1/report/hours rejects an unknown query param (schema)', async () => {
         expect((await request(app).get('/v1/report/hours?bogus=1').set('authKey', 'k')).status).toBe(400);
     });
+    test('GET /v1/report/revenue 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/revenue')).status).toBe(403);
+    });
+    test('GET /v1/report/revenue rejects an unknown query param (schema)', async () => {
+        expect((await request(app).get('/v1/report/revenue?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/unit/report-revenue.test.js
+++ b/tests/unit/report-revenue.test.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the revenue summary (app/services/report-revenue.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildRevenue, periodOf } = require('../../app/services/report-revenue.js');
+
+const inv = (custId, custName, invDate, total, collected) => ({ custId, custName, invDate, total, collected });
+
+describe('report-revenue.periodOf', () => {
+    test('extracts YYYY-MM', () => {
+        expect(periodOf('2026-07-05')).toBe('2026-07');
+        expect(periodOf(null)).toBe('unknown');
+    });
+});
+
+describe('report-revenue.buildRevenue', () => {
+    test('totals revenue, collected, and outstanding exactly', () => {
+        const r = buildRevenue([
+            inv(1, 'A', '2026-06-01', 100, 100),   // paid
+            inv(1, 'A', '2026-07-01', 200, 50),    // partial
+            inv(2, 'B', '2026-07-15', 33.33, 0),
+        ]);
+        expect(r.invoiceCount).toBe(3);
+        expect(r.totalRevenue).toBe(333.33);
+        expect(r.totalCollected).toBe(150);
+        expect(r.totalOutstanding).toBe(183.33);
+    });
+
+    test('groups by customer (with outstanding) and by month', () => {
+        const r = buildRevenue([
+            inv(1, 'A', '2026-06-10', 100, 40),
+            inv(1, 'A', '2026-07-10', 200, 200),
+            inv(2, 'B', '2026-07-20', 50, 0),
+        ]);
+        expect(r.byCustomer).toEqual([
+            { custId: 1, custName: 'A', invoiceCount: 2, revenue: 300, collected: 240, outstanding: 60 },
+            { custId: 2, custName: 'B', invoiceCount: 1, revenue: 50, collected: 0, outstanding: 50 },
+        ]);
+        expect(r.byPeriod).toEqual([
+            { period: '2026-06', invoiceCount: 1, revenue: 100, collected: 40 },
+            { period: '2026-07', invoiceCount: 2, revenue: 250, collected: 200 },
+        ]);
+    });
+
+    test('null totals count as zero; empty input → zeros', () => {
+        const r = buildRevenue([inv(1, 'A', '2026-07-01', null, null)]);
+        expect(r.totalRevenue).toBe(0);
+        expect(buildRevenue([]).totalRevenue).toBe(0);
+        expect(buildRevenue([]).byCustomer).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

`GET /v1/report/revenue` — what you invoiced, what you collected, what's still out.

Closes #429.

## Changes

- **`app/services/report-revenue.js`** (pure) — from the company's invoices, sums **revenue** (invoice total) and **collected** (allocated payments), grouped **by customer** (with outstanding) and **by month** (`YYYY-MM` of the invoice date), plus company-wide totals. Exact-cent throughout; null totals count as zero.
- **`GET /v1/report/revenue`** on the `report` controller — company-scoped (master passes `?companyId`), with optional `customerId` and `from`/`to` (invoice date) filters.

## Verification

`npm run lint` clean; `npm test` → 937 passing (revenue grouping by customer + month, outstanding math, null handling; route auth + schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/