### PR TITLE
feat(billing-rates): per-task rate (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Per-task rate** (#411). `Task.taskRate` + a `TimeEntry.teTaskId`
+  link (migration `20260613000000`) make the task the **most-specific**
+  tier of rate resolution in `rate.js`: per-entry override → **task** →
+  project → client → worker. It flows through the time-entry billing
+  view, the invoice roll-up, and the unbilled/billable-summary/budget
+  reports (all now eager-load `entry.task`). `teTaskId` is validated to a
+  task in the company (and, if a job is named, under that job); `taskRate`
+  settable on task create/PATCH.
 - **Retainer management** (#426). A new customer-scoped `Retainer`
   entity (`retAmount` deposit + `retBalance` remaining), migration
   `20260612000000`. Full REST: `POST /v1/retainer`,

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -193,6 +193,11 @@ db.AuditLog.belongsTo(db.Company, { foreignKey: 'alogCompId', as: 'company' });
 db.Job.hasMany(db.Task,   { foreignKey: 'taskJobId', as: 'tasks' });
 db.Task.belongsTo(db.Job, { foreignKey: 'taskJobId', as: 'job' });
 
+// TimeEntry → Task (teTaskId): the task an entry was worked against (#411);
+// its taskRate is the most-specific rate tier after a per-entry override.
+db.Task.hasMany(db.TimeEntry,   { foreignKey: 'teTaskId', as: 'timeEntries' });
+db.TimeEntry.belongsTo(db.Task, { foreignKey: 'teTaskId', as: 'task' });
+
 // Retainer → Customer (retCustId): a client prepayment (#426).
 db.Customer.hasMany(db.Retainer,   { foreignKey: 'retCustId', as: 'retainers' });
 db.Retainer.belongsTo(db.Customer, { foreignKey: 'retCustId', as: 'customer' });

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -335,6 +335,8 @@ exports.rollup = async (req, res) => {
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+                // Task rate (#411) — the most-specific rate tier.
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
             ],
         });
     } catch (error) {

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -102,6 +102,8 @@ exports.unbilled = async (req, res) => {
                     model: db.Customer, as: 'customer', required: false,
                     attributes: ['custId', 'custCompanyName', 'custFName', 'custLName', 'custDefaultRate'],
                 },
+                // Task rate (#411) — the most-specific rate tier.
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
             ],
         });
     } catch (error) {
@@ -119,9 +121,10 @@ exports.unbilled = async (req, res) => {
             teBillable: e.teBillable,
             billingType: e.billingType,
             worker: e.worker,
-            // Pass job + customer so rate.js reads the project/client rate (#410, #413).
+            // Pass job + customer + task so rate.js reads project/client/task rate (#410, #413, #411).
             job: e.job,
             customer: e.customer,
+            task: e.task,
             custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
             jobDesc: e.job ? e.job.jobDesc : null,
         };
@@ -311,6 +314,8 @@ exports.billableSummary = async (req, res) => {
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+                // Task rate (#411) — the most-specific rate tier.
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
             ],
         });
     } catch (error) {
@@ -424,6 +429,8 @@ exports.budget = async (req, res) => {
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+                // Task rate (#411) — the most-specific rate tier.
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
             ],
         });
     } catch (error) {

--- a/app/controllers/taskcontroller.js
+++ b/app/controllers/taskcontroller.js
@@ -12,8 +12,8 @@ const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
 
-const ALLOWED_FIELDS_CREATE = ['taskJobId', 'taskName', 'taskDesc'];
-const ALLOWED_FIELDS_UPDATE = ['taskName', 'taskDesc'];
+const ALLOWED_FIELDS_CREATE = ['taskJobId', 'taskName', 'taskDesc', 'taskRate'];
+const ALLOWED_FIELDS_UPDATE = ['taskName', 'taskDesc', 'taskRate'];
 
 /**
  * POST /v1/task — create a task under a job. The job's company (resolved

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -20,11 +20,11 @@ const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
     'teCustId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription',
-    'teStartedAt', 'teEndedAt', 'teBillable', 'teTags',
+    'teStartedAt', 'teEndedAt', 'teBillable', 'teTags', 'teTaskId',
 ];
 const ALLOWED_FIELDS_UPDATE = [
     'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription', 'teStartedAt',
-    'teEndedAt', 'teBillable', 'teTags',
+    'teEndedAt', 'teBillable', 'teTags', 'teTaskId',
 ];
 
 function computeMinutes(startedAt, endedAt) {
@@ -99,7 +99,7 @@ function isInvertedRange(startedAt, endedAt) {
  * Archived rows are filtered by defaultScope and therefore read as
  * "not found" → 400.
  */
-async function checkEntryLinks({ teWorkerId, teJobId, teBillTypeId }, companyId, custId) {
+async function checkEntryLinks({ teWorkerId, teJobId, teBillTypeId, teTaskId }, companyId, custId) {
     if (teWorkerId !== undefined && teWorkerId !== null) {
         const worker = await db.Worker.findByPk(Number(teWorkerId), {
             attributes: ['workerCompId'],
@@ -134,6 +134,22 @@ async function checkEntryLinks({ teWorkerId, teJobId, teBillTypeId }, companyId,
         });
         if (!bt || bt.btCompId !== companyId) {
             return { status: 400, message: 'teBillTypeId must reference a billing type in your company.' };
+        }
+    }
+    if (teTaskId !== undefined && teTaskId !== null) {
+        const task = await db.Task.findByPk(Number(teTaskId), {
+            attributes: ['taskJobId'],
+            include: [{
+                model: db.Job, as: 'job', attributes: ['jobCustId'], required: true,
+                include: [{ model: db.Customer, as: 'customer', attributes: ['custCompId'], required: true }],
+            }],
+        });
+        if (!task || !task.job || !task.job.customer || task.job.customer.custCompId !== companyId) {
+            return { status: 400, message: 'teTaskId must reference a task in your company.' };
+        }
+        // If the entry also names a job, the task must be under that job.
+        if (teJobId !== undefined && teJobId !== null && task.taskJobId !== Number(teJobId)) {
+            return { status: 400, message: 'teTaskId must belong to the job (teJobId).' };
         }
     }
     return null;
@@ -221,7 +237,7 @@ exports.create = async (req, res) => {
 };
 
 const START_FIELDS = [
-    'teCustId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription', 'teBillable', 'teTags',
+    'teCustId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription', 'teBillable', 'teTags', 'teTaskId',
 ];
 
 /**
@@ -512,6 +528,8 @@ exports.getById = async (req, res) => {
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+                // Task rate (#411) — the most-specific rate tier.
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
             ],
         });
     } catch (error) {

--- a/app/migrations/20260613000000-task-rate.js
+++ b/app/migrations/20260613000000-task-rate.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Per-task rate (#411). Task.taskRate is a flat hourly rate for a task;
+// TimeEntry.teTaskId links an entry to a task under its job. The task
+// rate is the most-specific tier of rate resolution after a per-entry
+// override (see app/services/rate.js). Both nullable. setup/*.sql
+// untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TASK = { tableName: 'Task', schema: SCHEMA };
+const TIMEENTRY = { tableName: 'TimeEntry', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.addColumn(TASK, 'taskRate', { type: Sequelize.DECIMAL(14, 2), allowNull: true }, { transaction: t });
+            await queryInterface.addColumn(TIMEENTRY, 'teTaskId', { type: Sequelize.INTEGER, allowNull: true }, { transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeColumn(TIMEENTRY, 'teTaskId', { transaction: t });
+            await queryInterface.removeColumn(TASK, 'taskRate', { transaction: t });
+        });
+    },
+};

--- a/app/models/task.model.js
+++ b/app/models/task.model.js
@@ -29,6 +29,16 @@ module.exports = (sequelize, Sequelize) => {
             field: 'taskDesc',
             type: Sequelize.TEXT,
         },
+        taskRate: {
+            field: 'taskRate',
+            // Per-task flat hourly rate (#411); the most-specific rate tier
+            // after a per-entry override. Number getter (pg NUMERIC→string).
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('taskRate');
+                return v == null ? null : Number(v);
+            },
+        },
         taskArch: {
             field: 'taskArch',
             type: Sequelize.BOOLEAN,

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -52,6 +52,12 @@ module.exports = (sequelize, Sequelize) => {
             // of rate resolution; NULL means "use the worker default".
             type: Sequelize.INTEGER,
         },
+        teTaskId: {
+            field: 'teTaskId',
+            // Nullable link to a Task under the job (#411). Its taskRate is
+            // the most-specific rate tier after a per-entry override.
+            type: Sequelize.INTEGER,
+        },
         teInvJobId: {
             field: 'teInvJobId',
             // The InvoiceJob line this entry was rolled into (#382), and

--- a/app/schemas/task.schema.js
+++ b/app/schemas/task.schema.js
@@ -13,16 +13,18 @@ const createTaskBody = z.object({
     taskJobId: z.coerce.number().int().positive(),
     taskName: z.string().min(1).max(255),
     taskDesc: z.string().max(10000).optional(),
+    taskRate: z.coerce.number().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: taskJobId, taskName, taskDesc.',
+    message: 'Unexpected field in body. Whitelist: taskJobId, taskName, taskDesc, taskRate.',
 });
 
 /** PATCH /v1/task/:id body — taskJobId is not re-parentable here. */
 const updateTaskBody = z.object({
     taskName: z.string().min(1).max(255).optional(),
     taskDesc: z.string().max(10000).nullable().optional(),
+    taskRate: z.coerce.number().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: taskName, taskDesc.',
+    message: 'Unexpected field in body. Whitelist: taskName, taskDesc, taskRate.',
 });
 
 const listByJobQuery = z.object({

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -38,13 +38,14 @@ const createTimeEntryBody = z.object({
     teWorkerId: z.coerce.number().int().positive().optional(),
     teJobId: z.coerce.number().int().positive().optional(),
     teBillTypeId: z.coerce.number().int().positive().optional(),
+    teTaskId: z.coerce.number().int().positive().optional(),
     teDescription: z.string().max(10000).optional(),
     teStartedAt: isoDatetime,
     teEndedAt: isoDatetime.optional(),
     teBillable: z.boolean().optional(),
     teTags: tagsField.optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teStartedAt, teEndedAt, teBillable, teTags.',
+    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teStartedAt, teEndedAt, teBillable, teTags, teTaskId.',
 }).refine(
     (data) => !data.teEndedAt || new Date(data.teEndedAt) >= new Date(data.teStartedAt),
     {
@@ -71,13 +72,14 @@ const updateTimeEntryBody = z.object({
     teWorkerId: z.coerce.number().int().positive().nullable().optional(),
     teJobId: z.coerce.number().int().positive().nullable().optional(),
     teBillTypeId: z.coerce.number().int().positive().nullable().optional(),
+    teTaskId: z.coerce.number().int().positive().nullable().optional(),
     teDescription: z.string().max(10000).optional(),
     teStartedAt: isoDatetime.optional(),
     teEndedAt: isoDatetime.nullable().optional(),
     teBillable: z.boolean().optional(),
     teTags: tagsField.optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: teWorkerId, teJobId, teBillTypeId, teDescription, teStartedAt, teEndedAt, teBillable, teTags.',
+    message: 'Unexpected field in body. Whitelist: teWorkerId, teJobId, teBillTypeId, teDescription, teStartedAt, teEndedAt, teBillable, teTags, teTaskId.',
 }).refine(
     (data) => !(data.teStartedAt && data.teEndedAt) ||
         new Date(data.teEndedAt) >= new Date(data.teStartedAt),
@@ -148,11 +150,12 @@ const startTimerBody = z.object({
     teWorkerId: z.coerce.number().int().positive().optional(),
     teJobId: z.coerce.number().int().positive().optional(),
     teBillTypeId: z.coerce.number().int().positive().optional(),
+    teTaskId: z.coerce.number().int().positive().optional(),
     teDescription: z.string().max(10000).optional(),
     teBillable: z.boolean().optional(),
     teTags: tagsField.optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teBillable, teTags.',
+    message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teBillable, teTags, teTaskId.',
 });
 
 module.exports = {

--- a/app/services/rate.js
+++ b/app/services/rate.js
@@ -8,13 +8,14 @@
  *
  * Rate precedence (first match wins):
  *   1. the entry's OWN BillingType (teBillTypeId — a per-entry override)
- *   2. the entry's Job's flat rate (jobFlatRate — a per-project rate, #410)
- *   3. the entry's Customer's default rate (custDefaultRate — a client
+ *   2. the entry's Task's rate (taskRate — a per-task rate, #411)
+ *   3. the entry's Job's flat rate (jobFlatRate — a per-project rate, #410)
+ *   4. the entry's Customer's default rate (custDefaultRate — a client
  *      rate card, #413)
- *   4. the entry's Worker's default BillingType (workerDefaultBillType)
+ *   5. the entry's Worker's default BillingType (workerDefaultBillType)
  *
  * These functions are PURE: the caller eager-loads the associations
- * (entry.billingType, entry.job, entry.customer and
+ * (entry.billingType, entry.task, entry.job, entry.customer and
  * entry.worker.defaultBillingType) so rate.js never touches the database
  * and stays trivially unit-testable.
  */
@@ -42,17 +43,24 @@ function clientRateOf(customer) {
     return customer ? numOrNull(customer.custDefaultRate) : null;
 }
 
+/** The per-task rate on a Task instance, or null if absent. */
+function taskRateOf(task) {
+    return task ? numOrNull(task.taskRate) : null;
+}
+
 /**
  * The effective hourly rate for a time entry, or null when none can be
  * resolved. Expects eager-loaded `entry.billingType` (per-entry),
- * `entry.job` (per-project flat rate), `entry.customer` (client rate
- * card) and `entry.worker.defaultBillingType` associations; a missing
- * association simply falls through to the next tier.
+ * `entry.task` (per-task rate), `entry.job` (per-project flat rate),
+ * `entry.customer` (client rate card) and `entry.worker.defaultBillingType`
+ * associations; a missing association simply falls through to the next tier.
  */
 function resolveHourlyRate(entry) {
     if (!entry) return null;
     const own = rateOf(entry.billingType);
     if (own != null) return own;
+    const taskR = taskRateOf(entry.task);
+    if (taskR != null) return taskR;
     const project = flatRateOf(entry.job);
     if (project != null) return project;
     const client = clientRateOf(entry.customer);

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -127,7 +127,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         // Selecting the new attributes proves the 20260521 + 20260523
         // migrations added the columns (a missing column would throw).
         const rows = await db.TimeEntry.findAll({
-            attributes: ['teId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teInvJobId', 'teTags', 'teApprovalStatus'],
+            attributes: ['teId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teInvJobId', 'teTags', 'teApprovalStatus', 'teTaskId'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);
@@ -232,7 +232,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('Task table exists with a job include (#407)', async () => {
         if (!connected) return;
         const rows = await db.Task.findAll({
-            attributes: ['taskId', 'taskJobId', 'taskName', 'taskDesc'],
+            attributes: ['taskId', 'taskJobId', 'taskName', 'taskDesc', 'taskRate'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/rate.test.js
+++ b/tests/unit/rate.test.js
@@ -26,6 +26,18 @@ describe('rate.resolveHourlyRate — precedence', () => {
         expect(rate.resolveHourlyRate(entry)).toBe(150);
     });
 
+    test('task rate wins over the project flat rate', () => {
+        expect(rate.resolveHourlyRate({ task: { taskRate: 250 }, job: { jobFlatRate: 200 } })).toBe(250);
+    });
+
+    test("entry's own BillingType wins over the task rate", () => {
+        expect(rate.resolveHourlyRate({ billingType: bt(150), task: { taskRate: 250 } })).toBe(150);
+    });
+
+    test('falls through a null task rate to the project rate', () => {
+        expect(rate.resolveHourlyRate({ task: { taskRate: null }, job: { jobFlatRate: 200 } })).toBe(200);
+    });
+
     test('project flat rate wins over the worker default', () => {
         const entry = { billingType: null, job: { jobFlatRate: 200 }, worker: { defaultBillingType: bt(100) } };
         expect(rate.resolveHourlyRate(entry)).toBe(200);


### PR DESCRIPTION
## Summary

A rate on a task, applied to time booked against it — the most specific rate a piece of work can carry. Builds on tasks (#407).

Closes #411.

## Changes

- **Migration `20260613000000`** — `Task.taskRate` (NUMERIC(14,2)) and `TimeEntry.teTaskId` (nullable INTEGER link).
- **`rate.js`** — `taskRate` becomes the top non-override tier (first match wins):
  1. the entry's own `BillingType` (per-entry override)
  2. the **task**'s rate ← new
  3. the **job**'s flat rate (#410)
  4. the **client**'s default rate (#413)
  5. the **worker**'s default `BillingType`
- **Flows everywhere the rate is priced** — the time-entry billing view, the invoice roll-up, and the unbilled / billable-summary / budget reports all now eager-load `entry.task`.
- **Validation** — `teTaskId` must reference a task in the caller's company, and if the entry also names `teJobId`, the task must be **under that job**. `taskRate` is settable on task create/PATCH.

## Verification

`npm run lint` clean; `npm test` → **1114 passing** (task vs entry-override vs project precedence, null-fallthrough; integration column checks for both new columns). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/