### PR TITLE
feat(invoicing): invoice summary vs detailed PDF (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Invoice summary vs detailed PDF** (#424) —
+  `GET /v1/invoice/{id}/pdf?format=summary|detailed`. `detailed`
+  (default) itemizes every line; `summary` collapses them into a single
+  "Professional services (N items)" row at the same total. No schema
+  change — a render option on the existing PDF endpoint.
 - **Invoice branding & narratives** (#423). A per-company invoice footer
   (`compInvFooter`, settable on company create/PATCH) and a per-invoice
   note (`invNotes`, settable on invoice create/PATCH and via the roll-up

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1492,7 +1492,10 @@ const spec = {
             get: {
                 summary: 'Download an invoice as a branded PDF',
                 security: [{ authKey: [] }],
-                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'format', in: 'query', schema: { type: 'string', enum: ['summary', 'detailed'] }, description: 'Detailed (default) itemizes lines; summary collapses them.' },
+                ],
                 responses: {
                     200: {
                         description: 'PDF document (attachment)',

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -616,6 +616,7 @@ exports.pdf = async (req, res) => {
         })),
         totals: { subtotal: invoice.invSubtotal, tax: invoice.invTax, total: invoice.invTotal },
         payment: billing,
+        format: req.query.format, // 'summary' | 'detailed' (default) — #424
     };
 
     let pdf;

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -399,6 +399,7 @@ router.get(
 router.get(
     '/v1/invoice/:id/pdf',
     v.params(invoiceSchemas.intIdParam),
+    v.query(invoiceSchemas.pdfQuery),
     invoice.pdf,
 );
 router.patch(

--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -108,6 +108,16 @@ const agingQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId.',
 });
 
+/**
+ * GET /v1/invoice/:id/pdf query — optional render format (#424).
+ * 'detailed' (default) itemizes lines; 'summary' collapses them.
+ */
+const pdfQuery = z.object({
+    format: z.enum(['summary', 'detailed']).optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: format.',
+});
+
 module.exports = {
     intIdParam,
     createInvoiceBody,
@@ -116,4 +126,5 @@ module.exports = {
     bulkInvoiceBody,
     rollupInvoiceBody,
     agingQuery,
+    pdfQuery,
 };

--- a/app/services/invoice-pdf.js
+++ b/app/services/invoice-pdf.js
@@ -53,6 +53,9 @@ function drawInvoice(doc, data) {
     doc.fontSize(11).font('Helvetica').text(customer.name || 'Customer', 50, 176);
 
     // ---- Line items table ----
+    // Summary format (#424) collapses the per-line breakdown into a
+    // single "professional services" row; detailed (default) itemizes.
+    const summary = data.format === 'summary';
     let y = 220;
     doc.fontSize(9).font('Helvetica-Bold');
     doc.text('DESCRIPTION', 50, y);
@@ -63,11 +66,17 @@ function drawInvoice(doc, data) {
     if (lines.length === 0) {
         doc.text('No billable line items.', 50, y);
         y += 18;
-    }
-    for (const line of lines) {
-        doc.text(String(line.description || ''), 50, y, { width: 320 });
-        doc.text(usd(line.amount), 380, y, { align: 'right', width: 165 });
+    } else if (summary) {
+        const sum = money.sum(lines.map((l) => (l.amount == null ? 0 : l.amount)));
+        doc.text(`Professional services (${lines.length} item${lines.length === 1 ? '' : 's'})`, 50, y, { width: 320 });
+        doc.text(usd(sum), 380, y, { align: 'right', width: 165 });
         y += 18;
+    } else {
+        for (const line of lines) {
+            doc.text(String(line.description || ''), 50, y, { width: 320 });
+            doc.text(usd(line.amount), 380, y, { align: 'right', width: 165 });
+            y += 18;
+        }
     }
 
     // ---- Totals ----

--- a/tests/unit/invoice-pdf.test.js
+++ b/tests/unit/invoice-pdf.test.js
@@ -45,4 +45,17 @@ describe('invoice-pdf.renderInvoicePdf', () => {
         expect(isPdf(buf)).toBe(true);
         expect(buf.length).toBeGreaterThan(500);
     });
+
+    test('summary format collapses line items; detailed itemizes (#424)', async () => {
+        const base = {
+            invoice: { number: 'INV-0003', date: '2026-07-01' },
+            lines: [{ description: 'Consulting', amount: 100 }, { description: 'Design', amount: 50 }],
+            totals: { subtotal: 150, tax: 0, total: 150 },
+            payment: {},
+        };
+        const detailed = await renderInvoicePdf(base);
+        const summary = await renderInvoicePdf({ ...base, format: 'summary' });
+        expect(isPdf(detailed)).toBe(true);
+        expect(isPdf(summary)).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary

Choose how much line-item detail the invoice PDF shows.

Closes #424.

## Changes

- **`GET /v1/invoice/{id}/pdf?format=summary|detailed`** — `detailed` (default) itemizes every line as today; `summary` collapses them into one **"Professional services (N items)"** row at the same total. Handy when the line-level breakdown is internal.
- New `pdfQuery` (`format` enum) validated on the existing PDF route. No migration, no model change — purely a render option.

## Note

The issue also mentions "group by phase/activity" — that depends on the tasks/phases model (#407/#408, not yet built), so it's deferred; the summary-vs-detailed split lands here.

## Verification

`npm run lint` clean; `npm test` → **1026 passing** (both formats render a well-formed PDF buffer; the `format` enum is schema-validated). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/