### PR TITLE
feat(reporting): billable vs non-billable summary (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Billable vs non-billable summary** (#432) —
+  `GET /v1/report/billable-summary`. Splits a company's tracked time into
+  billable / non-billable minutes + hours **by month**, prices the
+  billable portion (via `rate.js`), and reports the overall **billable
+  ratio** and total billable amount — the utilization trend. Company-
+  scoped; optional `customerId` / `from` / `to`. New pure
+  `app/services/report-billable-summary.js`. **Completes the v1.1
+  milestone.**
 - **Tags on time entries** (#406). `TimeEntry.teTags` — a JSONB array of
   freeform labels (≤ 50 tags, each ≤ 64 chars), migration
   `20260602000000` with a GIN index. Settable on create / PATCH / timer

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1374,6 +1374,23 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/report/billable-summary': {
+            get: {
+                summary: 'Billable vs non-billable time by month (+ ratio)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Summary — {billableRatio, totalBillableHours, totalNonBillableHours, totalBillableAmount, periods[]}' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/revenue': {
             get: {
                 summary: 'Revenue & earnings summary (by customer and month)',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -15,6 +15,7 @@ const money = require('../services/money.js');
 const { buildUnbilled } = require('../services/report-unbilled.js');
 const { buildHours } = require('../services/report-hours.js');
 const { buildRevenue } = require('../services/report-revenue.js');
+const { buildBillableSummary } = require('../services/report-billable-summary.js');
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
@@ -263,6 +264,55 @@ exports.revenue = async (req, res) => {
 
     const report = buildRevenue(items);
     return res.status(200).json({ message: "Revenue summary.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/billable-summary — billable vs non-billable time split
+ * by month, with the overall billable ratio and the billable amount.
+ * Company-scoped; optional customerId and from/to (entry start) filters.
+ */
+exports.billableSummary = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const where = { teCompId: companyId };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) where.teCustId = customerId;
+    const from = parseDate(req.query.from, false);
+    const to = parseDate(req.query.to, true);
+    if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+    if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where,
+            include: [
+                { model: db.BillingType, as: 'billingType', required: false },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
+                {
+                    model: db.Worker, as: 'worker', required: false,
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'billable-summary: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const report = buildBillableSummary(entries);
+    return res.status(200).json({ message: "Billable vs non-billable summary.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -725,5 +725,10 @@ router.get(
     v.query(reportSchemas.revenueQuery),
     report.revenue,
 );
+router.get(
+    '/v1/report/billable-summary',
+    v.query(reportSchemas.billableSummaryQuery),
+    report.billableSummary,
+);
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -49,4 +49,17 @@ const revenueQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery };
+/**
+ * GET /v1/report/billable-summary query. companyId required for master
+ * keys. Optional customerId filter and from/to (entry start) bounds.
+ */
+const billableSummaryQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery };

--- a/app/services/report-billable-summary.js
+++ b/app/services/report-billable-summary.js
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-billable-summary.js — billable vs non-billable time, split by
+ * month, with the overall billable ratio (#432). The utilization view:
+ * how much of the tracked time is actually billable, trending over time.
+ *
+ * PURE: the caller loads closed time entries (with their rate
+ * associations); this buckets minutes billable/non-billable per month,
+ * prices the billable minutes via rate.js, and sums exactly via money.js.
+ * No DB.
+ */
+
+const money = require('./money.js');
+const rate = require('./rate.js');
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+
+/** 'YYYY-MM' month from a Date or ISO string, else 'unknown'. */
+function periodOf(startedAt) {
+    if (!startedAt) return 'unknown';
+    let s;
+    if (typeof startedAt === 'string') s = startedAt;
+    else if (startedAt instanceof Date) s = startedAt.toISOString();
+    else s = String(startedAt);
+    return /^\d{4}-\d{2}/.test(s) ? s.slice(0, 7) : 'unknown';
+}
+
+/**
+ * @param entries closed time entries with { teId, teMinutes, teBillable,
+ *   teStartedAt } and eager-loaded rate associations. In-flight entries
+ *   (teMinutes null) are skipped.
+ * @returns totals + billableRatio + per-month periods.
+ */
+function buildBillableSummary(entries) {
+    const map = new Map();
+    const allAmounts = [];
+    const unresolvedRate = [];
+    let totalBillableMin = 0;
+    let totalNonBillableMin = 0;
+
+    for (const e of entries || []) {
+        if (e.teMinutes == null) continue;
+        const m = Number(e.teMinutes) || 0;
+        const p = periodOf(e.teStartedAt);
+        let g = map.get(p);
+        if (!g) { g = { period: p, billableMinutes: 0, nonBillableMinutes: 0, amounts: [] }; map.set(p, g); }
+        if (e.teBillable) {
+            g.billableMinutes += m;
+            totalBillableMin += m;
+            const amt = rate.billableAmount(e);
+            if (amt == null) unresolvedRate.push(e.teId);
+            else { g.amounts.push(amt); allAmounts.push(amt); }
+        } else {
+            g.nonBillableMinutes += m;
+            totalNonBillableMin += m;
+        }
+    }
+
+    const periods = Array.from(map.values()).map((g) => ({
+        period: g.period,
+        billableMinutes: g.billableMinutes,
+        nonBillableMinutes: g.nonBillableMinutes,
+        billableHours: round2(g.billableMinutes / 60),
+        nonBillableHours: round2(g.nonBillableMinutes / 60),
+        billableAmount: money.sum(g.amounts),
+    })).sort((a, b) => (a.period < b.period ? -1 : a.period > b.period ? 1 : 0));
+
+    const totalMin = totalBillableMin + totalNonBillableMin;
+    return {
+        periods,
+        totalBillableMinutes: totalBillableMin,
+        totalNonBillableMinutes: totalNonBillableMin,
+        totalBillableHours: round2(totalBillableMin / 60),
+        totalNonBillableHours: round2(totalNonBillableMin / 60),
+        billableRatio: totalMin > 0 ? round2(totalBillableMin / totalMin) : 0,
+        totalBillableAmount: money.sum(allAmounts),
+        unresolvedRateEntries: unresolvedRate.length,
+    };
+}
+
+module.exports = { buildBillableSummary, periodOf };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -49,4 +49,10 @@ describe('Report auth + schema contract', () => {
     test('GET /v1/report/revenue rejects an unknown query param (schema)', async () => {
         expect((await request(app).get('/v1/report/revenue?bogus=1').set('authKey', 'k')).status).toBe(400);
     });
+    test('GET /v1/report/billable-summary 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/billable-summary')).status).toBe(403);
+    });
+    test('GET /v1/report/billable-summary rejects an unknown query param (schema)', async () => {
+        expect((await request(app).get('/v1/report/billable-summary?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/unit/report-billable-summary.test.js
+++ b/tests/unit/report-billable-summary.test.js
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the billable-vs-non-billable summary
+// (app/services/report-billable-summary.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildBillableSummary, periodOf } = require('../../app/services/report-billable-summary.js');
+
+// entry at a per-entry hourly rate on a given start date.
+const e = (teId, teStartedAt, teMinutes, teBillable, hourly) => ({
+    teId, teStartedAt, teMinutes, teBillable,
+    billingType: hourly == null ? null : { btHourlyRate: hourly },
+});
+
+describe('report-billable-summary.periodOf', () => {
+    test('extracts YYYY-MM from an ISO string or Date', () => {
+        expect(periodOf('2026-07-05T09:00:00Z')).toBe('2026-07');
+        expect(periodOf(null)).toBe('unknown');
+    });
+});
+
+describe('report-billable-summary.buildBillableSummary', () => {
+    test('splits billable / non-billable by month with the overall ratio', () => {
+        const r = buildBillableSummary([
+            e(1, '2026-06-01T09:00:00Z', 60, true, 100),   // Jun: 60 billable, $100
+            e(2, '2026-06-02T09:00:00Z', 60, false, 100),  // Jun: 60 non-billable
+            e(3, '2026-07-01T09:00:00Z', 120, true, 50),   // Jul: 120 billable, $100
+        ]);
+        expect(r.totalBillableMinutes).toBe(180);
+        expect(r.totalNonBillableMinutes).toBe(60);
+        expect(r.totalBillableHours).toBe(3);
+        expect(r.billableRatio).toBe(0.75); // 180 / 240
+        expect(r.totalBillableAmount).toBe(200);
+        expect(r.periods).toEqual([
+            { period: '2026-06', billableMinutes: 60, nonBillableMinutes: 60, billableHours: 1, nonBillableHours: 1, billableAmount: 100 },
+            { period: '2026-07', billableMinutes: 120, nonBillableMinutes: 0, billableHours: 2, nonBillableHours: 0, billableAmount: 100 },
+        ]);
+    });
+
+    test('unresolved billable rate counts minutes but not amount', () => {
+        const r = buildBillableSummary([
+            e(1, '2026-07-01T09:00:00Z', 60, true, null), // billable, no rate
+        ]);
+        expect(r.totalBillableMinutes).toBe(60);
+        expect(r.totalBillableAmount).toBe(0);
+        expect(r.unresolvedRateEntries).toBe(1);
+    });
+
+    test('skips in-flight entries; empty input → zero ratio', () => {
+        const r = buildBillableSummary([e(1, '2026-07-01T09:00:00Z', null, true, 100)]);
+        expect(r.totalBillableMinutes).toBe(0);
+        expect(buildBillableSummary([]).billableRatio).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

The utilization view — how much tracked time is actually billable, trending by month. **This completes the v1.1 milestone.**

Closes #432.

## Changes

- **`app/services/report-billable-summary.js`** (pure) — buckets a company's closed time into **billable / non-billable** minutes + hours **per month**, prices the billable portion via `rate.js` (honoring the full precedence: entry override → project rate → worker default), and computes the overall **billable ratio** (`billable / total`) and total billable amount. In-flight entries skipped; billable time with an unresolvable rate counts minutes but not amount (surfaced as `unresolvedRateEntries`).
- **`GET /v1/report/billable-summary`** on the `report` controller — company-scoped (master passes `?companyId`), optional `customerId` / `from` / `to`.

## Verification

`npm run lint` clean; `npm test` → **1005 passing** (month split, ratio math, unresolved-rate handling, in-flight skip; route auth + schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/