### PR TITLE
feat(expenses): billable expenses with markup (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Billable expenses with markup** (#417). `expBillable` marks an
+  expense re-billable to the client; `expMarkupPct` (a fraction, e.g.
+  `0.15`) marks it up over cost. New pure `app/services/expense-billing.js`
+  computes the client-facing amount (0 if non-billable, else
+  `cost × (1 + markup)`, exact-cent), surfaced as `billing.billableAmount`
+  on `GET /v1/expense/{id}`. Both settable via create/PATCH; migration
+  `20260530000000`. Sets up the expense→invoice roll-up (#418).
 - **Expense entity + CRUD** (#416). A new `Expense` model (amount,
   category, description, date) scoped to a company (`expCompId`) and
   optionally linked to a customer (`expCustId`) and job (`expJobId`),

--- a/app/controllers/expensecontroller.js
+++ b/app/controllers/expensecontroller.js
@@ -6,6 +6,7 @@ const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
+const { billableAmount } = require('../services/expense-billing.js');
 const Expense = db.Expense;
 
 const IsMaster = auth.isMaster;
@@ -13,9 +14,11 @@ const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
     'expCustId', 'expJobId', 'expCategory', 'expDescription', 'expDate', 'expAmount',
+    'expBillable', 'expMarkupPct',
 ];
 const ALLOWED_FIELDS_UPDATE = [
     'expCustId', 'expJobId', 'expCategory', 'expDescription', 'expDate', 'expAmount',
+    'expBillable', 'expMarkupPct',
 ];
 
 const isISODate = (s) => typeof s === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(s);
@@ -141,7 +144,13 @@ exports.getById = async (req, res) => {
             return res.status(404).json({ message: "Not found." });
         }
     }
-    return res.status(200).json({ message: "Found.", expense });
+    // Computed billing view: what the client would be charged for this
+    // expense (0 if not billable, else cost × (1 + markup)). Derived.
+    return res.status(200).json({
+        message: "Found.",
+        expense,
+        billing: { billableAmount: billableAmount(expense) },
+    });
 };
 
 /**

--- a/app/migrations/20260530000000-expense-billable-markup.js
+++ b/app/migrations/20260530000000-expense-billable-markup.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Billable expenses with markup (#417). expBillable marks an expense as
+// re-billable to the client; expMarkupPct is the markup fraction applied
+// on top of cost (0.15 = +15%). expBillable defaults false (existing
+// expenses aren't re-billed until opted in); expMarkupPct is nullable
+// (NULL = bill at cost). setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const EXPENSE = { tableName: 'Expense', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                EXPENSE, 'expBillable',
+                { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                EXPENSE, 'expMarkupPct',
+                { type: Sequelize.DECIMAL(6, 4), allowNull: true },
+                { transaction: t },
+            );
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeColumn(EXPENSE, 'expMarkupPct', { transaction: t });
+            await queryInterface.removeColumn(EXPENSE, 'expBillable', { transaction: t });
+        });
+    },
+};

--- a/app/models/expense.model.js
+++ b/app/models/expense.model.js
@@ -55,6 +55,22 @@ module.exports = (sequelize, Sequelize) => {
                 return v == null ? null : Number(v);
             },
         },
+        expBillable: {
+            field: 'expBillable',
+            // Re-billable to the client? (#417)
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+        },
+        expMarkupPct: {
+            field: 'expMarkupPct',
+            // Markup fraction on top of cost (0.15 = +15%); null = at cost.
+            type: Sequelize.DECIMAL(6, 4),
+            get() {
+                const v = this.getDataValue('expMarkupPct');
+                return v == null ? null : Number(v);
+            },
+        },
         expArch: {
             field: 'expArch',
             type: Sequelize.BOOLEAN,

--- a/app/schemas/expense.schema.js
+++ b/app/schemas/expense.schema.js
@@ -29,10 +29,12 @@ const createExpenseBody = z.object({
     expJobId: z.coerce.number().int().positive().optional(),
     expCategory: z.string().max(255).optional(),
     expDescription: z.string().max(10000).optional(),
+    expBillable: z.boolean().optional(),
+    expMarkupPct: z.coerce.number().min(0).optional(),
     expDate: isoDate,
     expAmount: expAmountField,
 }).strict({
-    message: 'Unexpected field in body. Whitelist: expCompId, expCustId, expJobId, expCategory, expDescription, expDate, expAmount.',
+    message: 'Unexpected field in body. Whitelist: expCompId, expCustId, expJobId, expCategory, expDescription, expBillable, expMarkupPct, expDate, expAmount.',
 });
 
 /**
@@ -44,10 +46,12 @@ const updateExpenseBody = z.object({
     expJobId: z.coerce.number().int().positive().nullable().optional(),
     expCategory: z.string().max(255).nullable().optional(),
     expDescription: z.string().max(10000).nullable().optional(),
+    expBillable: z.boolean().optional(),
+    expMarkupPct: z.coerce.number().min(0).nullable().optional(),
     expDate: isoDate.optional(),
     expAmount: expAmountField.optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: expCustId, expJobId, expCategory, expDescription, expDate, expAmount.',
+    message: 'Unexpected field in body. Whitelist: expCustId, expJobId, expCategory, expDescription, expBillable, expMarkupPct, expDate, expAmount.',
 });
 
 const listByCompanyQuery = z.object({

--- a/app/services/expense-billing.js
+++ b/app/services/expense-billing.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * expense-billing.js — what to charge a client for an expense (#417).
+ *
+ * A billable expense is re-billed at cost, optionally with a percentage
+ * markup (expMarkupPct, a fraction: 0.15 = +15%). Non-billable expenses
+ * bill nothing. Exact-cent through money.js.
+ *
+ * PURE: no DB.
+ */
+
+const money = require('./money.js');
+
+/** Coerce a markup fraction to a sane non-negative number. Bad → 0. */
+function normalizeMarkup(pct) {
+    const n = typeof pct === 'string' ? Number(pct) : pct;
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return 0;
+    return n;
+}
+
+/**
+ * Amount to bill the client for an expense: 0 when not billable, else
+ * cost × (1 + markup) rounded to the cent. null when the cost is unknown.
+ * @param expense { expBillable, expAmount, expMarkupPct }
+ */
+function billableAmount(expense) {
+    if (!expense || !expense.expBillable) return 0;
+    if (expense.expAmount == null) return null;
+    return money.multiply(expense.expAmount, 1 + normalizeMarkup(expense.expMarkupPct));
+}
+
+module.exports = { normalizeMarkup, billableAmount };

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -180,7 +180,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         // Selecting the columns proves the 20260529 migration created the
         // table; a missing column/table would throw here.
         const rows = await db.Expense.findAll({
-            attributes: ['expId', 'expCompId', 'expCustId', 'expJobId', 'expAmount', 'expDate'],
+            attributes: ['expId', 'expCompId', 'expCustId', 'expJobId', 'expAmount', 'expDate', 'expBillable', 'expMarkupPct'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/expense-billing.test.js
+++ b/tests/unit/expense-billing.test.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for expense billing (app/services/expense-billing.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { normalizeMarkup, billableAmount } = require('../../app/services/expense-billing.js');
+
+describe('expense-billing.normalizeMarkup', () => {
+    test('passes non-negative through, coerces strings, zeroes junk', () => {
+        expect(normalizeMarkup(0.15)).toBe(0.15);
+        expect(normalizeMarkup('0.2')).toBe(0.2);
+        expect(normalizeMarkup(1.5)).toBe(1.5); // >100% markup is allowed
+        expect(normalizeMarkup(0)).toBe(0);
+        expect(normalizeMarkup(-0.1)).toBe(0);
+        expect(normalizeMarkup(NaN)).toBe(0);
+        expect(normalizeMarkup(null)).toBe(0);
+    });
+});
+
+describe('expense-billing.billableAmount', () => {
+    test('non-billable → 0 regardless of markup', () => {
+        expect(billableAmount({ expBillable: false, expAmount: 100, expMarkupPct: 0.15 })).toBe(0);
+    });
+    test('billable at cost when markup is absent/zero', () => {
+        expect(billableAmount({ expBillable: true, expAmount: 100, expMarkupPct: null })).toBe(100);
+        expect(billableAmount({ expBillable: true, expAmount: 100, expMarkupPct: 0 })).toBe(100);
+    });
+    test('billable with markup, rounded to the cent', () => {
+        expect(billableAmount({ expBillable: true, expAmount: 100, expMarkupPct: 0.15 })).toBe(115);
+        expect(billableAmount({ expBillable: true, expAmount: 19.99, expMarkupPct: 0.1 })).toBe(21.99);
+    });
+    test('null cost → null', () => {
+        expect(billableAmount({ expBillable: true, expAmount: null, expMarkupPct: 0.1 })).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Mark an expense re-billable and (optionally) mark it up before it goes on the client's invoice.

Closes #417.

## Changes

- **Migration `20260530000000`** — `Expense.expBillable` (BOOLEAN, NOT NULL default `false`) and `Expense.expMarkupPct` (NUMERIC(6,4), nullable — a fraction, `0.15` = +15%).
- **`app/services/expense-billing.js`** (pure) — `billableAmount(expense)` = `0` when not billable, else `cost × (1 + markup)` rounded to the cent via `money.js`; `null` if the cost is unknown. `normalizeMarkup` clamps to `≥ 0`.
- **Surfaced** as `billing.billableAmount` on `GET /v1/expense/{id}` (derived, not stored). Both fields settable via create/PATCH.

## Next

#418 rolls billable, un-invoiced expenses into an invoice using exactly this amount.

## Verification

`npm run lint` clean; `npm test` → 969 passing (markup math + rounding, non-billable → 0, null cost; markup normalize; integration column check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/