### PR TITLE
feat(compliance): audit log (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Audit log** (#460). An append-only `AuditLog` trail (migration
+  `20260607000000`) — a `/v1` middleware records every **successful
+  mutation** (POST/PATCH/PUT/DELETE) after the response is sent,
+  fire-and-forget so it never blocks or breaks a request: actor
+  (`master` or `company:<id>`), method, path, parsed entity, and status.
+  `GET /v1/auditlog/bycompany/{id}` reads a company's trail (scoped),
+  newest first, with `method` / `entity` filters + pagination.
 - **Worker target hours & alerts** (#400). `Worker.workerTargetMinsPerWeek`
   (migration `20260606000000`, settable on worker create/PATCH) sets a
   weekly capacity target. New `GET /v1/report/targets?from=&to=` scales

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -67,6 +67,7 @@ db.PurchaseOrderHeader = require('../models/purchaseorderheader.model.js')(seque
 db.PurchaseOrderLine = require('../models/purchaseorderline.model.js')(sequelize, Sequelize);
 db.InventoryTransaction = require('../models/inventorytransaction.model.js')(sequelize, Sequelize);
 db.Expense = require('../models/expense.model.js')(sequelize, Sequelize);
+db.AuditLog = require('../models/auditlog.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -181,5 +182,9 @@ db.Expense.belongsTo(db.Job,      { foreignKey: 'expJobId',  as: 'job' });
 // into (#418); doubles as the "invoiced" marker (NULL = unbilled).
 db.Invoice.hasMany(db.Expense,    { foreignKey: 'expInvId',  as: 'expenses' });
 db.Expense.belongsTo(db.Invoice,  { foreignKey: 'expInvId',  as: 'invoice' });
+
+// AuditLog → Company (alogCompId): the actor's company (#460).
+db.Company.hasMany(db.AuditLog,   { foreignKey: 'alogCompId', as: 'auditLogs' });
+db.AuditLog.belongsTo(db.Company, { foreignKey: 'alogCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1329,6 +1329,23 @@ const spec = {
             patch: { summary: 'Partial update of an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Invoice' } } } }, responses: { 200: { description: 'Updated' }, 400: { description: 'No updatable fields supplied' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
             delete: { summary: 'Soft-delete an invoice', security: [{ authKey: [] }], parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }], responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' }, 403: { description: 'Auth failure' } } },
         },
+        '/v1/auditlog/bycompany/{id}': {
+            get: {
+                summary: "A company's audit trail (successful mutations)",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'method', in: 'query', schema: { type: 'string', enum: ['POST', 'PATCH', 'PUT', 'DELETE'] } },
+                    { name: 'entity', in: 'query', schema: { type: 'string' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: {
+                    200: { description: 'Found — {entries[] (actor, method, path, entity, status, createdAt)}, newest first' },
+                    403: { description: 'Auth failure / cross-tenant' },
+                },
+            },
+        },
         '/v1/expense': {
             post: {
                 summary: 'Create an expense',

--- a/app/controllers/auditlogcontroller.js
+++ b/app/controllers/auditlogcontroller.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const AuditLog = db.AuditLog;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/**
+ * GET /v1/auditlog/bycompany/:id — the audit trail for a company (#460).
+ * Scoped: a non-master key may only read its own company's trail (403
+ * otherwise — the resource is the company's own log, not a cross-tenant
+ * row, so a plain 403 is fine here). Honors ?method / ?entity filters
+ * and pagination; newest first.
+ */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const where = { alogCompId: targetCompanyId };
+    if (typeof req.query.method === 'string' && req.query.method) where.alogMethod = req.query.method;
+    if (typeof req.query.entity === 'string' && req.query.entity) where.alogEntity = req.query.entity.toLowerCase();
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await AuditLog.findAndCountAll({
+            where,
+            limit,
+            offset,
+            order: [['alogId', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, entries: rows });
+    } catch (error) {
+        log.error({ err: error }, 'AuditLog.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/middleware/audit.js
+++ b/app/middleware/audit.js
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * audit.js — record successful mutations to the audit log (#460).
+ *
+ * Mounted on /v1 AFTER attachAuth (so req.isMaster / req.companyId are
+ * set). For mutating methods it attaches a `finish` listener and, once
+ * the response is sent, writes an AuditLog row FIRE-AND-FORGET: the write
+ * happens off the request's critical path and any failure is swallowed
+ * (logged) — an audit hiccup must never break or slow a real request.
+ * Only successful (< 400) mutations are recorded.
+ */
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+
+const MUTATING = new Set(['POST', 'PATCH', 'PUT', 'DELETE']);
+
+/** Parse the entity segment from a /v1/<entity>/... path. */
+function entityOf(path) {
+    const m = /^\/v1\/([a-zA-Z-]+)/.exec(path || '');
+    return m ? m[1].toLowerCase() : null;
+}
+
+function auditLog(req, res, next) {
+    const method = (req.method || '').toUpperCase();
+    if (!MUTATING.has(method)) return next();
+
+    res.on('finish', () => {
+        try {
+            if (res.statusCode >= 400) return; // only successful mutations
+            if (!db.AuditLog || typeof db.AuditLog.create !== 'function') return;
+
+            const isMaster = req.isMaster === true;
+            const companyId = typeof req.companyId === 'number' && req.companyId > 0 ? req.companyId : null;
+            const fullPath = (req.originalUrl || req.url || '').split('?')[0];
+
+            const row = {
+                alogCompId: isMaster ? null : companyId,
+                alogActor: isMaster ? 'master' : (companyId != null ? `company:${companyId}` : 'unknown'),
+                alogMethod: method,
+                alogPath: fullPath,
+                alogEntity: entityOf(fullPath),
+                alogStatus: res.statusCode,
+            };
+
+            Promise.resolve(db.AuditLog.create(row)).catch((err) => {
+                log.error({ err }, 'audit: write failed');
+            });
+        } catch (err) {
+            log.error({ err }, 'audit: middleware error');
+        }
+    });
+
+    return next();
+}
+
+module.exports = { auditLog, entityOf };

--- a/app/migrations/20260607000000-audit-log.js
+++ b/app/migrations/20260607000000-audit-log.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Audit log (#460): an append-only trail of successful mutations — who
+// (actor + company), what (method + path + entity), when. Written
+// fire-and-forget by the audit middleware after each mutating request.
+// A new table in the increment layer; no FK constraints. setup/*.sql
+// untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'AuditLog', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    alogId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    alogCompId: { type: Sequelize.INTEGER, allowNull: true },
+                    alogActor: { type: Sequelize.TEXT, allowNull: false },
+                    alogMethod: { type: Sequelize.TEXT, allowNull: false },
+                    alogPath: { type: Sequelize.TEXT, allowNull: false },
+                    alogEntity: { type: Sequelize.TEXT, allowNull: true },
+                    alogStatus: { type: Sequelize.INTEGER, allowNull: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, {
+                name: 'AuditLog_compId_id_idx',
+                fields: ['alogCompId', 'alogId'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/auditlog.model.js
+++ b/app/models/auditlog.model.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * AuditLog — an append-only record of a successful mutating request
+ * (#460): actor (a scoped company or a master key), the HTTP method +
+ * path + parsed entity, and the response status. Written by the audit
+ * middleware; never updated or soft-deleted.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const AuditLog = sequelize.define('AuditLog', {
+        alogId: {
+            field: 'alogId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        alogCompId: {
+            field: 'alogCompId',
+            // The actor's company (null for master keys).
+            type: Sequelize.INTEGER,
+        },
+        alogActor: { field: 'alogActor', type: Sequelize.TEXT, allowNull: false },
+        alogMethod: { field: 'alogMethod', type: Sequelize.TEXT, allowNull: false },
+        alogPath: { field: 'alogPath', type: Sequelize.TEXT, allowNull: false },
+        alogEntity: { field: 'alogEntity', type: Sequelize.TEXT },
+        alogStatus: { field: 'alogStatus', type: Sequelize.INTEGER, allowNull: false },
+    }, {
+        tableName: 'AuditLog',
+        timestamps: true,
+    });
+
+    return AuditLog;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -7,6 +7,7 @@ const swaggerUi = require('swagger-ui-express');
 const { attachAuth } = require('../middleware/auth.js');
 const { idempotency } = require('../middleware/idempotency.js');
 const { metricsHandler } = require('../middleware/metrics.js');
+const { auditLog } = require('../middleware/audit.js');
 
 const customer = require('../controllers/customercontroller.js');
 const health = require('../controllers/healthcontroller.js');
@@ -28,6 +29,7 @@ const inventoryTransaction = require('../controllers/inventorytransactioncontrol
 const whoami = require('../controllers/whoamicontroller.js');
 const report = require('../controllers/reportcontroller.js');
 const expense = require('../controllers/expensecontroller.js');
+const auditlog = require('../controllers/auditlogcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -47,6 +49,7 @@ const purchaseOrderHeaderSchemas = require('../schemas/purchaseorderheader.schem
 const purchaseOrderLineSchemas = require('../schemas/purchaseorderline.schema.js');
 const reportSchemas = require('../schemas/report.schema.js');
 const expenseSchemas = require('../schemas/expense.schema.js');
+const auditlogSchemas = require('../schemas/auditlog.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -78,6 +81,11 @@ router.use('/v1', (req, res, next) => {
     if (req.method !== 'POST') return next();
     return idempotency(req, res, next);
 });
+
+// Audit trail (#460): record successful mutations after the response is
+// sent. Fire-and-forget; never blocks or breaks a request. Mounted after
+// attachAuth so req.isMaster / req.companyId are populated.
+router.use('/v1', auditLog);
 
 // Identity probe — returns what the calling authKey resolves to.
 // Distinguishes "header missing" (403) from "header present but
@@ -708,6 +716,14 @@ router.delete(
     '/v1/expense/:id',
     v.params(expenseSchemas.intIdParam),
     expense.remove,
+);
+
+// v1 audit-log route (compliance, #460).
+router.get(
+    '/v1/auditlog/bycompany/:id',
+    v.params(auditlogSchemas.intIdParam),
+    v.query(auditlogSchemas.listQuery),
+    auditlog.listByCompany,
 );
 
 // v1 report routes (read-only analytics).

--- a/app/schemas/auditlog.schema.js
+++ b/app/schemas/auditlog.schema.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** GET /v1/auditlog/bycompany/:id query — optional filters + pagination. */
+const listQuery = z.object({
+    method: z.enum(['POST', 'PATCH', 'PUT', 'DELETE']).optional(),
+    entity: z.string().min(1).max(40).optional(),
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: method, entity, limit, offset.',
+});
+
+module.exports = { intIdParam, listQuery };

--- a/tests/api/auditlog.test.js
+++ b/tests/api/auditlog.test.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for the audit-log read endpoint (#460).
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, TimeEntry: {},
+    AuditLog: { findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Audit-log read contract', () => {
+    test('GET /v1/auditlog/bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/auditlog/bycompany/1')).status).toBe(403);
+    });
+    test('GET /v1/auditlog/bycompany/:id rejects an unknown query param (schema)', async () => {
+        expect((await request(app).get('/v1/auditlog/bycompany/1?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /v1/auditlog/bycompany/:id rejects an invalid method filter (schema)', async () => {
+        expect((await request(app).get('/v1/auditlog/bycompany/1?method=GET').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /v1/auditlog/bycompany/:id rejects a non-integer id (schema)', async () => {
+        expect((await request(app).get('/v1/auditlog/bycompany/abc').set('authKey', 'k')).status).toBe(400);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -206,6 +206,15 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(withLinks)).toBe(true);
     });
 
+    test('AuditLog table exists with its columns (#460)', async () => {
+        if (!connected) return;
+        const rows = await db.AuditLog.findAll({
+            attributes: ['alogId', 'alogCompId', 'alogActor', 'alogMethod', 'alogPath', 'alogEntity', 'alogStatus'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+    });
+
     test('Worker has the workerTargetMinsPerWeek column (#400)', async () => {
         if (!connected) return;
         const rows = await db.Worker.findAll({

--- a/tests/unit/audit-middleware.test.js
+++ b/tests/unit/audit-middleware.test.js
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the audit middleware's entity parser (#460).
+
+import { describe, test, expect } from 'vitest';
+
+const { entityOf } = require('../../app/middleware/audit.js');
+
+describe('audit.entityOf', () => {
+    test('parses the entity segment from a /v1 path', () => {
+        expect(entityOf('/v1/invoice/5')).toBe('invoice');
+        expect(entityOf('/v1/timeentry')).toBe('timeentry');
+        expect(entityOf('/v1/report/budget')).toBe('report');
+        expect(entityOf('/v1/auditlog/bycompany/1')).toBe('auditlog');
+    });
+    test('returns null for non-/v1 or empty paths', () => {
+        expect(entityOf('/healthz')).toBeNull();
+        expect(entityOf('')).toBeNull();
+        expect(entityOf(null)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

A who / what / when trail of every change. Opens the **compliance** area.

Closes #460.

## Changes

- **Migration `20260607000000`** — an append-only `AuditLog` table (`alogCompId`, `alogActor`, `alogMethod`, `alogPath`, `alogEntity`, `alogStatus`, `createdAt`) + a `(alogCompId, alogId)` index.
- **`app/middleware/audit.js`** — mounted on `/v1` **after `attachAuth`** (so `req.isMaster` / `req.companyId` are populated). For mutating methods it attaches a `finish` listener and, once the response is sent, writes the row **fire-and-forget** — off the request's critical path, and every failure is caught + logged. **Only successful (< 400) mutations** are recorded; reads are ignored.
- **`GET /v1/auditlog/bycompany/{id}`** — a company's trail, scoped (a non-master key may only read its own), newest first, with `method` / `entity` filters + RFC-5988 pagination.

## Design notes

- The audit write **never blocks or breaks a request** — it runs after `res.finish`, wrapped in try/catch, and no-ops when the model is absent.
- Actor is `master` or `company:<id>`; master mutations record `alogCompId = null` (cross-tenant operator actions).

## Verification

`npm run lint` clean; `npm test` → **1054 passing** (entity parser, route auth + schema incl. bad method/id, integration table check). The global middleware leaves every existing api test green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/