### PR TITLE
feat(billing-rates): per-project flat rate (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Per-project flat rate** (#410). `Job.jobFlatRate` (migration
+  `20260601000000`) is an hourly rate applied to all time on the job —
+  the **middle tier** of rate resolution in `rate.js`: per-entry
+  `BillingType` override → **project flat rate** → worker default. It
+  flows through the time-entry billing view, the invoice roll-up, and the
+  unbilled report. Settable on job create/PATCH.
 - **Worker time-list route** (#397) — `GET /v1/worker/{id}/timeentries`
   lists one worker's time entries, secure-404 scoped through the worker
   (missing / archived / cross-tenant read the same 404), with

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -327,6 +327,8 @@ exports.rollup = async (req, res) => {
             where,
             include: [
                 { model: db.BillingType, as: 'billingType', required: false },
+                // Job flat rate (#410) — resolveHourlyRate reads entry.job.
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
                 {
                     model: db.Worker, as: 'worker', required: false,
                     include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],

--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -20,8 +20,8 @@ const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
-const ALLOWED_FIELDS_CREATE = ['jobCustId', 'jobDesc'];
-const ALLOWED_FIELDS_UPDATE = ['jobDesc', 'jobInvoiced'];
+const ALLOWED_FIELDS_CREATE = ['jobCustId', 'jobDesc', 'jobFlatRate'];
+const ALLOWED_FIELDS_UPDATE = ['jobDesc', 'jobInvoiced', 'jobFlatRate'];
 
 exports.create = async (req, res) => {
     const authKey = req.get('authKey');

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -92,7 +92,7 @@ exports.unbilled = async (req, res) => {
                     model: db.Worker, as: 'worker', required: false,
                     include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
                 },
-                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc'] },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc', 'jobFlatRate'] },
                 {
                     model: db.Customer, as: 'customer', required: false,
                     attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
@@ -114,6 +114,8 @@ exports.unbilled = async (req, res) => {
             teBillable: e.teBillable,
             billingType: e.billingType,
             worker: e.worker,
+            // Pass the job so rate.js can read the per-project flat rate (#410).
+            job: e.job,
             custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
             jobDesc: e.job ? e.job.jobDesc : null,
         };
@@ -166,7 +168,7 @@ exports.hours = async (req, res) => {
         entries = await db.TimeEntry.findAll({
             where,
             include: [
-                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc'] },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc', 'jobFlatRate'] },
                 {
                     model: db.Customer, as: 'customer', required: false,
                     attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -357,6 +357,9 @@ exports.getById = async (req, res) => {
         entry = await TimeEntry.findByPk(req.params.id, {
             include: [
                 { model: db.BillingType, as: 'billingType', required: false },
+                // Job carries the per-project flat rate (#410) — the middle
+                // tier of rate resolution.
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
                 {
                     model: db.Worker,
                     as: 'worker',

--- a/app/migrations/20260601000000-job-flat-rate.js
+++ b/app/migrations/20260601000000-job-flat-rate.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Per-project flat rate (#410). jobFlatRate is an hourly rate applied to
+// all time booked against the job — the middle tier of rate resolution,
+// between a per-entry BillingType override and the worker's default rate
+// (see app/services/rate.js). NUMERIC(14,2), nullable (NULL = no project
+// rate; fall through). setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const JOB = { tableName: 'Job', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            JOB, 'jobFlatRate',
+            { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(JOB, 'jobFlatRate');
+    },
+};

--- a/app/models/job.model.js
+++ b/app/models/job.model.js
@@ -37,6 +37,16 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.BOOLEAN,
             defaultValue: false,
         },
+        jobFlatRate: {
+            field: 'jobFlatRate',
+            // Per-project flat hourly rate (#410); null = fall through to
+            // worker/entry rate resolution. Number getter (pg NUMERIC→string).
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('jobFlatRate');
+                return v == null ? null : Number(v);
+            },
+        },
     }, {
         tableName: 'Job',
         timestamps: true,

--- a/app/schemas/job.schema.js
+++ b/app/schemas/job.schema.js
@@ -11,15 +11,17 @@ const intIdParam = z.object({
 const createJobBody = z.object({
     jobCustId: z.coerce.number().int().positive(),
     jobDesc: z.string().min(1).max(10000),
+    jobFlatRate: z.coerce.number().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: jobCustId, jobDesc.',
+    message: 'Unexpected field in body. Whitelist: jobCustId, jobDesc, jobFlatRate.',
 });
 
 const updateJobBody = z.object({
     jobDesc: z.string().min(1).max(10000).optional(),
     jobInvoiced: z.boolean().optional(),
+    jobFlatRate: z.coerce.number().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: jobDesc, jobInvoiced.',
+    message: 'Unexpected field in body. Whitelist: jobDesc, jobInvoiced, jobFlatRate.',
 });
 
 const listByCustomerQuery = z.object({

--- a/app/services/rate.js
+++ b/app/services/rate.js
@@ -8,36 +8,45 @@
  *
  * Rate precedence (first match wins):
  *   1. the entry's OWN BillingType (teBillTypeId — a per-entry override)
- *   2. the entry's Worker's default BillingType (workerDefaultBillType)
- *   (A per-project rate is a planned middle tier — backlog #28 — and
- *    slots in between the worker default and "no rate" once Job carries
- *    its own rate.)
+ *   2. the entry's Job's flat rate (jobFlatRate — a per-project rate, #410)
+ *   3. the entry's Worker's default BillingType (workerDefaultBillType)
  *
  * These functions are PURE: the caller eager-loads the associations
- * (entry.billingType and entry.worker.defaultBillingType) so rate.js
- * never touches the database and stays trivially unit-testable.
+ * (entry.billingType, entry.job and entry.worker.defaultBillingType) so
+ * rate.js never touches the database and stays trivially unit-testable.
  */
 
 const money = require('./money.js');
 
-/** The hourly rate on a BillingType instance, or null if absent/invalid. */
-function rateOf(billingType) {
-    if (!billingType) return null;
-    const raw = billingType.btHourlyRate;
+/** Coerce a possibly-string numeric rate to a finite number, or null. */
+function numOrNull(raw) {
     const n = typeof raw === 'string' ? Number(raw) : raw;
     return typeof n === 'number' && Number.isFinite(n) ? n : null;
 }
 
+/** The hourly rate on a BillingType instance, or null if absent/invalid. */
+function rateOf(billingType) {
+    return billingType ? numOrNull(billingType.btHourlyRate) : null;
+}
+
+/** The flat per-project rate on a Job instance, or null if absent. */
+function flatRateOf(job) {
+    return job ? numOrNull(job.jobFlatRate) : null;
+}
+
 /**
  * The effective hourly rate for a time entry, or null when none can be
- * resolved. Expects eager-loaded `entry.billingType` (per-entry) and
- * `entry.worker.defaultBillingType` associations; a missing (or
- * archived, hence unloaded) association simply falls through.
+ * resolved. Expects eager-loaded `entry.billingType` (per-entry),
+ * `entry.job` (per-project flat rate) and `entry.worker.defaultBillingType`
+ * associations; a missing (or archived, hence unloaded) association
+ * simply falls through to the next tier.
  */
 function resolveHourlyRate(entry) {
     if (!entry) return null;
     const own = rateOf(entry.billingType);
     if (own != null) return own;
+    const project = flatRateOf(entry.job);
+    if (project != null) return project;
     return rateOf(entry.worker && entry.worker.defaultBillingType);
 }
 

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -113,6 +113,15 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(true).toBe(true);
     });
 
+    test('Job has the jobFlatRate column (#410)', async () => {
+        if (!connected) return;
+        const rows = await db.Job.findAll({
+            attributes: ['jobId', 'jobFlatRate'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+    });
+
     test('TimeEntry has worker/job/billtype columns and their includes resolve', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260521 + 20260523

--- a/tests/unit/rate.test.js
+++ b/tests/unit/rate.test.js
@@ -21,6 +21,25 @@ describe('rate.resolveHourlyRate — precedence', () => {
         expect(rate.resolveHourlyRate(entry)).toBe(100);
     });
 
+    test("entry's own BillingType wins over the project flat rate", () => {
+        const entry = { billingType: bt(150), job: { jobFlatRate: 200 }, worker: { defaultBillingType: bt(100) } };
+        expect(rate.resolveHourlyRate(entry)).toBe(150);
+    });
+
+    test('project flat rate wins over the worker default', () => {
+        const entry = { billingType: null, job: { jobFlatRate: 200 }, worker: { defaultBillingType: bt(100) } };
+        expect(rate.resolveHourlyRate(entry)).toBe(200);
+    });
+
+    test('falls through a null project flat rate to the worker default', () => {
+        const entry = { billingType: null, job: { jobFlatRate: null }, worker: { defaultBillingType: bt(100) } };
+        expect(rate.resolveHourlyRate(entry)).toBe(100);
+    });
+
+    test('coerces a NUMERIC-string project flat rate', () => {
+        expect(rate.resolveHourlyRate({ job: { jobFlatRate: '175.00' } })).toBe(175);
+    });
+
     test('null when neither a per-entry nor a worker rate is present', () => {
         expect(rate.resolveHourlyRate({ billingType: null, worker: null })).toBeNull();
         expect(rate.resolveHourlyRate({})).toBeNull();


### PR DESCRIPTION
## Summary

A project can carry its own hourly rate that applies to everyone's time on it.

Closes #410.

## Changes

- **Migration `20260601000000`** — `Job.jobFlatRate` (NUMERIC(14,2), nullable). `setup/*.sql` untouched.
- **`rate.js`** — `jobFlatRate` becomes the **middle tier** of rate resolution (first match wins):
  1. the entry's own `BillingType` (per-entry override)
  2. **the job's flat rate** (per-project) ← new
  3. the worker's default `BillingType`

  A negotiated project rate thus beats a worker's generic default, while a specific entry can still override it. Pure + coerces pg's NUMERIC string.
- **Flows through** every billing path: the time-entry billing view (`GET /v1/timeentry/{id}`), the invoice roll-up, and the unbilled report all now eager-load the job + `jobFlatRate`.
- Settable on **job create / PATCH** (and bulk create).

## Verification

`npm run lint` clean; `npm test` → 990 passing (rate precedence: project vs entry-override vs worker-default, NUMERIC-string coercion, null-fallthrough; integration column check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/