### PR TITLE
feat(expenses): roll expenses into invoices (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Expenses roll into invoices** (#418). `POST /v1/invoice/rollup` now
+  takes `includeExpenses: true` — the customer's billable, un-invoiced
+  expenses are priced (cost + markup) and added to the invoice subtotal
+  alongside billed time, then stamped `expInvId` in the same transaction
+  so they're marked invoiced and won't re-roll (mirrors
+  `TimeEntry.teInvJobId`). An invoice can now be expenses-only. New pure
+  `app/services/expense-rollup.js`; migration `20260531000000` adds the
+  link column + index; `Invoice`↔`Expense` association.
 - **Billable expenses with markup** (#417). `expBillable` marks an
   expense re-billable to the client; `expMarkupPct` (a fraction, e.g.
   `0.15`) marks it up over cost. New pure `app/services/expense-billing.js`

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -177,5 +177,9 @@ db.Customer.hasMany(db.Expense,   { foreignKey: 'expCustId', as: 'expenses' });
 db.Expense.belongsTo(db.Customer, { foreignKey: 'expCustId', as: 'customer' });
 db.Job.hasMany(db.Expense,        { foreignKey: 'expJobId',  as: 'expenses' });
 db.Expense.belongsTo(db.Job,      { foreignKey: 'expJobId',  as: 'job' });
+// Expense → Invoice (expInvId): the invoice a billable expense was rolled
+// into (#418); doubles as the "invoiced" marker (NULL = unbilled).
+db.Invoice.hasMany(db.Expense,    { foreignKey: 'expInvId',  as: 'expenses' });
+db.Expense.belongsTo(db.Invoice,  { foreignKey: 'expInvId',  as: 'invoice' });
 
 module.exports = db;

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -14,6 +14,7 @@ const invoiceNumber = require('../services/invoice-number.js');
 const { renderInvoicePdf } = require('../services/invoice-pdf.js');
 const { buildAging } = require('../services/invoice-aging.js');
 const invoiceTax = require('../services/invoice-tax.js');
+const { buildExpenseRollup } = require('../services/expense-rollup.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -337,15 +338,36 @@ exports.rollup = async (req, res) => {
         return res.status(500).json({ message: "Error!" });
     }
 
-    const { lines, subtotal, skipped } = buildRollup(entries);
+    const { lines, subtotal: timeSubtotal, skipped } = buildRollup(entries);
     const skippedCounts = {
         nonBillable: skipped.nonBillable.length,
         noJob: skipped.noJob.length,
         unresolvedRate: skipped.unresolvedRate.length,
     };
-    if (lines.length === 0) {
+
+    // Optionally roll the customer's billable, un-invoiced expenses in too
+    // (#418). Same date window as the time filter.
+    let expenseRollup = { lines: [], subtotal: 0, skipped: { nonBillable: [] } };
+    if (req.body.includeExpenses) {
+        const expWhere = { expCustId: custId, expBillable: true, expInvId: null };
+        if (Op && from) expWhere.expDate = Object.assign(expWhere.expDate || {}, { [Op.gte]: req.body.from });
+        if (Op && to) expWhere.expDate = Object.assign(expWhere.expDate || {}, { [Op.lte]: req.body.to });
+        let expenseRows;
+        try {
+            expenseRows = await db.Expense.findAll({ where: expWhere });
+        } catch (error) {
+            log.error({ err: error }, 'rollup: Expense.findAll failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        expenseRollup = buildExpenseRollup(expenseRows);
+    }
+
+    // Combined pre-discount subtotal: billable time + billable expenses.
+    const subtotal = money.add(timeSubtotal, expenseRollup.subtotal);
+
+    if (lines.length === 0 && expenseRollup.lines.length === 0) {
         return res.status(400).json({
-            message: "No billable, uninvoiced, job-linked time to roll up for this customer.",
+            message: "No billable, uninvoiced time or expenses to roll up for this customer.",
             skipped: skippedCounts,
         });
     }
@@ -414,6 +436,15 @@ exports.rollup = async (req, res) => {
                     entryCount: line.entryIds.length,
                 });
             }
+            // Attach rolled expenses to this invoice — stamping expInvId
+            // both links them and marks them invoiced (won't re-roll).
+            const expenseIds = expenseRollup.lines.map((l) => l.expId);
+            if (expenseIds.length) {
+                await db.Expense.update(
+                    { expInvId: invoice.invId },
+                    { where: { expId: expenseIds }, transaction: t },
+                );
+            }
             return { invoice, createdLines };
         });
     } catch (error) {
@@ -425,6 +456,11 @@ exports.rollup = async (req, res) => {
         message: "Invoice generated from time.",
         invoice: result.invoice,
         lines: result.createdLines,
+        expenses: {
+            count: expenseRollup.lines.length,
+            subtotal: expenseRollup.subtotal,
+            lines: expenseRollup.lines,
+        },
         subtotal,
         tax,
         total,

--- a/app/migrations/20260531000000-expense-invoice-link.js
+++ b/app/migrations/20260531000000-expense-invoice-link.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Expense → invoice link (#418). expInvId records the invoice a billable
+// expense was rolled into by the time/expense roll-up; NULL = not yet
+// invoiced (the "unbilled" marker, mirroring TimeEntry.teInvJobId). A
+// plain nullable INTEGER — no physical FK, enforced at the app layer.
+// The index backs the "billable, un-invoiced expenses for a customer"
+// query. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const EXPENSE = { tableName: 'Expense', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                EXPENSE, 'expInvId',
+                { type: Sequelize.INTEGER, allowNull: true },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(EXPENSE, {
+                name: 'Expense_custId_invId_idx',
+                fields: ['expCustId', 'expInvId'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeIndex(EXPENSE, 'Expense_custId_invId_idx', { transaction: t });
+            await queryInterface.removeColumn(EXPENSE, 'expInvId', { transaction: t });
+        });
+    },
+};

--- a/app/models/expense.model.js
+++ b/app/models/expense.model.js
@@ -71,6 +71,11 @@ module.exports = (sequelize, Sequelize) => {
                 return v == null ? null : Number(v);
             },
         },
+        expInvId: {
+            field: 'expInvId',
+            // Invoice this expense was rolled into (#418); null = unbilled.
+            type: Sequelize.INTEGER,
+        },
         expArch: {
             field: 'expArch',
             type: Sequelize.BOOLEAN,

--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -89,8 +89,11 @@ const rollupInvoiceBody = z.object({
     taxRate: z.coerce.number().min(0).max(1).optional(),
     // Optional discount applied to the subtotal before tax (>= 0).
     discount: z.coerce.number().min(0).optional(),
+    // Also roll the customer's billable, un-invoiced expenses into this
+    // invoice (#418).
+    includeExpenses: z.boolean().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, from, to, taxRate, discount.',
+    message: 'Unexpected field in body. Whitelist: invCustId, invDate, invDueDate, from, to, taxRate, discount, includeExpenses.',
 }).refine(refineDueDateAfterIssue, DUE_BEFORE_ISSUE);
 
 // GET /v1/invoice/aging query. companyId required for master keys

--- a/app/services/expense-rollup.js
+++ b/app/services/expense-rollup.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * expense-rollup.js — turn billable, un-invoiced expenses into invoice
+ * charges (#418). Each billable expense contributes its client-facing
+ * amount (cost × (1 + markup), from expense-billing) to the invoice.
+ *
+ * PURE: the caller loads the billable, un-invoiced expenses; this prices
+ * and sums them exactly. No DB.
+ */
+
+const money = require('./money.js');
+const { billableAmount } = require('./expense-billing.js');
+
+/**
+ * @param expenses array of Expense-shaped { expId, expBillable, expAmount,
+ *   expMarkupPct, expCategory, expDescription }.
+ * @returns { lines, subtotal, skipped } — lines[] = { expId, category,
+ *   description, amount }; skipped.nonBillable = ids with no billable
+ *   amount.
+ */
+function buildExpenseRollup(expenses) {
+    const lines = [];
+    const amounts = [];
+    const skipped = { nonBillable: [] };
+
+    for (const e of expenses || []) {
+        const amount = billableAmount(e);
+        // billableAmount is 0 for non-billable and null for unknown cost;
+        // neither belongs on an invoice.
+        if (amount == null || amount <= 0) {
+            skipped.nonBillable.push(e.expId);
+            continue;
+        }
+        lines.push({
+            expId: e.expId,
+            category: e.expCategory || null,
+            description: e.expDescription || null,
+            amount,
+        });
+        amounts.push(amount);
+    }
+
+    return { lines, subtotal: money.sum(amounts), skipped };
+}
+
+module.exports = { buildExpenseRollup };

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -180,7 +180,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         // Selecting the columns proves the 20260529 migration created the
         // table; a missing column/table would throw here.
         const rows = await db.Expense.findAll({
-            attributes: ['expId', 'expCompId', 'expCustId', 'expJobId', 'expAmount', 'expDate', 'expBillable', 'expMarkupPct'],
+            attributes: ['expId', 'expCompId', 'expCustId', 'expJobId', 'expAmount', 'expDate', 'expBillable', 'expMarkupPct', 'expInvId'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);
@@ -191,6 +191,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
                 { model: db.Customer, as: 'customer', required: false },
                 { model: db.Job, as: 'job', required: false },
                 { model: db.Company, as: 'company', required: false },
+                { model: db.Invoice, as: 'invoice', required: false },
             ],
         });
         expect(Array.isArray(withLinks)).toBe(true);

--- a/tests/unit/expense-rollup.test.js
+++ b/tests/unit/expense-rollup.test.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the expense roll-up (app/services/expense-rollup.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildExpenseRollup } = require('../../app/services/expense-rollup.js');
+
+const exp = (expId, expBillable, expAmount, expMarkupPct, expCategory) =>
+    ({ expId, expBillable, expAmount, expMarkupPct, expCategory, expDescription: null });
+
+describe('expense-rollup.buildExpenseRollup', () => {
+    test('prices billable expenses (cost + markup) and sums exactly', () => {
+        const r = buildExpenseRollup([
+            exp(1, true, 100, 0.15, 'Travel'), // 115
+            exp(2, true, 50, 0, 'Meals'),      // 50
+            exp(3, true, 19.99, 0.1, 'Parking'), // 21.99
+        ]);
+        expect(r.lines.map((l) => [l.expId, l.amount, l.category])).toEqual([
+            [1, 115, 'Travel'],
+            [2, 50, 'Meals'],
+            [3, 21.99, 'Parking'],
+        ]);
+        expect(r.subtotal).toBe(186.99);
+        expect(r.skipped.nonBillable).toEqual([]);
+    });
+
+    test('skips non-billable and unknown-cost expenses', () => {
+        const r = buildExpenseRollup([
+            exp(1, true, 100, 0, 'Travel'),
+            exp(2, false, 200, 0, 'Personal'), // non-billable → 0
+            exp(3, true, null, 0, 'Broken'),   // null cost
+        ]);
+        expect(r.subtotal).toBe(100);
+        expect(r.skipped.nonBillable.sort()).toEqual([2, 3]);
+        expect(r.lines).toHaveLength(1);
+    });
+
+    test('empty input → zero subtotal', () => {
+        expect(buildExpenseRollup([])).toEqual({ lines: [], subtotal: 0, skipped: { nonBillable: [] } });
+    });
+});


### PR DESCRIPTION
## Summary

Completes the expenses area: billable expenses now land on the invoice.

Closes #418.

## Changes

- **`POST /v1/invoice/rollup`** takes **`includeExpenses: true`**. On top of the billable-time lines, it loads the customer's **billable, un-invoiced** expenses (same date window), prices each (cost + markup, via `expense-billing`), and adds the expenses subtotal to the invoice's pre-discount subtotal — so tax/discount/total all account for them.
- In the **same transaction**, each rolled expense is stamped `expInvId = invoice.invId`, which both links it to the invoice and marks it invoiced (won't re-roll) — mirroring `TimeEntry.teInvJobId`.
- An invoice can now be **expenses-only** (the "no time to roll up" 400 now only fires when there's neither time nor expenses).
- Migration `20260531000000` adds `Expense.expInvId` + a `(expCustId, expInvId)` index; `Invoice`↔`Expense` association; the roll-up response gains an `expenses` block.
- New pure `app/services/expense-rollup.js`.

## Verification

`npm run lint` clean; `npm test` → 975 passing (expense pricing/skip/sum; integration column + association). Backward-compatible: without `includeExpenses` the response and totals are unchanged. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/