### PR TITLE
feat(structure): tasks / activities under jobs (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Tasks / activities under jobs** (#407). A new `Task` model
+  (`taskName`, `taskDesc`) under a Job, migration `20260611000000`. Full
+  REST: `POST /v1/task`, `GET /v1/task/byjob/{id}` (paginated),
+  `GET|PATCH|DELETE /v1/task/{id}`, all scoped through the job's company
+  (`getCompanyIdByJobId`) with the same secure-404 + soft-delete
+  (`taskArch`) as the other entities. Foundation for per-task rates and
+  task-level reporting.
 - **Client-specific rate cards** (#413). `Customer.custDefaultRate`
   (migration `20260610000000`, settable on customer create/PATCH) is the
   **client tier** of rate resolution in `rate.js`: per-entry override →

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -68,6 +68,7 @@ db.PurchaseOrderLine = require('../models/purchaseorderline.model.js')(sequelize
 db.InventoryTransaction = require('../models/inventorytransaction.model.js')(sequelize, Sequelize);
 db.Expense = require('../models/expense.model.js')(sequelize, Sequelize);
 db.AuditLog = require('../models/auditlog.model.js')(sequelize, Sequelize);
+db.Task = require('../models/task.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -186,5 +187,9 @@ db.Expense.belongsTo(db.Invoice,  { foreignKey: 'expInvId',  as: 'invoice' });
 // AuditLog → Company (alogCompId): the actor's company (#460).
 db.Company.hasMany(db.AuditLog,   { foreignKey: 'alogCompId', as: 'auditLogs' });
 db.AuditLog.belongsTo(db.Company, { foreignKey: 'alogCompId', as: 'company' });
+
+// Task → Job (taskJobId): a unit of work / activity under a project (#407).
+db.Job.hasMany(db.Task,   { foreignKey: 'taskJobId', as: 'tasks' });
+db.Task.belongsTo(db.Job, { foreignKey: 'taskJobId', as: 'job' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1362,6 +1362,49 @@ const spec = {
                 },
             },
         },
+        '/v1/task': {
+            post: {
+                summary: 'Create a task / activity under a job',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Created' },
+                    400: { description: 'Validation error or bad taskJobId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
+        '/v1/task/byjob/{id}': {
+            get: {
+                summary: "List a job's tasks",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 404: { description: 'Job not found / cross-tenant' } },
+            },
+        },
+        '/v1/task/{id}': {
+            get: {
+                summary: 'Fetch a task',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a task',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a task',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/expense': {
             post: {
                 summary: 'Create an expense',

--- a/app/controllers/taskcontroller.js
+++ b/app/controllers/taskcontroller.js
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const Task = db.Task;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
+
+const ALLOWED_FIELDS_CREATE = ['taskJobId', 'taskName', 'taskDesc'];
+const ALLOWED_FIELDS_UPDATE = ['taskName', 'taskDesc'];
+
+/**
+ * POST /v1/task — create a task under a job. The job's company (resolved
+ * through taskJobId → Job → Customer) must be the caller's company
+ * (master keys may target any).
+ */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const taskJobId = Number(body.taskJobId);
+    if (!Number.isInteger(taskJobId) || taskJobId <= 0) {
+        return res.status(400).json({ message: "taskJobId is required and must be an integer." });
+    }
+
+    let jobCompanyId;
+    try {
+        jobCompanyId = await GetCompanyIdByJobId(taskJobId);
+    } catch (error) {
+        log.error({ err: error }, 'task create: job company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (jobCompanyId === -1) {
+        return res.status(400).json({ message: "taskJobId must reference a job." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== jobCompanyId) {
+            return res.status(403).json({ message: "Cannot create a task for a job in a company you do not belong to." });
+        }
+    }
+
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+    payload.taskArch = false;
+
+    try {
+        const created = await Task.create(payload);
+        return res.status(201).json({ message: "Task created.", task: created });
+    } catch (error) {
+        log.error({ err: error }, 'Task.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * GET /v1/task/:id — fetch one task. Secure-404 scoped through its job's
+ * company: a cross-tenant id reads as 404.
+ */
+exports.getById = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let task;
+    try {
+        task = await Task.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Task.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!task || task.taskArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        let taskCompanyId;
+        try {
+            taskCompanyId = await GetCompanyIdByJobId(task.taskJobId);
+        } catch (error) {
+            log.error({ err: error }, 'task getById: company resolve failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1 || taskCompanyId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+    return res.status(200).json({ message: "Found.", task });
+};
+
+/**
+ * GET /v1/task/byjob/:id — list a job's tasks. Secure-404 scoped through
+ * the job's company (a job in another tenant reads as 404).
+ */
+exports.listByJob = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const jobId = Number(req.params.id);
+    if (!Number.isInteger(jobId) || jobId <= 0) {
+        return res.status(400).json({ message: "Invalid job id." });
+    }
+
+    let jobCompanyId;
+    try {
+        jobCompanyId = await GetCompanyIdByJobId(jobId);
+    } catch (error) {
+        log.error({ err: error }, 'task listByJob: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (jobCompanyId === -1) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== jobCompanyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Task.findAndCountAll({
+            where: { taskJobId: jobId },
+            limit,
+            offset,
+            order: [['taskId', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, tasks: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Task.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** Load a task and enforce the secure-404 scope. Returns the task or null (after sending the response). */
+async function findScoped(req, res) {
+    let task;
+    try {
+        task = await Task.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Task.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!task || task.taskArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        let taskCompanyId;
+        try {
+            taskCompanyId = await GetCompanyIdByJobId(task.taskJobId);
+        } catch (error) {
+            log.error({ err: error }, 'task scope: company resolve failed');
+            res.status(500).json({ message: "Error!" });
+            return null;
+        }
+        if (companyId === -1 || taskCompanyId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return task;
+}
+
+/** PATCH /v1/task/:id — partial update. taskJobId / taskArch not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const task = await findScoped(req, res);
+    if (!task) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await task.update(updates);
+        return res.status(200).json({ message: "Updated.", task });
+    } catch (error) {
+        log.error({ err: error }, 'Task.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/task/:id — soft-delete (sets taskArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const task = await findScoped(req, res);
+    if (!task) return undefined;
+
+    try {
+        await task.update({ taskArch: true });
+        return res.status(200).json({ message: "Archived.", id: task.taskId });
+    } catch (error) {
+        log.error({ err: error }, 'Task archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260611000000-task.js
+++ b/app/migrations/20260611000000-task.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Task / activity entity (#407): a unit of work under a Job. Scoped to a
+// company through taskJobId → Job → Customer. A new table in the
+// increment layer (like the Expense/PurchaseOrder tables); no FK
+// constraints — enforced at the app layer. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Task', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    taskId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    taskJobId: { type: Sequelize.INTEGER, allowNull: false },
+                    taskName: { type: Sequelize.TEXT, allowNull: false },
+                    taskDesc: { type: Sequelize.TEXT, allowNull: true },
+                    taskArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, {
+                name: 'Task_jobId_arch_idx',
+                fields: ['taskJobId', 'taskArch'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/task.model.js
+++ b/app/models/task.model.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Task — a unit of work / activity under a Job (#407). Scope resolves
+ * through taskJobId → Job → Customer.custCompId (see
+ * auth.getCompanyIdByJobId). Soft-deletes via taskArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Task = sequelize.define('Task', {
+        taskId: {
+            field: 'taskId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        taskJobId: {
+            field: 'taskJobId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        taskName: {
+            field: 'taskName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        taskDesc: {
+            field: 'taskDesc',
+            type: Sequelize.TEXT,
+        },
+        taskArch: {
+            field: 'taskArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Task',
+        timestamps: true,
+        defaultScope: { where: { taskArch: false } }
+    });
+
+    return Task;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -30,6 +30,7 @@ const whoami = require('../controllers/whoamicontroller.js');
 const report = require('../controllers/reportcontroller.js');
 const expense = require('../controllers/expensecontroller.js');
 const auditlog = require('../controllers/auditlogcontroller.js');
+const task = require('../controllers/taskcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -50,6 +51,7 @@ const purchaseOrderLineSchemas = require('../schemas/purchaseorderline.schema.js
 const reportSchemas = require('../schemas/report.schema.js');
 const expenseSchemas = require('../schemas/expense.schema.js');
 const auditlogSchemas = require('../schemas/auditlog.schema.js');
+const taskSchemas = require('../schemas/task.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -694,6 +696,35 @@ router.delete(
     '/v1/inventorytransaction/:id',
     v.params(inventoryTransactionSchemas.intIdParam),
     inventoryTransaction.remove,
+);
+
+// v1 task routes (activities under jobs, #407).
+router.post(
+    '/v1/task',
+    v.body(taskSchemas.createTaskBody),
+    task.create,
+);
+router.get(
+    '/v1/task/byjob/:id',
+    v.params(taskSchemas.intIdParam),
+    v.query(taskSchemas.listByJobQuery),
+    task.listByJob,
+);
+router.get(
+    '/v1/task/:id',
+    v.params(taskSchemas.intIdParam),
+    task.getById,
+);
+router.patch(
+    '/v1/task/:id',
+    v.params(taskSchemas.intIdParam),
+    v.body(taskSchemas.updateTaskBody),
+    task.update,
+);
+router.delete(
+    '/v1/task/:id',
+    v.params(taskSchemas.intIdParam),
+    task.remove,
 );
 
 // v1 expense routes.

--- a/app/schemas/task.schema.js
+++ b/app/schemas/task.schema.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/task body. taskJobId + taskName required. */
+const createTaskBody = z.object({
+    taskJobId: z.coerce.number().int().positive(),
+    taskName: z.string().min(1).max(255),
+    taskDesc: z.string().max(10000).optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: taskJobId, taskName, taskDesc.',
+});
+
+/** PATCH /v1/task/:id body — taskJobId is not re-parentable here. */
+const updateTaskBody = z.object({
+    taskName: z.string().min(1).max(255).optional(),
+    taskDesc: z.string().max(10000).nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: taskName, taskDesc.',
+});
+
+const listByJobQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createTaskBody,
+    updateTaskBody,
+    listByJobQuery,
+};

--- a/tests/api/task.test.js
+++ b/tests/api/task.test.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/task (#407) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, TimeEntry: {},
+    Task: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Task auth + schema contract', () => {
+    test('POST /v1/task 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/task').send({ taskJobId: 1, taskName: 'Design' })).status).toBe(403);
+    });
+    test('POST /v1/task 400 on missing taskName (schema)', async () => {
+        expect((await request(app).post('/v1/task').set('authKey', 'k').send({ taskJobId: 1 })).status).toBe(400);
+    });
+    test('POST /v1/task 400 on an unknown field (strict schema)', async () => {
+        const res = await request(app).post('/v1/task').set('authKey', 'k').send({ taskJobId: 1, taskName: 'X', bogus: 1 });
+        expect(res.status).toBe(400);
+    });
+    test('GET /v1/task/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/task/1')).status).toBe(403);
+    });
+    test('GET /v1/task/byjob/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/task/byjob/1')).status).toBe(403);
+    });
+    test('PATCH /v1/task/:id 403 without authKey', async () => {
+        expect((await request(app).patch('/v1/task/1').send({ taskName: 'Y' })).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('Task table exists with a job include (#407)', async () => {
+        if (!connected) return;
+        const rows = await db.Task.findAll({
+            attributes: ['taskId', 'taskJobId', 'taskName', 'taskDesc'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withJob = await db.Task.findAll({
+            limit: 1,
+            include: [{ model: db.Job, as: 'job', required: false }],
+        });
+        expect(Array.isArray(withJob)).toBe(true);
+    });
+
     test('Customer has the custDefaultRate column (#413)', async () => {
         if (!connected) return;
         const rows = await db.Customer.findAll({


### PR DESCRIPTION
## Summary

Break a project into tasks. The structural foundation for per-task rates and task-level reporting.

Closes #407.

## Changes

- **Migration `20260611000000`** — creates the `Task` table (`taskId`, `taskJobId`, `taskName`, `taskDesc?`, `taskArch`) + a `(taskJobId, taskArch)` index. New table in the increment layer; no FK constraints — enforced at the app layer.
- **Model / associations** — a `Task` belongs to a `Job` (`taskJobId`); centralized JS associations in `db.config.js`. Soft-delete via `taskArch`.
- **Full REST** on `/v1/task` — `POST`, `GET /byjob/{id}` (paginated), `GET|PATCH|DELETE /{id}` — **scoped through the job's company** via `auth.getCompanyIdByJobId`, with the same **secure-404** cross-tenant behavior as the other entities.
- OpenAPI paths for all five routes.

## Follow-ups this unblocks

Per-task rates (#411), task-level time/reporting (link `TimeEntry` → task).

## Verification

`npm run lint` clean; `npm test` → **1091 passing** (6 route auth + schema cases; integration table/association check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/