### PR TITLE
feat(time-capture): copy-previous time entry (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Copy-previous time entry** (#399). `POST /v1/timeentry/{id}/copy`
+  clones an entry's "what" — customer, worker, job, billing type,
+  description, billable flag, tags — into a **fresh** entry (always
+  `open` / un-invoiced). The optional body sets `teStartedAt` /
+  `teEndedAt` (default: start now, in-flight). Secure-404 scoped; **409**
+  if the copy would land in a locked period (#441). No migration.
 - **Tasks / activities under jobs** (#407). A new `Task` model
   (`taskName`, `taskDesc`) under a Job, migration `20260611000000`. Full
   REST: `POST /v1/task`, `GET /v1/task/byjob/{id}` (paginated),

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -836,6 +836,22 @@ const spec = {
                 },
             },
         },
+        '/v1/timeentry/{id}/copy': {
+            post: {
+                summary: 'Copy a time entry into a fresh entry',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                requestBody: {
+                    content: { 'application/json': { schema: { type: 'object', properties: { teStartedAt: { type: 'string', format: 'date-time' }, teEndedAt: { type: 'string', format: 'date-time' } } } } },
+                },
+                responses: {
+                    201: { description: 'Copied' },
+                    400: { description: 'Inverted range' },
+                    404: { description: 'Not found' },
+                    409: { description: 'Copy lands in a locked period' },
+                },
+            },
+        },
         '/v1/timeentry/{id}/approval': {
             post: {
                 summary: 'Advance a time entry through the approval workflow',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -405,6 +405,82 @@ exports.approval = async (req, res) => {
 };
 
 /**
+ * POST /v1/timeentry/:id/copy — duplicate an entry's "what" into a fresh
+ * entry (#399): same customer / worker / job / billtype / description /
+ * billable / tags, but a new time. The optional body sets teStartedAt /
+ * teEndedAt (defaults: start now, in-flight). The copy is always open /
+ * un-invoiced. Secure-404 scoped; 409 if the copy lands in a locked
+ * period.
+ */
+exports.copy = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let src;
+    try {
+        src = await TimeEntry.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'copy: TimeEntry.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!src || src.teArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || src.teCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const body = req.body || {};
+    const startedAt = body.teStartedAt || new Date();
+    const endedAt = body.teEndedAt !== undefined ? body.teEndedAt : null;
+    if (isInvertedRange(startedAt, endedAt)) {
+        return res.status(400).json({ message: 'teEndedAt must be at or after teStartedAt.' });
+    }
+
+    let lock;
+    try {
+        const lockDate = await companyLockDate(src.teCompId);
+        lock = lockReason({ approvalStatus: 'open', startedAt, lockDate });
+    } catch (error) {
+        log.error({ err: error }, 'copy: lock check failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (lock) {
+        return res.status(409).json({ message: lock });
+    }
+
+    const payload = {
+        teCustId: src.teCustId,
+        teCompId: src.teCompId,
+        teWorkerId: src.teWorkerId,
+        teJobId: src.teJobId,
+        teBillTypeId: src.teBillTypeId,
+        teDescription: src.teDescription,
+        teBillable: src.teBillable,
+        teTags: src.teTags,
+        teStartedAt: startedAt,
+        teEndedAt: endedAt,
+        teMinutes: computeMinutes(startedAt, endedAt),
+        teArch: false,
+        // teApprovalStatus defaults 'open'; teInvJobId stays null (unbilled).
+    };
+    try {
+        const created = await TimeEntry.create(payload);
+        return res.status(201).json({ message: "Time entry copied.", timeEntry: created });
+    } catch (error) {
+        log.error({ err: error }, 'copy: TimeEntry.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
  * GET /v1/timeentry/:id — fetch a single time entry by id.
  *
  * Scoped: non-master keys may only read entries in their own company.

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -175,6 +175,13 @@ router.post(
     v.body(timeEntrySchemas.approvalBody),
     timeEntry.approval,
 );
+// Copy-previous (#399): clone an entry's metadata into a fresh entry.
+router.post(
+    '/v1/timeentry/:id/copy',
+    v.params(timeEntrySchemas.intIdParam),
+    v.body(timeEntrySchemas.copyTimeEntryBody),
+    timeEntry.copy,
+);
 // Literal paths declared BEFORE /:id so express doesn't try to
 // parse "export.csv" / "bycompany" as a customer id.
 router.get(

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -109,6 +109,21 @@ const approvalBody = z.object({
     message: 'Body must be { action: submit|approve|reject }.',
 });
 
+/**
+ * POST /v1/timeentry/:id/copy body — optional new time for the copy
+ * (#399). Omit both to start a fresh in-flight entry now.
+ */
+const copyTimeEntryBody = z.object({
+    teStartedAt: isoDatetime.optional(),
+    teEndedAt: isoDatetime.optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: teStartedAt, teEndedAt.',
+}).refine(
+    (data) => !(data.teStartedAt && data.teEndedAt) ||
+        new Date(data.teEndedAt) >= new Date(data.teStartedAt),
+    { message: 'teEndedAt must be at or after teStartedAt.', path: ['teEndedAt'] },
+);
+
 const listByCompanyQuery = z.object({
     customerId: z.coerce.number().int().positive().optional(),
     tag: z.string().min(1).max(64).optional(),
@@ -146,6 +161,7 @@ module.exports = {
     updateTimeEntryBody,
     startTimerBody,
     approvalBody,
+    copyTimeEntryBody,
     listByCompanyQuery,
     exportCsvQuery,
 };

--- a/tests/api/timeentry-copy.test.js
+++ b/tests/api/timeentry-copy.test.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for the copy-previous endpoint (#399) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {},
+    TimeEntry: { findByPk: vi.fn().mockResolvedValue(null), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Copy-previous time entry contract', () => {
+    test('POST /v1/timeentry/:id/copy 403 without authKey (empty body ok)', async () => {
+        expect((await request(app).post('/v1/timeentry/1/copy').send({})).status).toBe(403);
+    });
+    test('POST /v1/timeentry/:id/copy 400 on a non-datetime teStartedAt (schema)', async () => {
+        const res = await request(app).post('/v1/timeentry/1/copy').set('authKey', 'k').send({ teStartedAt: 'yesterday' });
+        expect(res.status).toBe(400);
+    });
+    test('POST /v1/timeentry/:id/copy 400 on an inverted range (schema refine)', async () => {
+        const res = await request(app).post('/v1/timeentry/1/copy').set('authKey', 'k')
+            .send({ teStartedAt: '2026-07-02T10:00:00Z', teEndedAt: '2026-07-02T09:00:00Z' });
+        expect(res.status).toBe(400);
+    });
+    test('POST /v1/timeentry/:id/copy 400 on an unknown field (strict)', async () => {
+        expect((await request(app).post('/v1/timeentry/1/copy').set('authKey', 'k').send({ bogus: 1 })).status).toBe(400);
+    });
+});


### PR DESCRIPTION
## Summary

"Same as yesterday" in one call — duplicate a time entry's setup into a fresh entry.

Closes #399.

## Changes

- **`POST /v1/timeentry/{id}/copy`** — clones the source entry's **"what"** (customer, worker, job, billing type, description, billable flag, tags) into a **new** entry. The copy is always `open` (approval) and un-invoiced (`teInvJobId` null) — it's new work, not a re-file.
- Optional body sets the copy's time (`teStartedAt` / `teEndedAt`); default is **start now, in-flight**.
- **Secure-404** scoped like the other single-entry routes; **409** if the copy would land in a **locked period** (#441). No migration.

## Verification

`npm run lint` clean; `npm test` → **1096 passing** (route auth; schema rejects a non-datetime, an inverted range, and unknown fields). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/