### PR TITLE
feat(time-capture): worker target hours & alerts (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Worker target hours & alerts** (#400). `Worker.workerTargetMinsPerWeek`
+  (migration `20260606000000`, settable on worker create/PATCH) sets a
+  weekly capacity target. New `GET /v1/report/targets?from=&to=` scales
+  each target by the number of ISO weeks in the range, compares it to
+  actual logged time, and flags `under` / `on` (±10%) / `over`, with an
+  `underCount`. New pure `app/services/report-targets.js`.
 - **Invoice currency** (#427). A per-company default currency
   (`compCurrency`, ISO-4217, defaults `USD`) and a per-invoice
   `invCurrency`; migration `20260605000000`. The roll-up stamps the

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1374,6 +1374,22 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/report/targets': {
+            get: {
+                summary: 'Worker target hours vs actuals (under/on/over)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Targets — {weeks, workers[] (target/actual/ratio/status), underCount}' },
+                    400: { description: 'Missing from/to, or master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/budget': {
             get: {
                 summary: 'Project budget vs actuals (hours + amount, with alerts)',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -18,6 +18,7 @@ const { buildRevenue } = require('../services/report-revenue.js');
 const { buildBillableSummary } = require('../services/report-billable-summary.js');
 const { buildTimesheet } = require('../services/report-timesheet.js');
 const { buildBudget } = require('../services/report-budget.js');
+const { buildTargets, weeksBetween } = require('../services/report-targets.js');
 const rate = require('../services/rate.js');
 
 const IsMaster = auth.isMaster;
@@ -454,6 +455,76 @@ exports.budget = async (req, res) => {
 
     const report = buildBudget(jobRows);
     return res.status(200).json({ message: "Budget vs actuals.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/targets — worker capacity: actual hours vs the weekly
+ * target scaled over the date range (#400), flagged under/on/over. from
+ * and to are required. Company-scoped.
+ */
+exports.targets = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const fromISO = req.query.from;
+    const toISO = req.query.to;
+    const from = parseDate(fromISO, false);
+    const to = parseDate(toISO, true);
+    const Op = db.Sequelize && db.Sequelize.Op;
+
+    let workers;
+    try {
+        workers = await db.Worker.findAll({
+            where: { workerCompId: companyId, workerTargetMinsPerWeek: { [Op.ne]: null } },
+            attributes: ['workerId', 'workerFName', 'workerLName', 'workerTargetMinsPerWeek'],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'targets: Worker.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (workers.length === 0) {
+        return res.status(200).json({
+            message: "Targets vs actuals.", companyId,
+            weeks: weeksBetween(fromISO, toISO), workers: [], count: 0, underCount: 0,
+        });
+    }
+
+    const workerIds = workers.map((w) => w.workerId);
+    let entries;
+    try {
+        const where = { teCompId: companyId, teWorkerId: { [Op.in]: workerIds } };
+        if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+        if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+        entries = await db.TimeEntry.findAll({ where, attributes: ['teWorkerId', 'teMinutes'] });
+    } catch (error) {
+        log.error({ err: error }, 'targets: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const actual = new Map();
+    for (const e of entries) {
+        if (e.teWorkerId == null || e.teMinutes == null) continue;
+        actual.set(e.teWorkerId, (actual.get(e.teWorkerId) || 0) + (Number(e.teMinutes) || 0));
+    }
+
+    const rows = workers.map((w) => ({
+        workerId: w.workerId,
+        workerName: [w.workerFName, w.workerLName].filter(Boolean).join(' ') || null,
+        targetMinsPerWeek: w.workerTargetMinsPerWeek,
+        actualMins: actual.get(w.workerId) || 0,
+    }));
+
+    const report = buildTargets(rows, weeksBetween(fromISO, toISO));
+    return res.status(200).json({ message: "Targets vs actuals.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -14,10 +14,10 @@ const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
     'workerFName', 'workerLName', 'workerTitle',
-    'workerDefaultBillType', 'workerCompId',
+    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek',
 ];
 const ALLOWED_FIELDS_UPDATE = [
-    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType',
+    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek',
 ];
 
 /**

--- a/app/migrations/20260606000000-worker-target-hours.js
+++ b/app/migrations/20260606000000-worker-target-hours.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Worker weekly target hours (#400). workerTargetMinsPerWeek is a
+// capacity target in minutes/week; the targets report compares actual
+// logged time against it over a date range. Nullable INTEGER (NULL = no
+// target). setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const WORKER = { tableName: 'Worker', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            WORKER, 'workerTargetMinsPerWeek',
+            { type: Sequelize.INTEGER, allowNull: true },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(WORKER, 'workerTargetMinsPerWeek');
+    },
+};

--- a/app/models/worker.model.js
+++ b/app/models/worker.model.js
@@ -52,6 +52,11 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.INTEGER,
             allowNull: false,
         },
+        workerTargetMinsPerWeek: {
+            field: 'workerTargetMinsPerWeek',
+            // Weekly capacity target in minutes (#400); null = no target.
+            type: Sequelize.INTEGER,
+        },
     }, {
         tableName: 'Worker',
         timestamps: true,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -741,5 +741,10 @@ router.get(
     v.query(reportSchemas.budgetQuery),
     report.budget,
 );
+router.get(
+    '/v1/report/targets',
+    v.query(reportSchemas.targetsQuery),
+    report.targets,
+);
 
 module.exports = router;

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -88,4 +88,16 @@ const budgetQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery };
+/**
+ * GET /v1/report/targets query. companyId required for master keys.
+ * from and to are required — a target only means something over a range.
+ */
+const targetsQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    from: isoDate,
+    to: isoDate,
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery, targetsQuery };

--- a/app/schemas/worker.schema.js
+++ b/app/schemas/worker.schema.js
@@ -22,8 +22,9 @@ const createWorkerBody = z.object({
     workerTitle: z.string().min(1).max(255),
     workerDefaultBillType: z.coerce.number().int().positive(),
     workerCompId: z.coerce.number().int().positive().optional(),
+    workerTargetMinsPerWeek: z.coerce.number().int().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek.',
 });
 
 /**
@@ -37,8 +38,9 @@ const updateWorkerBody = z.object({
     workerLName: z.string().min(1).max(255).optional(),
     workerTitle: z.string().min(1).max(255).optional(),
     workerDefaultBillType: z.coerce.number().int().positive().optional(),
+    workerTargetMinsPerWeek: z.coerce.number().int().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek.',
 });
 
 const listByCompanyQuery = z.object({

--- a/app/services/report-targets.js
+++ b/app/services/report-targets.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-targets.js — worker capacity: actual hours vs target over a
+ * date range (#400). Each worker's weekly target is scaled by the number
+ * of ISO weeks in the range, then compared to what they actually logged,
+ * flagging under / on / over (±10% band).
+ *
+ * PURE: the caller loads the workers (with a target + summed actual
+ * minutes) and the week count. No DB.
+ */
+
+const { weekKey } = require('./report-timesheet.js');
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+const BAND = 0.1;
+
+/** under / on / over from a ratio; 'no-target' when the ratio is null. */
+function statusOf(ratio) {
+    if (ratio == null) return 'no-target';
+    if (ratio > 1 + BAND) return 'over';
+    if (ratio < 1 - BAND) return 'under';
+    return 'on';
+}
+
+/** Count of ISO weeks spanned by [fromISO, toISO] (inclusive), min 1. */
+function weeksBetween(fromISO, toISO) {
+    const w1 = weekKey(fromISO);
+    const w2 = weekKey(toISO);
+    if (w1 === 'unknown' || w2 === 'unknown') return 1;
+    const d1 = new Date(w1 + 'T00:00:00.000Z').getTime();
+    const d2 = new Date(w2 + 'T00:00:00.000Z').getTime();
+    if (!Number.isFinite(d1) || !Number.isFinite(d2)) return 1;
+    return Math.max(1, Math.round((d2 - d1) / (7 * 86400000)) + 1);
+}
+
+/**
+ * @param workers array of { workerId, workerName, targetMinsPerWeek,
+ *   actualMins }.
+ * @param weeks number of weeks the target applies over.
+ * @returns { weeks, workers: [...rows], count, underCount }.
+ */
+function buildTargets(workers, weeks) {
+    const w = Math.max(1, Math.round(Number(weeks) || 1));
+    const rows = (workers || []).map((x) => {
+        const perWeek = x.targetMinsPerWeek == null ? null : Number(x.targetMinsPerWeek);
+        const targetMins = perWeek == null ? null : perWeek * w;
+        const actualMins = Number(x.actualMins) || 0;
+        const ratio = (targetMins == null || targetMins <= 0) ? null : actualMins / targetMins;
+        return {
+            workerId: x.workerId,
+            workerName: x.workerName || null,
+            targetMinutesPerWeek: perWeek,
+            targetMinutes: targetMins,
+            targetHours: targetMins == null ? null : round2(targetMins / 60),
+            actualMinutes: actualMins,
+            actualHours: round2(actualMins / 60),
+            ratio: ratio == null ? null : round2(ratio),
+            status: statusOf(ratio),
+        };
+    }).sort((a, b) => a.workerId - b.workerId);
+
+    const underCount = rows.filter((r) => r.status === 'under').length;
+    return { weeks: w, workers: rows, count: rows.length, underCount };
+}
+
+module.exports = { buildTargets, weeksBetween, statusOf };

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -67,4 +67,10 @@ describe('Report auth + schema contract', () => {
     test('GET /v1/report/budget rejects an unknown query param (schema)', async () => {
         expect((await request(app).get('/v1/report/budget?bogus=1').set('authKey', 'k')).status).toBe(400);
     });
+    test('GET /v1/report/targets 403 without authKey (from/to present)', async () => {
+        expect((await request(app).get('/v1/report/targets?from=2026-07-01&to=2026-07-14')).status).toBe(403);
+    });
+    test('GET /v1/report/targets 400 when from/to are missing (schema)', async () => {
+        expect((await request(app).get('/v1/report/targets').set('authKey', 'k')).status).toBe(400);
+    });
 });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -206,6 +206,15 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(withLinks)).toBe(true);
     });
 
+    test('Worker has the workerTargetMinsPerWeek column (#400)', async () => {
+        if (!connected) return;
+        const rows = await db.Worker.findAll({
+            attributes: ['workerId', 'workerTargetMinsPerWeek'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+    });
+
     test('/healthz reports a non-null migration name (dbo-qualified read)', async () => {
         // sequelize-cli writes the SequelizeMeta table into the `dbo`
         // schema (`migrationStorageTableSchema: 'dbo'` in

--- a/tests/unit/report-targets.test.js
+++ b/tests/unit/report-targets.test.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the worker-targets report (app/services/report-targets.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { buildTargets, weeksBetween, statusOf } = require('../../app/services/report-targets.js');
+
+describe('report-targets.statusOf', () => {
+    test('under / on / over within a ±10% band; no-target on null', () => {
+        expect(statusOf(null)).toBe('no-target');
+        expect(statusOf(0.5)).toBe('under');
+        expect(statusOf(0.9)).toBe('on');
+        expect(statusOf(1)).toBe('on');
+        expect(statusOf(1.1)).toBe('on');
+        expect(statusOf(1.2)).toBe('over');
+        expect(statusOf(0.89)).toBe('under');
+    });
+});
+
+describe('report-targets.weeksBetween', () => {
+    test('counts ISO weeks spanned (inclusive), min 1', () => {
+        expect(weeksBetween('2026-07-06', '2026-07-12')).toBe(1); // one Mon–Sun week
+        expect(weeksBetween('2026-07-06', '2026-07-13')).toBe(2); // two Mondays
+        expect(weeksBetween('2026-07-01', '2026-07-14')).toBe(3); // weeks 06-29, 07-06, 07-13
+        expect(weeksBetween(null, '2026-07-14')).toBe(1);
+    });
+});
+
+describe('report-targets.buildTargets', () => {
+    test('scales weekly target by weeks and flags status', () => {
+        const r = buildTargets([
+            { workerId: 1, workerName: 'W', targetMinsPerWeek: 2400, actualMins: 4800 }, // 40h/wk × 2 = 80h, did 80h → on
+            { workerId: 2, workerName: 'V', targetMinsPerWeek: 2400, actualMins: 2000 }, // did far less → under
+            { workerId: 3, workerName: 'U', targetMinsPerWeek: null, actualMins: 100 },  // no target
+        ], 2);
+        expect(r.weeks).toBe(2);
+        const a = r.workers.find((x) => x.workerId === 1);
+        expect(a.targetHours).toBe(80);
+        expect(a.actualHours).toBe(80);
+        expect(a.status).toBe('on');
+        expect(r.workers.find((x) => x.workerId === 2).status).toBe('under');
+        expect(r.workers.find((x) => x.workerId === 3).status).toBe('no-target');
+        expect(r.underCount).toBe(1);
+    });
+
+    test('empty input → empty report', () => {
+        expect(buildTargets([], 1)).toEqual({ weeks: 1, workers: [], count: 0, underCount: 0 });
+    });
+});


### PR DESCRIPTION
## Summary

Set a weekly capacity target per worker; see who's under, on, or over.

Closes #400.

## Changes

- **Migration `20260606000000`** — `Worker.workerTargetMinsPerWeek` (nullable INTEGER), settable on worker create/PATCH.
- **`app/services/report-targets.js`** (pure) — scales each worker's weekly target by the number of **ISO weeks** in the range, compares to actual logged minutes, and flags `under` / `on` (within ±10%) / `over` / `no-target`.
- **`GET /v1/report/targets?from=&to=`** — company-scoped; `from`/`to` **required** (a target only means something over a period). Returns per-worker target/actual/ratio/status plus an `underCount`.

## Verification

`npm run lint` clean; `npm test` → **1038 passing** (±10% band incl. exact 0.9/1.1 edges, ISO-week counting incl. Sunday spans, target scaling; integration column check; route auth + `from`/`to`-required schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/