### PR TITLE
feat(time-capture): timesheet aggregation report (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Timesheet aggregation** (#398) — `GET /v1/report/timesheet`. A
+  hours-per-worker-per-**day** (`period=day`, default) or per-**week**
+  (`period=week`, bucketed to the ISO Monday) grid over a date range,
+  with per-worker row totals, per-period column totals, and a grand
+  total. Company-scoped; optional `customerId` / `workerId` / `from` /
+  `to`. New pure `app/services/report-timesheet.js`. First v1.2 item.
 - **Billable vs non-billable summary** (#432) —
   `GET /v1/report/billable-summary`. Splits a company's tracked time into
   billable / non-billable minutes + hours **by month**, prices the

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1374,6 +1374,25 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/report/timesheet': {
+            get: {
+                summary: 'Timesheet grid — hours per worker per day or week',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'workerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'period', in: 'query', schema: { type: 'string', enum: ['day', 'week'] }, description: 'Default day.' },
+                ],
+                responses: {
+                    200: { description: 'Grid — {period, buckets[], rows[] (worker × period), bucketTotals[], grandTotalHours}' },
+                    400: { description: 'Master keys must specify companyId, or bad period' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/billable-summary': {
             get: {
                 summary: 'Billable vs non-billable time by month (+ ratio)',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -16,6 +16,7 @@ const { buildUnbilled } = require('../services/report-unbilled.js');
 const { buildHours } = require('../services/report-hours.js');
 const { buildRevenue } = require('../services/report-revenue.js');
 const { buildBillableSummary } = require('../services/report-billable-summary.js');
+const { buildTimesheet } = require('../services/report-timesheet.js');
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
@@ -313,6 +314,60 @@ exports.billableSummary = async (req, res) => {
 
     const report = buildBillableSummary(entries);
     return res.status(200).json({ message: "Billable vs non-billable summary.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/timesheet — a timesheet grid: hours per worker per day
+ * (period=day, default) or per week (period=week) over the range.
+ * Company-scoped; optional customerId / workerId / from / to.
+ */
+exports.timesheet = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const where = { teCompId: companyId };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) where.teCustId = customerId;
+    const workerId = Number(req.query.workerId);
+    if (Number.isInteger(workerId) && workerId > 0) where.teWorkerId = workerId;
+    const from = parseDate(req.query.from, false);
+    const to = parseDate(req.query.to, true);
+    if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+    if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where,
+            include: [{ model: db.Worker, as: 'worker', required: false, attributes: ['workerId', 'workerFName', 'workerLName'] }],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'timesheet: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const items = entries.map((e) => {
+        const w = e.worker;
+        return {
+            teMinutes: e.teMinutes,
+            teStartedAt: e.teStartedAt,
+            teWorkerId: e.teWorkerId,
+            workerName: w ? ([w.workerFName, w.workerLName].filter(Boolean).join(' ') || null) : null,
+        };
+    });
+
+    const report = buildTimesheet(items, req.query.period);
+    return res.status(200).json({ message: "Timesheet.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -730,5 +730,10 @@ router.get(
     v.query(reportSchemas.billableSummaryQuery),
     report.billableSummary,
 );
+router.get(
+    '/v1/report/timesheet',
+    v.query(reportSchemas.timesheetQuery),
+    report.timesheet,
+);
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -62,4 +62,20 @@ const billableSummaryQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery };
+/**
+ * GET /v1/report/timesheet query. companyId required for master keys.
+ * Optional customerId / workerId filters, from/to bounds, and period
+ * ('day' default, or 'week').
+ */
+const timesheetQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    workerId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+    period: z.enum(['day', 'week']).optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, workerId, from, to, period.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery };

--- a/app/services/report-timesheet.js
+++ b/app/services/report-timesheet.js
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-timesheet.js — a timesheet grid: hours per worker per day (or
+ * per week) over a date range (#398). The classic "who worked how much
+ * when" view.
+ *
+ * PURE: the caller loads closed time entries (with the worker's name);
+ * this buckets minutes by worker × period. No DB. Weeks bucket to their
+ * Monday (ISO week start).
+ */
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+
+/** 'YYYY-MM-DD' from a Date or ISO string, else 'unknown'. */
+function isoDatePart(startedAt) {
+    if (!startedAt) return 'unknown';
+    let s;
+    if (typeof startedAt === 'string') s = startedAt;
+    else if (startedAt instanceof Date) s = startedAt.toISOString();
+    else s = String(startedAt);
+    return /^\d{4}-\d{2}-\d{2}/.test(s) ? s.slice(0, 10) : 'unknown';
+}
+
+function dayKey(startedAt) {
+    return isoDatePart(startedAt);
+}
+
+/** The Monday (UTC) of the entry's ISO week, as 'YYYY-MM-DD'. */
+function weekKey(startedAt) {
+    const d = isoDatePart(startedAt);
+    if (d === 'unknown') return 'unknown';
+    const dt = new Date(d + 'T00:00:00.000Z');
+    const dow = dt.getUTCDay();          // 0=Sun..6=Sat
+    const backToMonday = dow === 0 ? 6 : dow - 1;
+    dt.setUTCDate(dt.getUTCDate() - backToMonday);
+    return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * @param entries closed time entries with { teMinutes, teStartedAt,
+ *   teWorkerId, workerName }. In-flight entries (null minutes) skipped.
+ * @param period 'day' (default) or 'week'.
+ * @returns { period, buckets, rows, bucketTotals, grandTotal* }.
+ *   rows[] = { workerId, workerName, buckets:[{bucket,minutes,hours}],
+ *   totalMinutes, totalHours }; bucketTotals mirror per column.
+ */
+function buildTimesheet(entries, period) {
+    const p = period === 'week' ? 'week' : 'day';
+    const keyFn = p === 'week' ? weekKey : dayKey;
+    const workers = new Map();
+    const bucketTotals = new Map();
+
+    for (const e of entries || []) {
+        if (e.teMinutes == null) continue;
+        const m = Number(e.teMinutes) || 0;
+        const bucket = keyFn(e.teStartedAt);
+        const wid = e.teWorkerId == null ? 0 : e.teWorkerId;
+        let w = workers.get(wid);
+        if (!w) {
+            w = { workerId: wid || null, workerName: e.workerName || (wid ? null : 'Unassigned'), cells: new Map() };
+            workers.set(wid, w);
+        }
+        w.cells.set(bucket, (w.cells.get(bucket) || 0) + m);
+        bucketTotals.set(bucket, (bucketTotals.get(bucket) || 0) + m);
+    }
+
+    const buckets = Array.from(bucketTotals.keys()).sort();
+    const rows = Array.from(workers.values()).map((w) => {
+        let total = 0;
+        const cells = buckets.map((b) => {
+            const min = w.cells.get(b) || 0;
+            total += min;
+            return { bucket: b, minutes: min, hours: round2(min / 60) };
+        });
+        return {
+            workerId: w.workerId,
+            workerName: w.workerName,
+            buckets: cells,
+            totalMinutes: total,
+            totalHours: round2(total / 60),
+        };
+    }).sort((a, b) => (a.workerId || 0) - (b.workerId || 0));
+
+    const cols = buckets.map((b) => {
+        const min = bucketTotals.get(b);
+        return { bucket: b, minutes: min, hours: round2(min / 60) };
+    });
+    const grand = cols.reduce((s, c) => s + c.minutes, 0);
+
+    return {
+        period: p,
+        buckets,
+        rows,
+        bucketTotals: cols,
+        grandTotalMinutes: grand,
+        grandTotalHours: round2(grand / 60),
+    };
+}
+
+module.exports = { buildTimesheet, dayKey, weekKey };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -55,4 +55,10 @@ describe('Report auth + schema contract', () => {
     test('GET /v1/report/billable-summary rejects an unknown query param (schema)', async () => {
         expect((await request(app).get('/v1/report/billable-summary?bogus=1').set('authKey', 'k')).status).toBe(400);
     });
+    test('GET /v1/report/timesheet 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/timesheet')).status).toBe(403);
+    });
+    test('GET /v1/report/timesheet rejects an invalid period (schema)', async () => {
+        expect((await request(app).get('/v1/report/timesheet?period=month').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/unit/report-timesheet.test.js
+++ b/tests/unit/report-timesheet.test.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the timesheet grid (app/services/report-timesheet.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildTimesheet, dayKey, weekKey } = require('../../app/services/report-timesheet.js');
+
+const e = (teWorkerId, workerName, teStartedAt, teMinutes) => ({ teWorkerId, workerName, teStartedAt, teMinutes });
+
+describe('report-timesheet keys', () => {
+    test('dayKey extracts the date', () => {
+        expect(dayKey('2026-07-05T14:00:00Z')).toBe('2026-07-05');
+    });
+    test('weekKey buckets to the Monday of the ISO week', () => {
+        // 2026-07-05 is a Sunday → Monday 2026-06-29.
+        expect(weekKey('2026-07-05T14:00:00Z')).toBe('2026-06-29');
+        // 2026-07-06 is a Monday → itself.
+        expect(weekKey('2026-07-06T09:00:00Z')).toBe('2026-07-06');
+    });
+});
+
+describe('report-timesheet.buildTimesheet', () => {
+    test('grid by worker × day with row + column totals', () => {
+        const r = buildTimesheet([
+            e(1, 'Wanda', '2026-07-06T09:00:00Z', 60),
+            e(1, 'Wanda', '2026-07-06T13:00:00Z', 30),
+            e(1, 'Wanda', '2026-07-07T09:00:00Z', 120),
+            e(2, 'Vic', '2026-07-06T09:00:00Z', 45),
+        ], 'day');
+        expect(r.period).toBe('day');
+        expect(r.buckets).toEqual(['2026-07-06', '2026-07-07']);
+        const wanda = r.rows.find((x) => x.workerId === 1);
+        expect(wanda.buckets.map((b) => b.minutes)).toEqual([90, 120]);
+        expect(wanda.totalHours).toBe(3.5);
+        expect(r.bucketTotals.map((c) => c.minutes)).toEqual([135, 120]); // day1: 90+45, day2: 120
+        expect(r.grandTotalHours).toBe(round(255));
+    });
+
+    test('week period buckets days into their Monday; unassigned worker labelled', () => {
+        const r = buildTimesheet([
+            e(null, null, '2026-07-06T09:00:00Z', 60), // Mon week 07-06
+            e(null, null, '2026-07-08T09:00:00Z', 60), // Wed same week
+        ], 'week');
+        expect(r.buckets).toEqual(['2026-07-06']);
+        expect(r.rows[0].workerName).toBe('Unassigned');
+        expect(r.rows[0].totalHours).toBe(2);
+    });
+
+    test('skips in-flight entries; empty → zero grand total', () => {
+        expect(buildTimesheet([e(1, 'W', '2026-07-06T09:00:00Z', null)], 'day').grandTotalMinutes).toBe(0);
+        expect(buildTimesheet([]).grandTotalHours).toBe(0);
+    });
+});
+
+function round(min) { return Math.round((min / 60) * 100) / 100; }


### PR DESCRIPTION
## Summary

The timesheet grid — who worked how much, when. Opens the **v1.2** milestone.

Closes #398.

## Changes

- **`app/services/report-timesheet.js`** (pure) — buckets a company's closed time into a **worker × period** grid: `period=day` (default, `YYYY-MM-DD`) or `period=week` (bucketed to the **ISO Monday**). Each row is a worker with per-bucket minutes/hours + a row total; `bucketTotals` give column totals; plus a grand total. In-flight entries skipped; time with no worker rolls into an "Unassigned" row.
- **`GET /v1/report/timesheet`** on the `report` controller — company-scoped (master passes `?companyId`), optional `customerId` / `workerId` / `from` / `to` / `period`.

## Verification

`npm run lint` clean; `npm test` → **1014 passing** (day/week bucketing incl. Sunday→prior-Monday, grid + row + column totals, Unassigned label, in-flight skip; route auth + `period` enum rejection). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/