### PR TITLE
feat(time-capture): start/stop timer endpoints (#396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Start/stop timer endpoints** (#396). `POST /v1/timeentry/start`
+  opens an in-flight entry stamped with the server clock (teEndedAt
+  null), rejecting a second concurrent timer for the same worker (409);
+  `POST /v1/timeentry/{id}/stop` stamps the end time and computes
+  `teMinutes`, 409-ing if already stopped. Reuses the existing columns —
+  no migration. Same company-scoping / secure-404 / link validation as
+  the rest of the time-entry API.
 - **Expenses roll into invoices** (#418). `POST /v1/invoice/rollup` now
   takes `includeExpenses: true` — the customer's billable, un-invoiced
   expenses are priced (cost + markup) and added to the invoice subtotal

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -812,6 +812,30 @@ const spec = {
                 },
             },
         },
+        '/v1/timeentry/start': {
+            post: {
+                summary: 'Start an in-flight timer',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Timer started' },
+                    400: { description: 'Validation error' },
+                    403: { description: 'Auth failure' },
+                    409: { description: 'Worker already has a running timer' },
+                },
+            },
+        },
+        '/v1/timeentry/{id}/stop': {
+            post: {
+                summary: 'Stop a running timer (sets end + computes minutes)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: { description: 'Timer stopped' },
+                    404: { description: 'Not found' },
+                    409: { description: 'Timer already stopped' },
+                },
+            },
+        },
         '/v1/timeentry': {
             post: {
                 summary: 'Create a time entry',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -197,6 +197,145 @@ exports.create = async (req, res) => {
     }
 };
 
+const START_FIELDS = [
+    'teCustId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription', 'teBillable',
+];
+
+/**
+ * POST /v1/timeentry/start — begin an in-flight timer (#396).
+ *
+ * The server stamps teStartedAt = now and leaves teEndedAt null
+ * (teMinutes null) — a live entry to be closed later by /stop. Company
+ * scoping and worker/job/billtype link validation mirror create. If a
+ * worker is named and already has a running timer, this 409s so a
+ * worker never has two clocks going at once.
+ */
+exports.start = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.body && req.body.teCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify teCompId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (req.body && req.body.teCompId !== undefined &&
+            Number(req.body.teCompId) !== companyId) {
+            return res.status(403).json({
+                message: "Cannot start a timer for a company you do not belong to.",
+            });
+        }
+    }
+
+    const body = req.body || {};
+    const payload = {};
+    for (const f of START_FIELDS) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+    if (!payload.teCustId || !Number.isInteger(Number(payload.teCustId))) {
+        return res.status(400).json({ message: "teCustId is required and must be an integer." });
+    }
+    payload.teCompId = companyId;
+    payload.teArch = false;
+    payload.teStartedAt = new Date(); // server clock; timer is now running
+    payload.teEndedAt = null;
+    payload.teMinutes = null;
+
+    let linkError;
+    try {
+        linkError = await checkEntryLinks(payload, companyId, payload.teCustId);
+    } catch (error) {
+        log.error({ err: error }, 'timer start: link validation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (linkError) {
+        return res.status(linkError.status).json({ message: linkError.message });
+    }
+
+    // One running timer per worker: reject a second concurrent clock.
+    if (payload.teWorkerId != null) {
+        let running;
+        try {
+            running = await TimeEntry.findOne({
+                where: { teCompId: companyId, teWorkerId: Number(payload.teWorkerId), teEndedAt: null },
+            });
+        } catch (error) {
+            log.error({ err: error }, 'timer start: running-timer check failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (running) {
+            return res.status(409).json({
+                message: "This worker already has a running timer.",
+                runningId: running.teId,
+            });
+        }
+    }
+
+    try {
+        const created = await TimeEntry.create(payload);
+        return res.status(201).json({ message: "Timer started.", timeEntry: created });
+    } catch (error) {
+        log.error({ err: error }, 'timer start: TimeEntry.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/timeentry/:id/stop — stop a running timer (#396).
+ *
+ * Stamps teEndedAt = now and computes teMinutes. Secure-404 scoped like
+ * the other single-entry routes. A timer that's already stopped
+ * (teEndedAt set) 409s rather than silently re-clocking.
+ */
+exports.stop = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let entry;
+    try {
+        entry = await TimeEntry.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'timer stop: TimeEntry.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!entry || entry.teArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || entry.teCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    if (entry.teEndedAt) {
+        return res.status(409).json({ message: "Timer is already stopped." });
+    }
+
+    const endedAt = new Date();
+    const minutes = computeMinutes(entry.teStartedAt, endedAt);
+    try {
+        await entry.update({ teEndedAt: endedAt, teMinutes: minutes });
+        return res.status(200).json({ message: "Timer stopped.", timeEntry: entry });
+    } catch (error) {
+        log.error({ err: error }, 'timer stop: TimeEntry.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
 /**
  * GET /v1/timeentry/:id — fetch a single time entry by id.
  *

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -147,6 +147,17 @@ router.post(
     v.body(timeEntrySchemas.createTimeEntryBody),
     timeEntry.create,
 );
+// Timer capture (#396): start begins an in-flight entry, stop closes it.
+router.post(
+    '/v1/timeentry/start',
+    v.body(timeEntrySchemas.startTimerBody),
+    timeEntry.start,
+);
+router.post(
+    '/v1/timeentry/:id/stop',
+    v.params(timeEntrySchemas.intIdParam),
+    timeEntry.stop,
+);
 // Literal paths declared BEFORE /:id so express doesn't try to
 // parse "export.csv" / "bycompany" as a customer id.
 router.get(

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -107,10 +107,29 @@ const listByCompanyQuery = z.object({
     message: 'Unexpected query parameter. Allowed: customerId, from, to, limit, offset.',
 });
 
+/**
+ * POST /v1/timeentry/start body — begins an in-flight timer (#396). The
+ * server sets teStartedAt (now) and leaves teEndedAt open, so neither
+ * timestamp is accepted here. teCustId required; teCompId optional
+ * (master specifies).
+ */
+const startTimerBody = z.object({
+    teCustId: z.coerce.number().int().positive(),
+    teCompId: z.coerce.number().int().positive().optional(),
+    teWorkerId: z.coerce.number().int().positive().optional(),
+    teJobId: z.coerce.number().int().positive().optional(),
+    teBillTypeId: z.coerce.number().int().positive().optional(),
+    teDescription: z.string().max(10000).optional(),
+    teBillable: z.boolean().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teBillable.',
+});
+
 module.exports = {
     intIdParam,
     createTimeEntryBody,
     updateTimeEntryBody,
+    startTimerBody,
     listByCompanyQuery,
     exportCsvQuery,
 };

--- a/tests/api/timeentry-timer.test.js
+++ b/tests/api/timeentry-timer.test.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for the timer endpoints (#396) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: { ne: Symbol('ne') } },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {},
+    TimeEntry: { findByPk: vi.fn().mockResolvedValue(null), findOne: vi.fn(), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Timer endpoints auth + schema contract', () => {
+    test('POST /v1/timeentry/start 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/timeentry/start').send({ teCustId: 1 })).status).toBe(403);
+    });
+    test('POST /v1/timeentry/start 400 on missing teCustId (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/start').set('authKey', 'k').send({})).status).toBe(400);
+    });
+    test('POST /v1/timeentry/start 400 rejects server-managed teStartedAt (strict schema)', async () => {
+        const res = await request(app).post('/v1/timeentry/start').set('authKey', 'k')
+            .send({ teCustId: 1, teStartedAt: '2026-07-01T00:00:00Z' });
+        expect(res.status).toBe(400);
+    });
+    test('POST /v1/timeentry/:id/stop 403 without authKey', async () => {
+        expect((await request(app).post('/v1/timeentry/1/stop')).status).toBe(403);
+    });
+});


### PR DESCRIPTION
## Summary

Live time capture — click to start, click to stop.

Closes #396.

## Changes

- **`POST /v1/timeentry/start`** — opens an in-flight entry: server stamps `teStartedAt = now`, leaves `teEndedAt`/`teMinutes` null. Body carries the customer + optional worker/job/billtype/description/billable (no timestamps — server-managed, rejected by the strict schema). If the named worker already has a running timer, it **409s** (`runningId` returned) so a worker never has two clocks going.
- **`POST /v1/timeentry/{id}/stop`** — stamps `teEndedAt = now` and computes `teMinutes`; **409** if the entry is already stopped. Secure-404 scoped.
- Same company-scoping and worker/job/billtype link validation as `create`. **No migration** — reuses the existing in-flight columns (`teEndedAt` nullable, server-computed `teMinutes`).

## Verification

`npm run lint` clean; `npm test` → 980 passing (route auth + strict schema rejecting server-managed timestamps). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/