### PR TITLE
feat(approvals): timesheet submit/review/approve (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Timesheet approval workflow** (#440). `TimeEntry.teApprovalStatus`
+  (migration `20260608000000`, default `open`) tracks an entry through
+  **open → submitted → approved / rejected** (a rejected entry may
+  re-submit; approved is terminal). `POST /v1/timeentry/{id}/approval`
+  with `{ action: submit|approve|reject }` applies the guarded transition
+  (409 on an illegal one); both list routes accept `?approvalStatus=`.
+  New pure `app/services/approval.js` state machine.
 - **Audit log** (#460). An append-only `AuditLog` trail (migration
   `20260607000000`) — a `/v1` middleware records every **successful
   mutation** (POST/PATCH/PUT/DELETE) after the response is sent,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -836,6 +836,22 @@ const spec = {
                 },
             },
         },
+        '/v1/timeentry/{id}/approval': {
+            post: {
+                summary: 'Advance a time entry through the approval workflow',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                requestBody: {
+                    content: { 'application/json': { schema: { type: 'object', properties: { action: { type: 'string', enum: ['submit', 'approve', 'reject'] } }, required: ['action'] } } },
+                },
+                responses: {
+                    200: { description: 'Approval updated' },
+                    400: { description: 'Bad action' },
+                    404: { description: 'Not found' },
+                    409: { description: 'Illegal transition from current state' },
+                },
+            },
+        },
         '/v1/timeentry': {
             post: {
                 summary: 'Create a time entry',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -8,6 +8,7 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const { escapeCsvCell } = require('./_csv-escape.js');
 const rate = require('../services/rate.js');
+const { applyAction } = require('../services/approval.js');
 const TimeEntry = db.TimeEntry;
 
 // Auth helpers used to live inline here — they now share a single
@@ -337,6 +338,51 @@ exports.stop = async (req, res) => {
 };
 
 /**
+ * POST /v1/timeentry/:id/approval — advance an entry through the
+ * approval workflow (#440). Body { action: submit|approve|reject }.
+ * Secure-404 scoped; 409 on an illegal transition from the current state.
+ */
+exports.approval = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let entry;
+    try {
+        entry = await TimeEntry.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'approval: TimeEntry.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!entry || entry.teArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || entry.teCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const action = req.body && req.body.action;
+    const result = applyAction(entry.teApprovalStatus, action);
+    if (result.error) {
+        return res.status(409).json({ message: result.error });
+    }
+
+    try {
+        await entry.update({ teApprovalStatus: result.status });
+        return res.status(200).json({ message: "Approval updated.", timeEntry: entry });
+    } catch (error) {
+        log.error({ err: error }, 'approval: TimeEntry.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
  * GET /v1/timeentry/:id — fetch a single time entry by id.
  *
  * Scoped: non-master keys may only read entries in their own company.
@@ -435,6 +481,10 @@ exports.listByCompany = async (req, res) => {
     // Tag filter (#406): entries whose teTags JSONB array contains the tag.
     if (db.Sequelize && db.Sequelize.Op && typeof req.query.tag === 'string' && req.query.tag) {
         where.teTags = { [db.Sequelize.Op.contains]: [req.query.tag] };
+    }
+    // Approval-status filter (#440).
+    if (typeof req.query.approvalStatus === 'string' && req.query.approvalStatus) {
+        where.teApprovalStatus = req.query.approvalStatus;
     }
     // Date range — use Sequelize.Op.gte/lte. Keep it permissive: bad
     // dates are silently dropped rather than 400'd, so a typo in the
@@ -535,6 +585,10 @@ exports.listByWorker = async (req, res) => {
     // Tag filter (#406): entries whose teTags JSONB array contains the tag.
     if (db.Sequelize && db.Sequelize.Op && typeof req.query.tag === 'string' && req.query.tag) {
         where.teTags = { [db.Sequelize.Op.contains]: [req.query.tag] };
+    }
+    // Approval-status filter (#440).
+    if (typeof req.query.approvalStatus === 'string' && req.query.approvalStatus) {
+        where.teApprovalStatus = req.query.approvalStatus;
     }
     const Op = db.Sequelize && db.Sequelize.Op;
     const fromDate = parseDateOrNull(req.query.from);

--- a/app/migrations/20260608000000-timeentry-approval.js
+++ b/app/migrations/20260608000000-timeentry-approval.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Timesheet approval workflow (#440). teApprovalStatus tracks a time
+// entry through open → submitted → approved / rejected. NOT NULL default
+// 'open' — Postgres backfills existing rows to 'open' when the column is
+// added. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'TimeEntry', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            TABLE, 'teApprovalStatus',
+            { type: Sequelize.TEXT, allowNull: false, defaultValue: 'open' },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(TABLE, 'teApprovalStatus');
+    },
+};

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -94,6 +94,13 @@ module.exports = (sequelize, Sequelize) => {
                 return Array.isArray(v) ? v : [];
             },
         },
+        teApprovalStatus: {
+            field: 'teApprovalStatus',
+            // Approval workflow state (#440): open → submitted →
+            // approved / rejected. Defaults 'open'.
+            type: Sequelize.TEXT,
+            defaultValue: 'open',
+        },
         teArch: {
             field: 'teArch',
             type: Sequelize.BOOLEAN,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -166,6 +166,13 @@ router.post(
     v.params(timeEntrySchemas.intIdParam),
     timeEntry.stop,
 );
+// Timesheet approval workflow (#440): submit / approve / reject.
+router.post(
+    '/v1/timeentry/:id/approval',
+    v.params(timeEntrySchemas.intIdParam),
+    v.body(timeEntrySchemas.approvalBody),
+    timeEntry.approval,
+);
 // Literal paths declared BEFORE /:id so express doesn't try to
 // parse "export.csv" / "bycompany" as a customer id.
 router.get(

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -103,15 +103,22 @@ const exportCsvQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, from, to, limit, offset.',
 });
 
+const approvalBody = z.object({
+    action: z.enum(['submit', 'approve', 'reject']),
+}).strict({
+    message: 'Body must be { action: submit|approve|reject }.',
+});
+
 const listByCompanyQuery = z.object({
     customerId: z.coerce.number().int().positive().optional(),
     tag: z.string().min(1).max(64).optional(),
+    approvalStatus: z.enum(['open', 'submitted', 'approved', 'rejected']).optional(),
     from: isoDatetime.optional(),
     to: isoDatetime.optional(),
     limit: z.coerce.number().int().positive().max(500).optional(),
     offset: z.coerce.number().int().nonnegative().optional(),
 }).strict({
-    message: 'Unexpected query parameter. Allowed: customerId, tag, from, to, limit, offset.',
+    message: 'Unexpected query parameter. Allowed: customerId, tag, approvalStatus, from, to, limit, offset.',
 });
 
 /**
@@ -138,6 +145,7 @@ module.exports = {
     createTimeEntryBody,
     updateTimeEntryBody,
     startTimerBody,
+    approvalBody,
     listByCompanyQuery,
     exportCsvQuery,
 };

--- a/app/services/approval.js
+++ b/app/services/approval.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * approval.js — the timesheet approval state machine (#440).
+ *
+ *   open ─submit─▶ submitted ─approve─▶ approved
+ *     ▲                 │
+ *     └──── (resubmit)  └─reject─▶ rejected ─submit─▶ submitted
+ *
+ * A rejected entry can be re-submitted. Approved is terminal. PURE — no
+ * DB; the controller loads the row, applies the transition, and saves.
+ */
+
+const STATUSES = ['open', 'submitted', 'approved', 'rejected'];
+
+const TRANSITIONS = {
+    submit: { from: ['open', 'rejected'], to: 'submitted' },
+    approve: { from: ['submitted'], to: 'approved' },
+    reject: { from: ['submitted'], to: 'rejected' },
+};
+
+/**
+ * Apply an action to the current status.
+ * @returns { status } on a legal transition, or { error } (a message)
+ *   when the action is unknown or illegal from the current state.
+ */
+function applyAction(current, action) {
+    const cur = STATUSES.includes(current) ? current : 'open';
+    const t = TRANSITIONS[action];
+    if (!t) return { error: `Unknown action '${action}'. Use submit, approve, or reject.` };
+    if (!t.from.includes(cur)) {
+        return { error: `Cannot ${action} a time entry whose approval status is '${cur}'.` };
+    }
+    return { status: t.to };
+}
+
+module.exports = { applyAction, STATUSES, TRANSITIONS };

--- a/tests/api/timeentry-approval.test.js
+++ b/tests/api/timeentry-approval.test.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for the approval endpoint (#440) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {},
+    TimeEntry: { findByPk: vi.fn().mockResolvedValue(null) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Timesheet approval contract', () => {
+    test('POST /v1/timeentry/:id/approval 403 without authKey (valid body)', async () => {
+        expect((await request(app).post('/v1/timeentry/1/approval').send({ action: 'submit' })).status).toBe(403);
+    });
+    test('POST /v1/timeentry/:id/approval 400 on an invalid action (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/1/approval').set('authKey', 'k').send({ action: 'lgtm' })).status).toBe(400);
+    });
+    test('POST /v1/timeentry/:id/approval 400 on a missing action (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/1/approval').set('authKey', 'k').send({})).status).toBe(400);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -127,7 +127,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         // Selecting the new attributes proves the 20260521 + 20260523
         // migrations added the columns (a missing column would throw).
         const rows = await db.TimeEntry.findAll({
-            attributes: ['teId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teInvJobId', 'teTags'],
+            attributes: ['teId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teInvJobId', 'teTags', 'teApprovalStatus'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/approval.test.js
+++ b/tests/unit/approval.test.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the approval state machine (app/services/approval.js).
+
+import { describe, test, expect } from 'vitest';
+
+const { applyAction } = require('../../app/services/approval.js');
+
+describe('approval.applyAction', () => {
+    test('the happy path: open → submitted → approved', () => {
+        expect(applyAction('open', 'submit')).toEqual({ status: 'submitted' });
+        expect(applyAction('submitted', 'approve')).toEqual({ status: 'approved' });
+    });
+
+    test('reject sends submitted → rejected, and rejected can re-submit', () => {
+        expect(applyAction('submitted', 'reject')).toEqual({ status: 'rejected' });
+        expect(applyAction('rejected', 'submit')).toEqual({ status: 'submitted' });
+    });
+
+    test('illegal transitions error (no state change)', () => {
+        expect(applyAction('open', 'approve').error).toMatch(/Cannot approve/);
+        expect(applyAction('approved', 'reject').error).toMatch(/Cannot reject/);
+        expect(applyAction('open', 'reject').error).toMatch(/Cannot reject/);
+    });
+
+    test('unknown action errors; unknown current status treated as open', () => {
+        expect(applyAction('submitted', 'bogus').error).toMatch(/Unknown action/);
+        expect(applyAction(null, 'submit')).toEqual({ status: 'submitted' });
+    });
+});


### PR DESCRIPTION
## Summary

A submit → review → approve workflow on time entries. Opens the **approvals** area.

Closes #440.

## Changes

- **Migration `20260608000000`** — `TimeEntry.teApprovalStatus` (TEXT, NOT NULL default `open`; Postgres backfills existing rows).
- **`app/services/approval.js`** (pure state machine) — `open ─submit▶ submitted ─approve▶ approved`, `submitted ─reject▶ rejected`, and `rejected ─submit▶ submitted`. Approved is terminal; illegal transitions return an error.
- **`POST /v1/timeentry/{id}/approval`** with `{ action: submit|approve|reject }` — secure-404 scoped; **409** on an illegal transition from the current state.
- Both list routes (`bycompany`, `worker/{id}/timeentries`) accept **`?approvalStatus=`**.

## Verification

`npm run lint` clean; `npm test` → **1065 passing** (happy path, reject + re-submit, illegal transitions, unknown action, unknown-status→open; route auth + schema; integration column check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/