### PR TITLE
feat(invoicing): sales tax on invoices (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Invoice sales tax** (#420). A per-company default tax rate
+  (`compTaxRate`, a fraction like `0.0725`) plus a per-invoice effective
+  rate (`invTaxRate`), migration `20260527000000`. The time→invoice
+  roll-up now applies tax to the subtotal — `taxRate` in the roll-up body
+  overrides, else the company default, else 0 — setting `invTax` and
+  `invTotal = subtotal + tax` (exact-cent). `compTaxRate` is settable via
+  company create/PATCH. New pure `app/services/invoice-tax.js`.
 - **Revenue & earnings summary** (#429) — `GET /v1/report/revenue`.
   Revenue (invoiced total) and collected (payments allocated) grouped by
   customer and by month, with outstanding per group and company totals,

--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -26,7 +26,7 @@ const GetCompanyId = auth.getCompanyId;
 const ALLOWED_FIELDS_CREATE = [
     'compName', 'compAddress1', 'compAddress2', 'compCity',
     'compState', 'compZip', 'compPhone', 'compEmail',
-    'compInvPrefix', 'compInvPad', 'compInvNextSeq',
+    'compInvPrefix', 'compInvPad', 'compInvNextSeq', 'compTaxRate',
 ];
 const ALLOWED_FIELDS_UPDATE = ALLOWED_FIELDS_CREATE;
 

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -13,6 +13,7 @@ const invoiceStatus = require('../services/invoice-status.js');
 const invoiceNumber = require('../services/invoice-number.js');
 const { renderInvoicePdf } = require('../services/invoice-pdf.js');
 const { buildAging } = require('../services/invoice-aging.js');
+const invoiceTax = require('../services/invoice-tax.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -351,7 +352,19 @@ exports.rollup = async (req, res) => {
 
     const invDate = req.body.invDate || todayISO();
     const invDueDate = req.body.invDueDate || addDaysISO(invDate, 30);
-    const tax = 0;
+    // Effective tax rate: explicit body override → company default → 0.
+    let companyDefaultRate = 0;
+    if (req.body.taxRate == null) {
+        try {
+            const company = await db.Company.findByPk(custCompanyId, { attributes: ['compTaxRate'] });
+            companyDefaultRate = company ? company.compTaxRate : 0;
+        } catch (error) {
+            log.error({ err: error }, 'rollup: company tax-rate lookup failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+    }
+    const taxRate = invoiceTax.resolveRate({ override: req.body.taxRate, companyDefault: companyDefaultRate });
+    const tax = invoiceTax.computeTax(subtotal, taxRate);
     const total = money.add(subtotal, tax);
 
     let result;
@@ -368,6 +381,7 @@ exports.rollup = async (req, res) => {
                 invSubtotal: subtotal,
                 invTax: tax,
                 invTotal: total,
+                invTaxRate: taxRate,
             }, { transaction: t });
 
             const createdLines = [];

--- a/app/migrations/20260527000000-invoice-tax.js
+++ b/app/migrations/20260527000000-invoice-tax.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Sales tax (#420). Adds a per-company default tax rate (compTaxRate)
+// and a per-invoice effective-rate column (invTaxRate). Rates are
+// fractions stored as NUMERIC(6,4) — e.g. 0.0725 for 7.25%.
+//
+// compTaxRate is NOT NULL default 0 so existing companies simply charge
+// no tax until configured. invTaxRate is nullable: invoices created
+// before this migration (and un-rolled-up drafts) have no rate recorded.
+// setup/*.sql (frozen original schema) untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const COMPANY = { tableName: 'Company', schema: SCHEMA };
+const INVOICE = { tableName: 'Invoice', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                COMPANY, 'compTaxRate',
+                { type: Sequelize.DECIMAL(6, 4), allowNull: false, defaultValue: 0 },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                INVOICE, 'invTaxRate',
+                { type: Sequelize.DECIMAL(6, 4), allowNull: true },
+                { transaction: t },
+            );
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeColumn(INVOICE, 'invTaxRate', { transaction: t });
+            await queryInterface.removeColumn(COMPANY, 'compTaxRate', { transaction: t });
+        });
+    },
+};

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -36,6 +36,18 @@ module.exports = (sequelize, Sequelize) => {
         compInvPrefix:  { field: 'compInvPrefix',  type: Sequelize.TEXT,    allowNull: false, defaultValue: 'INV-' },
         compInvPad:     { field: 'compInvPad',     type: Sequelize.INTEGER, allowNull: false, defaultValue: 4 },
         compInvNextSeq: { field: 'compInvNextSeq', type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+        // Default sales-tax rate as a fraction (e.g. 0.0725 = 7.25%),
+        // #420. pg returns NUMERIC as a string; getter hands out a Number.
+        compTaxRate: {
+            field: 'compTaxRate',
+            type: Sequelize.DECIMAL(6, 4),
+            allowNull: false,
+            defaultValue: 0,
+            get() {
+                const v = this.getDataValue('compTaxRate');
+                return v == null ? 0 : Number(v);
+            },
+        },
         compArch: {
             field: 'compArch',
             type: Sequelize.BOOLEAN,

--- a/app/models/invoice.model.js
+++ b/app/models/invoice.model.js
@@ -79,6 +79,16 @@ module.exports = (sequelize, Sequelize) => {
             // numbering existed.
             type: Sequelize.TEXT,
         },
+        invTaxRate: {
+            field: 'invTaxRate',
+            // Effective tax rate (fraction) applied when this invoice was
+            // totalled (#420). Number getter; null until totalled.
+            type: Sequelize.DECIMAL(6, 4),
+            get() {
+                const v = this.getDataValue('invTaxRate');
+                return v == null ? null : Number(v);
+            },
+        },
     }, {
         tableName: 'Invoice',
         timestamps: true,

--- a/app/schemas/company.schema.js
+++ b/app/schemas/company.schema.js
@@ -14,8 +14,9 @@ const invNumberingFields = {
     compInvPrefix: z.string().max(16).optional(),
     compInvPad: z.coerce.number().int().min(0).max(12).optional(),
     compInvNextSeq: z.coerce.number().int().positive().optional(),
+    compTaxRate: z.coerce.number().min(0).max(1).optional(),
 };
-const NUMBERING_WHITELIST = ', compInvPrefix, compInvPad, compInvNextSeq';
+const NUMBERING_WHITELIST = ', compInvPrefix, compInvPad, compInvNextSeq, compTaxRate';
 
 const createCompanyBody = z.object({
     compName: z.string().min(1).max(255),

--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -82,8 +82,11 @@ const rollupInvoiceBody = z.object({
     invDueDate: isoDate.optional(),
     from: isoDate.optional(),
     to: isoDate.optional(),
+    // Optional tax-rate override (fraction 0..1); defaults to the
+    // company's compTaxRate.
+    taxRate: z.coerce.number().min(0).max(1).optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, from, to.',
+    message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, from, to, taxRate.',
 }).refine(refineDueDateAfterIssue, DUE_BEFORE_ISSUE);
 
 // GET /v1/invoice/aging query. companyId required for master keys

--- a/app/services/invoice-tax.js
+++ b/app/services/invoice-tax.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invoice-tax.js — sales-tax computation for invoices (#420).
+ *
+ * A tax rate is a fraction (0.0725 = 7.25%). The effective rate for an
+ * invoice is: an explicit per-invoice override → the company's default
+ * (compTaxRate) → 0. Tax is the subtotal times the rate, rounded to the
+ * cent through money.js so the printed tax + total never drift.
+ *
+ * PURE: no DB.
+ */
+
+const money = require('./money.js');
+
+/** Coerce a tax rate to a sane fraction in [0, 1]. Bad input → 0. */
+function normalizeRate(rate) {
+    const n = typeof rate === 'string' ? Number(rate) : rate;
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return 0;
+    return n > 1 ? 1 : n;
+}
+
+/** tax = subtotal × rate, rounded to the cent. */
+function computeTax(subtotal, rate) {
+    return money.multiply(subtotal == null ? 0 : subtotal, normalizeRate(rate));
+}
+
+/**
+ * The effective rate for an invoice: explicit override first, else the
+ * company default, else 0. Any of the inputs may be null/undefined.
+ */
+function resolveRate({ override, companyDefault }) {
+    if (override != null) return normalizeRate(override);
+    if (companyDefault != null) return normalizeRate(companyDefault);
+    return 0;
+}
+
+module.exports = { normalizeRate, computeTax, resolveRate };

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -164,12 +164,12 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('invoice-numbering columns exist (Company config + Invoice.invNumber)', async () => {
         if (!connected) return;
         const companies = await db.Company.findAll({
-            attributes: ['compId', 'compInvPrefix', 'compInvPad', 'compInvNextSeq'],
+            attributes: ['compId', 'compInvPrefix', 'compInvPad', 'compInvNextSeq', 'compTaxRate'],
             limit: 1,
         });
         expect(Array.isArray(companies)).toBe(true);
         const invoices = await db.Invoice.findAll({
-            attributes: ['invId', 'invNumber'],
+            attributes: ['invId', 'invNumber', 'invTaxRate'],
             limit: 1,
         });
         expect(Array.isArray(invoices)).toBe(true);

--- a/tests/unit/invoice-tax.test.js
+++ b/tests/unit/invoice-tax.test.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for invoice tax (app/services/invoice-tax.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { normalizeRate, computeTax, resolveRate } = require('../../app/services/invoice-tax.js');
+
+describe('invoice-tax.normalizeRate', () => {
+    test('passes fractions through, clamps out-of-range, zeroes junk', () => {
+        expect(normalizeRate(0.0725)).toBe(0.0725);
+        expect(normalizeRate('0.1')).toBe(0.1);
+        expect(normalizeRate(0)).toBe(0);
+        expect(normalizeRate(-1)).toBe(0);
+        expect(normalizeRate(2)).toBe(1);
+        expect(normalizeRate(NaN)).toBe(0);
+        expect(normalizeRate(null)).toBe(0);
+    });
+});
+
+describe('invoice-tax.computeTax', () => {
+    test('tax = subtotal × rate, rounded to the cent', () => {
+        expect(computeTax(100, 0.0725)).toBe(7.25);
+        expect(computeTax(19.99, 0.1)).toBe(2); // 1.999 → 2.00
+        expect(computeTax(200, 0)).toBe(0);
+        expect(computeTax(null, 0.1)).toBe(0);
+    });
+});
+
+describe('invoice-tax.resolveRate', () => {
+    test('override wins, then company default, then 0', () => {
+        expect(resolveRate({ override: 0.05, companyDefault: 0.0725 })).toBe(0.05);
+        expect(resolveRate({ override: null, companyDefault: 0.0725 })).toBe(0.0725);
+        expect(resolveRate({ override: null, companyDefault: null })).toBe(0);
+        expect(resolveRate({ override: 0 })).toBe(0); // explicit zero override is honored
+    });
+});


### PR DESCRIPTION
## Summary

Invoices can now carry sales tax.

Closes #420.

## Changes

- **Migration `20260527000000`** — `Company.compTaxRate` (NUMERIC(6,4), NOT NULL default `0`) and `Invoice.invTaxRate` (nullable). Rates are fractions (`0.0725` = 7.25%). `setup/*.sql` untouched.
- **`app/services/invoice-tax.js`** (pure) — `computeTax(subtotal, rate)` = `subtotal × rate` rounded to the cent via `money.js`; `resolveRate` (override → company default → 0); rate normalize/clamp to `[0, 1]`.
- **Roll-up** — `POST /v1/invoice/rollup` now applies tax: `taxRate` in the body overrides, else the company default, else 0. Sets `invTax`, `invTotal = subtotal + tax`, and records the effective `invTaxRate`.
- **`compTaxRate`** settable via company create/PATCH (bounded `0..1`).

## Note

Per-invoice tax rate (this) covers the time-based flow; per-line taxable flags (honoring `ProductEntry.pentTaxable` for product invoicing) remain a follow-up.

## Verification

`npm run lint` clean; `npm test` → 943 passing (rate normalize/clamp, exact-cent tax, resolve precedence; integration column checks). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/