### PR TITLE
feat(reporting): budget vs actuals with alerts (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Budget vs actuals** (#434). Per-project budgets on Job —
+  `jobBudgetMinutes` (effort) and `jobBudgetAmount` (value), migration
+  `20260603000000`, settable on job create/PATCH. New
+  `GET /v1/report/budget` sums each budgeted job's logged minutes +
+  billable amount (via `rate.js`) and flags **each dimension**
+  `under` / `near` (≥ 80%) / `over` (> 100%), with an `overCount`. New
+  pure `app/services/report-budget.js`.
 - **Timesheet aggregation** (#398) — `GET /v1/report/timesheet`. A
   hours-per-worker-per-**day** (`period=day`, default) or per-**week**
   (`period=week`, bucketed to the ISO Monday) grid over a date range,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1374,6 +1374,20 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/report/budget': {
+            get: {
+                summary: 'Project budget vs actuals (hours + amount, with alerts)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                ],
+                responses: {
+                    200: { description: 'Budget — {jobs[] (budget/actual/ratio/status per hours & amount), count, overCount}' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/timesheet': {
             get: {
                 summary: 'Timesheet grid — hours per worker per day or week',

--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -20,8 +20,8 @@ const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
-const ALLOWED_FIELDS_CREATE = ['jobCustId', 'jobDesc', 'jobFlatRate'];
-const ALLOWED_FIELDS_UPDATE = ['jobDesc', 'jobInvoiced', 'jobFlatRate'];
+const ALLOWED_FIELDS_CREATE = ['jobCustId', 'jobDesc', 'jobFlatRate', 'jobBudgetMinutes', 'jobBudgetAmount'];
+const ALLOWED_FIELDS_UPDATE = ['jobDesc', 'jobInvoiced', 'jobFlatRate', 'jobBudgetMinutes', 'jobBudgetAmount'];
 
 exports.create = async (req, res) => {
     const authKey = req.get('authKey');

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -17,6 +17,8 @@ const { buildHours } = require('../services/report-hours.js');
 const { buildRevenue } = require('../services/report-revenue.js');
 const { buildBillableSummary } = require('../services/report-billable-summary.js');
 const { buildTimesheet } = require('../services/report-timesheet.js');
+const { buildBudget } = require('../services/report-budget.js');
+const rate = require('../services/rate.js');
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
@@ -368,6 +370,90 @@ exports.timesheet = async (req, res) => {
 
     const report = buildTimesheet(items, req.query.period);
     return res.status(200).json({ message: "Timesheet.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/budget — project budget vs actuals (#434). For each
+ * company job carrying a budget (hours and/or amount), sums logged
+ * minutes + billable amount and flags each dimension under/near/over.
+ */
+exports.budget = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    let jobs;
+    try {
+        jobs = await db.Job.findAll({
+            where: { [Op.or]: [{ jobBudgetMinutes: { [Op.ne]: null } }, { jobBudgetAmount: { [Op.ne]: null } }] },
+            include: [{ model: db.Customer, as: 'customer', required: true, where: { custCompId: companyId }, attributes: ['custId'] }],
+            attributes: ['jobId', 'jobDesc', 'jobBudgetMinutes', 'jobBudgetAmount'],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'budget: Job.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (jobs.length === 0) {
+        return res.status(200).json({ message: "Budget vs actuals.", companyId, jobs: [], count: 0, overCount: 0 });
+    }
+
+    const jobIds = jobs.map((j) => j.jobId);
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where: { teCompId: companyId, teJobId: { [Op.in]: jobIds } },
+            include: [
+                { model: db.BillingType, as: 'billingType', required: false },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
+                {
+                    model: db.Worker, as: 'worker', required: false,
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'budget: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    // Actuals per job: all logged minutes + summed billable amount.
+    const actualMin = new Map();
+    const actualAmt = new Map();
+    for (const e of entries) {
+        if (e.teJobId == null) continue;
+        if (e.teMinutes != null) {
+            actualMin.set(e.teJobId, (actualMin.get(e.teJobId) || 0) + (Number(e.teMinutes) || 0));
+        }
+        if (e.teBillable) {
+            const amt = rate.billableAmount(e);
+            if (amt != null) {
+                const arr = actualAmt.get(e.teJobId) || [];
+                arr.push(amt);
+                actualAmt.set(e.teJobId, arr);
+            }
+        }
+    }
+
+    const jobRows = jobs.map((j) => ({
+        jobId: j.jobId,
+        jobDesc: j.jobDesc,
+        budgetMinutes: j.jobBudgetMinutes,
+        budgetAmount: j.jobBudgetAmount,
+        actualMinutes: actualMin.get(j.jobId) || 0,
+        actualAmount: money.sum(actualAmt.get(j.jobId) || []),
+    }));
+
+    const report = buildBudget(jobRows);
+    return res.status(200).json({ message: "Budget vs actuals.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/migrations/20260603000000-job-budget.js
+++ b/app/migrations/20260603000000-job-budget.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Per-project budgets (#434). jobBudgetMinutes caps effort (hours),
+// jobBudgetAmount caps billable value. Either or both may be set; both
+// nullable (NULL = no budget on that dimension). The budget report
+// compares actuals to these. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const JOB = { tableName: 'Job', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(
+                JOB, 'jobBudgetMinutes',
+                { type: Sequelize.INTEGER, allowNull: true },
+                { transaction: t },
+            );
+            await queryInterface.addColumn(
+                JOB, 'jobBudgetAmount',
+                { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+                { transaction: t },
+            );
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeColumn(JOB, 'jobBudgetAmount', { transaction: t });
+            await queryInterface.removeColumn(JOB, 'jobBudgetMinutes', { transaction: t });
+        });
+    },
+};

--- a/app/models/job.model.js
+++ b/app/models/job.model.js
@@ -47,6 +47,20 @@ module.exports = (sequelize, Sequelize) => {
                 return v == null ? null : Number(v);
             },
         },
+        jobBudgetMinutes: {
+            field: 'jobBudgetMinutes',
+            // Effort budget in minutes (#434); null = no hours budget.
+            type: Sequelize.INTEGER,
+        },
+        jobBudgetAmount: {
+            field: 'jobBudgetAmount',
+            // Value budget (#434); null = no amount budget. Number getter.
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('jobBudgetAmount');
+                return v == null ? null : Number(v);
+            },
+        },
     }, {
         tableName: 'Job',
         timestamps: true,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -735,5 +735,10 @@ router.get(
     v.query(reportSchemas.timesheetQuery),
     report.timesheet,
 );
+router.get(
+    '/v1/report/budget',
+    v.query(reportSchemas.budgetQuery),
+    report.budget,
+);
 
 module.exports = router;

--- a/app/schemas/job.schema.js
+++ b/app/schemas/job.schema.js
@@ -12,16 +12,20 @@ const createJobBody = z.object({
     jobCustId: z.coerce.number().int().positive(),
     jobDesc: z.string().min(1).max(10000),
     jobFlatRate: z.coerce.number().positive().optional(),
+    jobBudgetMinutes: z.coerce.number().int().positive().optional(),
+    jobBudgetAmount: z.coerce.number().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: jobCustId, jobDesc, jobFlatRate.',
+    message: 'Unexpected field in body. Whitelist: jobCustId, jobDesc, jobFlatRate, jobBudgetMinutes, jobBudgetAmount.',
 });
 
 const updateJobBody = z.object({
     jobDesc: z.string().min(1).max(10000).optional(),
     jobInvoiced: z.boolean().optional(),
     jobFlatRate: z.coerce.number().positive().nullable().optional(),
+    jobBudgetMinutes: z.coerce.number().int().positive().nullable().optional(),
+    jobBudgetAmount: z.coerce.number().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: jobDesc, jobInvoiced, jobFlatRate.',
+    message: 'Unexpected field in body. Whitelist: jobDesc, jobInvoiced, jobFlatRate, jobBudgetMinutes, jobBudgetAmount.',
 });
 
 const listByCustomerQuery = z.object({

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -78,4 +78,14 @@ const timesheetQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, workerId, from, to, period.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery };
+/**
+ * GET /v1/report/budget query. companyId required for master keys.
+ * Budgets are lifetime per job, so no date/customer filters.
+ */
+const budgetQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery };

--- a/app/services/report-budget.js
+++ b/app/services/report-budget.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-budget.js — project budget vs actuals (#434). For each budgeted
+ * job, compares logged hours against jobBudgetMinutes and billable value
+ * against jobBudgetAmount, flagging each dimension under / near / over.
+ *
+ * PURE: the caller loads the budgeted jobs with their actuals already
+ * summed. "near" fires at ≥ 80% of budget, "over" past 100%.
+ */
+
+const money = require('./money.js');
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+const NEAR_THRESHOLD = 0.8;
+
+/** ratio actual/budget, or null when there's no positive budget. */
+function ratioOf(actual, budget) {
+    if (budget == null || Number(budget) <= 0) return null;
+    return Number(actual || 0) / Number(budget);
+}
+
+/** under / near / over from a ratio; 'no-budget' when the ratio is null. */
+function statusOf(ratio) {
+    if (ratio == null) return 'no-budget';
+    if (ratio > 1) return 'over';
+    if (ratio >= NEAR_THRESHOLD) return 'near';
+    return 'under';
+}
+
+/**
+ * @param jobs array of { jobId, jobDesc, budgetMinutes, budgetAmount,
+ *   actualMinutes, actualAmount }.
+ * @returns { jobs: [...per-job budget rows], count, overCount }.
+ */
+function buildBudget(jobs) {
+    const rows = (jobs || []).map((j) => {
+        const bMin = j.budgetMinutes == null ? null : Number(j.budgetMinutes);
+        const bAmt = j.budgetAmount == null ? null : Number(j.budgetAmount);
+        const aMin = Number(j.actualMinutes) || 0;
+        const aAmt = money.round(Number(j.actualAmount) || 0);
+        const hoursRatio = ratioOf(aMin, bMin);
+        const amountRatio = ratioOf(aAmt, bAmt);
+        return {
+            jobId: j.jobId,
+            jobDesc: j.jobDesc || null,
+            budgetMinutes: bMin,
+            budgetHours: bMin == null ? null : round2(bMin / 60),
+            actualMinutes: aMin,
+            actualHours: round2(aMin / 60),
+            hoursRatio: hoursRatio == null ? null : round2(hoursRatio),
+            hoursStatus: statusOf(hoursRatio),
+            budgetAmount: bAmt,
+            actualAmount: aAmt,
+            amountRatio: amountRatio == null ? null : round2(amountRatio),
+            amountStatus: statusOf(amountRatio),
+        };
+    }).sort((a, b) => a.jobId - b.jobId);
+
+    const overCount = rows.filter((r) => r.hoursStatus === 'over' || r.amountStatus === 'over').length;
+    return { jobs: rows, count: rows.length, overCount };
+}
+
+module.exports = { buildBudget, ratioOf, statusOf };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -61,4 +61,10 @@ describe('Report auth + schema contract', () => {
     test('GET /v1/report/timesheet rejects an invalid period (schema)', async () => {
         expect((await request(app).get('/v1/report/timesheet?period=month').set('authKey', 'k')).status).toBe(400);
     });
+    test('GET /v1/report/budget 403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/budget')).status).toBe(403);
+    });
+    test('GET /v1/report/budget rejects an unknown query param (schema)', async () => {
+        expect((await request(app).get('/v1/report/budget?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -116,7 +116,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('Job has the jobFlatRate column (#410)', async () => {
         if (!connected) return;
         const rows = await db.Job.findAll({
-            attributes: ['jobId', 'jobFlatRate'],
+            attributes: ['jobId', 'jobFlatRate', 'jobBudgetMinutes', 'jobBudgetAmount'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/report-budget.test.js
+++ b/tests/unit/report-budget.test.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the budget-vs-actuals report (app/services/report-budget.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildBudget, ratioOf, statusOf } = require('../../app/services/report-budget.js');
+
+describe('report-budget.statusOf', () => {
+    test('under / near / over thresholds; no-budget on null', () => {
+        expect(statusOf(null)).toBe('no-budget');
+        expect(statusOf(0.5)).toBe('under');
+        expect(statusOf(0.8)).toBe('near');
+        expect(statusOf(1)).toBe('near');
+        expect(statusOf(1.01)).toBe('over');
+    });
+    test('ratioOf guards a zero/absent budget', () => {
+        expect(ratioOf(10, null)).toBeNull();
+        expect(ratioOf(10, 0)).toBeNull();
+        expect(ratioOf(90, 60)).toBe(1.5);
+    });
+});
+
+describe('report-budget.buildBudget', () => {
+    test('per-job hours + amount status vs budget', () => {
+        const r = buildBudget([
+            { jobId: 1, jobDesc: 'A', budgetMinutes: 600, budgetAmount: 1000, actualMinutes: 660, actualAmount: 900 },
+            { jobId: 2, jobDesc: 'B', budgetMinutes: 600, budgetAmount: null, actualMinutes: 300, actualAmount: 0 },
+        ]);
+        const a = r.jobs.find((j) => j.jobId === 1);
+        expect(a.budgetHours).toBe(10);
+        expect(a.actualHours).toBe(11);
+        expect(a.hoursStatus).toBe('over');       // 660/600 = 1.1
+        expect(a.amountStatus).toBe('near');       // 900/1000 = 0.9
+        const b = r.jobs.find((j) => j.jobId === 2);
+        expect(b.hoursStatus).toBe('under');       // 300/600 = 0.5
+        expect(b.amountStatus).toBe('no-budget');  // no amount budget
+        expect(r.overCount).toBe(1);
+        expect(r.count).toBe(2);
+    });
+
+    test('empty input → empty report', () => {
+        expect(buildBudget([])).toEqual({ jobs: [], count: 0, overCount: 0 });
+    });
+});


### PR DESCRIPTION
## Summary

Set a budget on a project; see how close the actuals are.

Closes #434.

## Changes

- **Migration `20260603000000`** — `Job.jobBudgetMinutes` (effort budget) and `Job.jobBudgetAmount` (value budget), both `nullable`. Either or both may be set; settable on **job create / PATCH** (and bulk).
- **`app/services/report-budget.js`** (pure) — per job, `ratio = actual / budget`, `status` = `under` / `near` (≥ 80%) / `over` (> 100%) / `no-budget` (that dimension unset). Independent status for **hours** and **amount**.
- **`GET /v1/report/budget`** — loads the company's budgeted jobs, sums each one's **logged minutes** and **billable amount** (via `rate.js`, honoring the full rate precedence), and returns per-job budget/actual/ratio/status plus a company `overCount`.

## Verification

`npm run lint` clean; `npm test` → **1023 passing** (status thresholds incl. exact 80%/100% edges, zero-budget guard, per-job hours+amount, over-count; integration column check; route auth + schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/