### PR TITLE
feat(time-capture): worker time-list route (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Worker time-list route** (#397) — `GET /v1/worker/{id}/timeentries`
+  lists one worker's time entries, secure-404 scoped through the worker
+  (missing / archived / cross-tenant read the same 404), with
+  `customerId` / `from` / `to` filters and RFC-5988 pagination. No
+  migration.
 - **Start/stop timer endpoints** (#396). `POST /v1/timeentry/start`
   opens an in-flight entry stamped with the server clock (teEndedAt
   null), rejecting a second concurrent timer for the same worker (409);

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1066,6 +1066,24 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } },
             },
         },
+        '/v1/worker/{id}/timeentries': {
+            get: {
+                summary: "List a worker's time entries",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: {
+                    200: { description: 'Found (paginated)' },
+                    404: { description: 'Worker not found / cross-tenant' },
+                },
+            },
+        },
         '/v1/worker/bycompany/{id}': {
             get: {
                 summary: 'List workers in a company (paginated)',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -481,6 +481,93 @@ exports.listByCompany = async (req, res) => {
 };
 
 /**
+ * GET /v1/worker/:id/timeentries — list one worker's time entries (#397).
+ *
+ * Secure-404 scoped through the worker: a missing / archived /
+ * cross-tenant worker id reads the same 404, so a scoped caller can't
+ * probe which worker ids exist across the tenant table. Honors
+ * ?customerId, ?from / ?to (date range), and pagination — same shape as
+ * listByCompany.
+ */
+exports.listByWorker = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const workerId = Number(req.params.id);
+    if (!Number.isInteger(workerId) || workerId <= 0) {
+        return res.status(400).json({ message: "Invalid worker id." });
+    }
+
+    let worker;
+    try {
+        // defaultScope hides archived workers → they read as "not found".
+        worker = await db.Worker.findByPk(workerId, { attributes: ['workerId', 'workerCompId'] });
+    } catch (error) {
+        log.error({ err: error }, 'listByWorker: Worker.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!worker) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || worker.workerCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const where = { teWorkerId: workerId, teCompId: worker.workerCompId };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) {
+        where.teCustId = customerId;
+    }
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const fromDate = parseDateOrNull(req.query.from);
+    const toDate = parseDateOrNull(req.query.to);
+    if (Op && fromDate) {
+        where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: fromDate });
+    }
+    if (Op && toDate) {
+        where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: toDate });
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0
+        ? Math.min(requestedLimit, 500)
+        : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0
+        ? requestedOffset
+        : 0;
+
+    try {
+        const { count, rows } = await TimeEntry.findAndCountAll({
+            where,
+            limit,
+            offset,
+            order: [['teStartedAt', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({
+            message: "Found.",
+            workerId,
+            count,
+            limit,
+            offset,
+            timeEntries: rows,
+        });
+    } catch (error) {
+        log.error({ err: error }, 'listByWorker: TimeEntry.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
  * PATCH /v1/timeentry/:id — partial update.
  *
  * Only ALLOWED_FIELDS_UPDATE may be patched. teCompId / teCustId /

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -214,6 +214,14 @@ router.get(
     v.params(workerSchemas.intIdParam),
     worker.getById,
 );
+// A worker's own time entries (#397) — handled by the timeentry
+// controller since it owns the TimeEntry model + list helpers.
+router.get(
+    '/v1/worker/:id/timeentries',
+    v.params(workerSchemas.intIdParam),
+    v.query(timeEntrySchemas.listByCompanyQuery),
+    timeEntry.listByWorker,
+);
 router.patch(
     '/v1/worker/:id',
     v.params(workerSchemas.intIdParam),

--- a/tests/api/worker-timeentries.test.js
+++ b/tests/api/worker-timeentries.test.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for GET /v1/worker/:id/timeentries (#397).
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: { gte: Symbol('gte'), lte: Symbol('lte') } },
+    Customer: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {},
+    Worker: { findByPk: vi.fn().mockResolvedValue(null) },
+    TimeEntry: { findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Worker time-list route auth + schema', () => {
+    test('GET /v1/worker/:id/timeentries 403 without authKey', async () => {
+        expect((await request(app).get('/v1/worker/1/timeentries')).status).toBe(403);
+    });
+    test('GET /v1/worker/:id/timeentries rejects an unknown query param (schema)', async () => {
+        const res = await request(app).get('/v1/worker/1/timeentries?bogus=1').set('authKey', 'k');
+        expect(res.status).toBe(400);
+    });
+    test('GET /v1/worker/:id/timeentries rejects a non-integer id (schema)', async () => {
+        const res = await request(app).get('/v1/worker/abc/timeentries').set('authKey', 'k');
+        expect(res.status).toBe(400);
+    });
+});


### PR DESCRIPTION
## Summary

See everything one worker has clocked.

Closes #397.

## Changes

- **`GET /v1/worker/{id}/timeentries`** — lists a single worker's time entries. **Secure-404 scoped through the worker**: a missing, archived, or cross-tenant worker id all read the same 404, so a scoped caller can't probe which worker ids exist. Honors `?customerId`, `?from`/`?to` (date range), and RFC-5988 pagination — same response shape as `bycompany`.
- Handled by the **timeentry controller** (`listByWorker`) since it owns the `TimeEntry` model and the list/pagination helpers; the route lives under `/v1/worker` and reuses the worker `intIdParam` + the existing list query schema. **No migration.**

## Verification

`npm run lint` clean; `npm test` → 984 passing (route auth + schema: unknown query param, non-integer id). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/