### PR TITLE
feat(invoicing): retainer management (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Retainer management** (#426). A new customer-scoped `Retainer`
+  entity (`retAmount` deposit + `retBalance` remaining), migration
+  `20260612000000`. Full REST: `POST /v1/retainer`,
+  `GET /v1/retainer/bycustomer/{id}`, `GET|PATCH|DELETE /v1/retainer/{id}`,
+  plus `POST /v1/retainer/{id}/drawdown` which reduces the balance
+  exact-cent and **409s on overdraw**. Secure-404 scoped through the
+  customer's company; soft-delete via `retArch`.
 - **Copy-previous time entry** (#399). `POST /v1/timeentry/{id}/copy`
   clones an entry's "what" — customer, worker, job, billing type,
   description, billable flag, tags — into a **fresh** entry (always

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -69,6 +69,7 @@ db.InventoryTransaction = require('../models/inventorytransaction.model.js')(seq
 db.Expense = require('../models/expense.model.js')(sequelize, Sequelize);
 db.AuditLog = require('../models/auditlog.model.js')(sequelize, Sequelize);
 db.Task = require('../models/task.model.js')(sequelize, Sequelize);
+db.Retainer = require('../models/retainer.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -191,5 +192,9 @@ db.AuditLog.belongsTo(db.Company, { foreignKey: 'alogCompId', as: 'company' });
 // Task → Job (taskJobId): a unit of work / activity under a project (#407).
 db.Job.hasMany(db.Task,   { foreignKey: 'taskJobId', as: 'tasks' });
 db.Task.belongsTo(db.Job, { foreignKey: 'taskJobId', as: 'job' });
+
+// Retainer → Customer (retCustId): a client prepayment (#426).
+db.Customer.hasMany(db.Retainer,   { foreignKey: 'retCustId', as: 'retainers' });
+db.Retainer.belongsTo(db.Customer, { foreignKey: 'retCustId', as: 'customer' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1378,6 +1378,54 @@ const spec = {
                 },
             },
         },
+        '/v1/retainer': {
+            post: {
+                summary: 'Open a retainer for a customer',
+                security: [{ authKey: [] }],
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error or bad retCustId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/retainer/bycustomer/{id}': {
+            get: {
+                summary: "List a customer's retainers",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 404: { description: 'Customer not found / cross-tenant' } },
+            },
+        },
+        '/v1/retainer/{id}/drawdown': {
+            post: {
+                summary: 'Draw an amount down from a retainer',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { amount: { type: 'number' } }, required: ['amount'] } } } },
+                responses: { 200: { description: 'Drawn down' }, 400: { description: 'Bad amount' }, 404: { description: 'Not found' }, 409: { description: 'Exceeds balance' } },
+            },
+        },
+        '/v1/retainer/{id}': {
+            get: {
+                summary: 'Fetch a retainer',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a retainer note',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Nothing to update' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a retainer',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/task': {
             post: {
                 summary: 'Create a task / activity under a job',

--- a/app/controllers/retainercontroller.js
+++ b/app/controllers/retainercontroller.js
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const money = require('../services/money.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const Retainer = db.Retainer;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
+
+/**
+ * Load a retainer and enforce the secure-404 scope (through its
+ * customer's company). Returns the retainer or null (after responding).
+ */
+async function findScoped(req, res) {
+    let ret;
+    try {
+        ret = await Retainer.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Retainer.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!ret || ret.retArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        let retCompanyId;
+        try {
+            retCompanyId = await GetCompanyIdByCustomerId(ret.retCustId);
+        } catch (error) {
+            log.error({ err: error }, 'retainer scope: company resolve failed');
+            res.status(500).json({ message: "Error!" });
+            return null;
+        }
+        if (companyId === -1 || retCompanyId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return ret;
+}
+
+/**
+ * POST /v1/retainer — open a retainer for a customer. Starts fully
+ * funded (retBalance = retAmount). The customer's company must be the
+ * caller's (master keys may target any).
+ */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const retCustId = Number(body.retCustId);
+    if (!Number.isInteger(retCustId) || retCustId <= 0) {
+        return res.status(400).json({ message: "retCustId is required and must be an integer." });
+    }
+
+    let custCompanyId;
+    try {
+        custCompanyId = await GetCompanyIdByCustomerId(retCustId);
+    } catch (error) {
+        log.error({ err: error }, 'retainer create: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (custCompanyId === -1) {
+        return res.status(400).json({ message: "retCustId must reference a customer." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== custCompanyId) {
+            return res.status(403).json({ message: "Cannot open a retainer for a customer in a company you do not belong to." });
+        }
+    }
+
+    const amount = money.round(Number(body.retAmount));
+    const payload = {
+        retCustId,
+        retAmount: amount,
+        retBalance: amount,
+        retNote: body.retNote,
+        retArch: false,
+    };
+    try {
+        const created = await Retainer.create(payload);
+        return res.status(201).json({ message: "Retainer created.", retainer: created });
+    } catch (error) {
+        log.error({ err: error }, 'Retainer.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/retainer/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const ret = await findScoped(req, res);
+    if (!ret) return undefined;
+    return res.status(200).json({ message: "Found.", retainer: ret });
+};
+
+/** GET /v1/retainer/bycustomer/:id — a customer's retainers. Secure-404 scoped. */
+exports.listByCustomer = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const custId = Number(req.params.id);
+    if (!Number.isInteger(custId) || custId <= 0) {
+        return res.status(400).json({ message: "Invalid customer id." });
+    }
+
+    let custCompanyId;
+    try {
+        custCompanyId = await GetCompanyIdByCustomerId(custId);
+    } catch (error) {
+        log.error({ err: error }, 'retainer listByCustomer: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (custCompanyId === -1) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== custCompanyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Retainer.findAndCountAll({
+            where: { retCustId: custId },
+            limit,
+            offset,
+            order: [['retId', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, retainers: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Retainer.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** PATCH /v1/retainer/:id — only the note is editable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const ret = await findScoped(req, res);
+    if (!ret) return undefined;
+
+    const body = req.body || {};
+    if (body.retNote === undefined) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+    try {
+        await ret.update({ retNote: body.retNote });
+        return res.status(200).json({ message: "Updated.", retainer: ret });
+    } catch (error) {
+        log.error({ err: error }, 'Retainer.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/retainer/:id/drawdown — draw an amount down from the balance.
+ * 409 when the amount exceeds the remaining balance. Exact-cent.
+ */
+exports.drawdown = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const ret = await findScoped(req, res);
+    if (!ret) return undefined;
+
+    const amount = money.round(Number(req.body && req.body.amount));
+    if (!(amount > 0)) {
+        return res.status(400).json({ message: "amount must be a positive number." });
+    }
+    const newBalance = money.subtract(ret.retBalance, amount);
+    if (newBalance < 0) {
+        return res.status(409).json({ message: "Drawdown exceeds the retainer balance." });
+    }
+    try {
+        await ret.update({ retBalance: newBalance });
+        return res.status(200).json({ message: "Retainer drawn down.", retainer: ret });
+    } catch (error) {
+        log.error({ err: error }, 'Retainer drawdown failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/retainer/:id — soft-delete (sets retArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const ret = await findScoped(req, res);
+    if (!ret) return undefined;
+    try {
+        await ret.update({ retArch: true });
+        return res.status(200).json({ message: "Archived.", id: ret.retId });
+    } catch (error) {
+        log.error({ err: error }, 'Retainer archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260612000000-retainer.js
+++ b/app/migrations/20260612000000-retainer.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Retainer entity (#426): a client prepayment that invoices/work draw
+// down. retAmount is the original deposit; retBalance is what's left.
+// Scoped to a company through retCustId → Customer. A new table in the
+// increment layer; no FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Retainer', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    retId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    retCustId: { type: Sequelize.INTEGER, allowNull: false },
+                    retAmount: { type: Sequelize.DECIMAL(14, 2), allowNull: false },
+                    retBalance: { type: Sequelize.DECIMAL(14, 2), allowNull: false },
+                    retNote: { type: Sequelize.TEXT, allowNull: true },
+                    retArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, {
+                name: 'Retainer_custId_arch_idx',
+                fields: ['retCustId', 'retArch'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/retainer.model.js
+++ b/app/models/retainer.model.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Retainer — a client prepayment drawn down over time (#426). retAmount
+ * is the original deposit; retBalance is what remains. Scope resolves
+ * through retCustId → Customer.custCompId. Amounts are NUMERIC(14,2);
+ * pg returns them as strings, so the getters hand the API Numbers.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Retainer = sequelize.define('Retainer', {
+        retId: {
+            field: 'retId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        retCustId: {
+            field: 'retCustId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        retAmount: {
+            field: 'retAmount',
+            type: Sequelize.DECIMAL(14, 2),
+            allowNull: false,
+            get() {
+                const v = this.getDataValue('retAmount');
+                return v == null ? null : Number(v);
+            },
+        },
+        retBalance: {
+            field: 'retBalance',
+            type: Sequelize.DECIMAL(14, 2),
+            allowNull: false,
+            get() {
+                const v = this.getDataValue('retBalance');
+                return v == null ? null : Number(v);
+            },
+        },
+        retNote: {
+            field: 'retNote',
+            type: Sequelize.TEXT,
+        },
+        retArch: {
+            field: 'retArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Retainer',
+        timestamps: true,
+        defaultScope: { where: { retArch: false } }
+    });
+
+    return Retainer;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -31,6 +31,7 @@ const report = require('../controllers/reportcontroller.js');
 const expense = require('../controllers/expensecontroller.js');
 const auditlog = require('../controllers/auditlogcontroller.js');
 const task = require('../controllers/taskcontroller.js');
+const retainer = require('../controllers/retainercontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -52,6 +53,7 @@ const reportSchemas = require('../schemas/report.schema.js');
 const expenseSchemas = require('../schemas/expense.schema.js');
 const auditlogSchemas = require('../schemas/auditlog.schema.js');
 const taskSchemas = require('../schemas/task.schema.js');
+const retainerSchemas = require('../schemas/retainer.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -703,6 +705,41 @@ router.delete(
     '/v1/inventorytransaction/:id',
     v.params(inventoryTransactionSchemas.intIdParam),
     inventoryTransaction.remove,
+);
+
+// v1 retainer routes (client prepayments, #426).
+router.post(
+    '/v1/retainer',
+    v.body(retainerSchemas.createRetainerBody),
+    retainer.create,
+);
+router.get(
+    '/v1/retainer/bycustomer/:id',
+    v.params(retainerSchemas.intIdParam),
+    v.query(retainerSchemas.listByCustomerQuery),
+    retainer.listByCustomer,
+);
+router.post(
+    '/v1/retainer/:id/drawdown',
+    v.params(retainerSchemas.intIdParam),
+    v.body(retainerSchemas.drawdownBody),
+    retainer.drawdown,
+);
+router.get(
+    '/v1/retainer/:id',
+    v.params(retainerSchemas.intIdParam),
+    retainer.getById,
+);
+router.patch(
+    '/v1/retainer/:id',
+    v.params(retainerSchemas.intIdParam),
+    v.body(retainerSchemas.updateRetainerBody),
+    retainer.update,
+);
+router.delete(
+    '/v1/retainer/:id',
+    v.params(retainerSchemas.intIdParam),
+    retainer.remove,
 );
 
 // v1 task routes (activities under jobs, #407).

--- a/app/schemas/retainer.schema.js
+++ b/app/schemas/retainer.schema.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const positiveAmount = z.coerce.number().finite().positive();
+
+/** POST /v1/retainer body. retCustId + retAmount required. */
+const createRetainerBody = z.object({
+    retCustId: z.coerce.number().int().positive(),
+    retAmount: positiveAmount,
+    retNote: z.string().max(10000).optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: retCustId, retAmount, retNote.',
+});
+
+/** PATCH /v1/retainer/:id — only the note is editable; balance moves via drawdown. */
+const updateRetainerBody = z.object({
+    retNote: z.string().max(10000).nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: retNote.',
+});
+
+/** POST /v1/retainer/:id/drawdown body. */
+const drawdownBody = z.object({
+    amount: positiveAmount,
+}).strict({
+    message: 'Body must be { amount: <positive number> }.',
+});
+
+const listByCustomerQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createRetainerBody,
+    updateRetainerBody,
+    drawdownBody,
+    listByCustomerQuery,
+};

--- a/tests/api/retainer.test.js
+++ b/tests/api/retainer.test.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/retainer (#426) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, TimeEntry: {},
+    Retainer: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Retainer auth + schema contract', () => {
+    test('POST /v1/retainer 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/retainer').send({ retCustId: 1, retAmount: 1000 })).status).toBe(403);
+    });
+    test('POST /v1/retainer 400 on missing retAmount (schema)', async () => {
+        expect((await request(app).post('/v1/retainer').set('authKey', 'k').send({ retCustId: 1 })).status).toBe(400);
+    });
+    test('POST /v1/retainer 400 on a non-positive retAmount (schema)', async () => {
+        expect((await request(app).post('/v1/retainer').set('authKey', 'k').send({ retCustId: 1, retAmount: 0 })).status).toBe(400);
+    });
+    test('POST /v1/retainer/:id/drawdown 403 without authKey (valid body)', async () => {
+        expect((await request(app).post('/v1/retainer/1/drawdown').send({ amount: 100 })).status).toBe(403);
+    });
+    test('POST /v1/retainer/:id/drawdown 400 on a non-positive amount (schema)', async () => {
+        expect((await request(app).post('/v1/retainer/1/drawdown').set('authKey', 'k').send({ amount: -5 })).status).toBe(400);
+    });
+    test('GET /v1/retainer/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/retainer/1')).status).toBe(403);
+    });
+    test('GET /v1/retainer/bycustomer/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/retainer/bycustomer/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('Retainer table exists with a customer include (#426)', async () => {
+        if (!connected) return;
+        const rows = await db.Retainer.findAll({
+            attributes: ['retId', 'retCustId', 'retAmount', 'retBalance'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCustomer = await db.Retainer.findAll({
+            limit: 1,
+            include: [{ model: db.Customer, as: 'customer', required: false }],
+        });
+        expect(Array.isArray(withCustomer)).toBe(true);
+    });
+
     test('Task table exists with a job include (#407)', async () => {
         if (!connected) return;
         const rows = await db.Task.findAll({


### PR DESCRIPTION
## Summary

Track a client's prepaid retainer and draw it down.

Closes #426.

## Changes

- **Migration `20260612000000`** — creates the `Retainer` table (`retId`, `retCustId`, `retAmount`, `retBalance`, `retNote?`, `retArch`) + a `(retCustId, retArch)` index. New table in the increment layer; no FK constraints.
- **Model / associations** — a `Retainer` belongs to a `Customer` (`retCustId`); `retAmount`/`retBalance` carry Number getters. Soft-delete via `retArch`.
- **Full REST** on `/v1/retainer` — `POST` (opens fully funded: `retBalance = retAmount`), `GET /bycustomer/{id}` (paginated), `GET|PATCH|DELETE /{id}` — **scoped through the customer's company** with **secure-404**.
- **`POST /v1/retainer/{id}/drawdown`** `{ amount }` — reduces the balance **exact-cent** via `money.js`, **409** if the amount exceeds the remaining balance.

## Follow-up

Auto-drawdown on invoice generation (apply a retainer to a rolled-up invoice) is a natural next step.

## Verification

`npm run lint` clean; `npm test` → **1110 passing** (7 route auth + schema cases incl. non-positive amount/deposit; integration table/association check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/