### PR TITLE
feat(reporting): project profitability & margin (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Project profitability & margin** (#436). A new `Worker.workerCostRate`
+  (internal cost/hour, migration `20260614000000`) plus
+  `GET /v1/report/profitability`: per job, **revenue** (billable time
+  priced through `rate.js`) net of **cost** (all logged time × the
+  worker's cost rate) → **margin** and **margin %**, with company totals.
+  The response flags entries with no resolvable rate or no cost basis so
+  the numbers stay honest. Pure `report-profitability.js` service.
 - **Per-task rate** (#411). `Task.taskRate` + a `TimeEntry.teTaskId`
   link (migration `20260613000000`) make the task the **most-specific**
   tier of rate resolution in `rate.js`: per-entry override → **task** →

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1580,6 +1580,24 @@ const spec = {
                 },
             },
         },
+        '/v1/report/profitability': {
+            get: {
+                summary: 'Project profitability & margin (revenue − cost per job)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'customerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'jobId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Per-job {revenue, cost, margin, marginPct} + totals; flags entries missing a rate/cost basis' },
+                    400: { description: 'Master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/revenue': {
             get: {
                 summary: 'Revenue & earnings summary (by customer and month)',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -19,6 +19,7 @@ const { buildBillableSummary } = require('../services/report-billable-summary.js
 const { buildTimesheet } = require('../services/report-timesheet.js');
 const { buildBudget } = require('../services/report-budget.js');
 const { buildTargets, weeksBetween } = require('../services/report-targets.js');
+const { buildProfitability } = require('../services/report-profitability.js');
 const rate = require('../services/rate.js');
 
 const IsMaster = auth.isMaster;
@@ -325,6 +326,60 @@ exports.billableSummary = async (req, res) => {
 
     const report = buildBillableSummary(entries);
     return res.status(200).json({ message: "Billable vs non-billable summary.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/profitability — project profitability & margin (#436):
+ * per-job revenue (billable time priced via rate.js) net of cost (all
+ * logged time × the worker's cost rate). Company-scoped; optional
+ * customerId / jobId / from / to.
+ */
+exports.profitability = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const where = { teCompId: companyId };
+    const customerId = Number(req.query.customerId);
+    if (Number.isInteger(customerId) && customerId > 0) where.teCustId = customerId;
+    const jobId = Number(req.query.jobId);
+    if (Number.isInteger(jobId) && jobId > 0) where.teJobId = jobId;
+    const from = parseDate(req.query.from, false);
+    const to = parseDate(req.query.to, true);
+    if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+    if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+
+    let entries;
+    try {
+        entries = await db.TimeEntry.findAll({
+            where,
+            include: [
+                { model: db.BillingType, as: 'billingType', required: false },
+                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc', 'jobFlatRate'] },
+                {
+                    model: db.Worker, as: 'worker', required: false,
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                },
+                { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'profitability: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const report = buildProfitability(entries);
+    return res.status(200).json({ message: "Project profitability & margin.", companyId, ...report });
 };
 
 /**

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -14,10 +14,10 @@ const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
     'workerFName', 'workerLName', 'workerTitle',
-    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek',
+    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek', 'workerCostRate',
 ];
 const ALLOWED_FIELDS_UPDATE = [
-    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek',
+    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek', 'workerCostRate',
 ];
 
 /**

--- a/app/migrations/20260614000000-worker-cost-rate.js
+++ b/app/migrations/20260614000000-worker-cost-rate.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Worker cost rate (#436): the internal cost per hour of a worker, used
+// to compute project profitability / margin (revenue − cost). NUMERIC,
+// nullable (NULL = no cost basis; the entry is excluded from cost).
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const WORKER = { tableName: 'Worker', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            WORKER, 'workerCostRate',
+            { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(WORKER, 'workerCostRate');
+    },
+};

--- a/app/models/worker.model.js
+++ b/app/models/worker.model.js
@@ -57,6 +57,16 @@ module.exports = (sequelize, Sequelize) => {
             // Weekly capacity target in minutes (#400); null = no target.
             type: Sequelize.INTEGER,
         },
+        workerCostRate: {
+            field: 'workerCostRate',
+            // Internal cost per hour (#436); powers profitability/margin.
+            // Number getter (pg NUMERIC→string). null = no cost basis.
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('workerCostRate');
+                return v == null ? null : Number(v);
+            },
+        },
     }, {
         tableName: 'Worker',
         timestamps: true,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -830,6 +830,11 @@ router.get(
     report.billableSummary,
 );
 router.get(
+    '/v1/report/profitability',
+    v.query(reportSchemas.profitabilityQuery),
+    report.profitability,
+);
+router.get(
     '/v1/report/timesheet',
     v.query(reportSchemas.timesheetQuery),
     report.timesheet,

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -100,4 +100,18 @@ const targetsQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, from, to.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery, targetsQuery };
+/**
+ * GET /v1/report/profitability query. companyId required for master keys.
+ * Optional customerId / jobId filters and from/to bounds.
+ */
+const profitabilityQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    customerId: z.coerce.number().int().positive().optional(),
+    jobId: z.coerce.number().int().positive().optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, customerId, jobId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery, targetsQuery, profitabilityQuery };

--- a/app/schemas/worker.schema.js
+++ b/app/schemas/worker.schema.js
@@ -23,8 +23,9 @@ const createWorkerBody = z.object({
     workerDefaultBillType: z.coerce.number().int().positive(),
     workerCompId: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().optional(),
+    workerCostRate: z.coerce.number().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate.',
 });
 
 /**
@@ -39,8 +40,9 @@ const updateWorkerBody = z.object({
     workerTitle: z.string().min(1).max(255).optional(),
     workerDefaultBillType: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().nullable().optional(),
+    workerCostRate: z.coerce.number().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate.',
 });
 
 const listByCompanyQuery = z.object({

--- a/app/services/report-profitability.js
+++ b/app/services/report-profitability.js
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-profitability.js — project profitability & margin (#436).
+ *
+ * For each job: REVENUE is the billable time priced through rate.js; COST
+ * is ALL logged time (billable or not — cost is cost) valued at the
+ * worker's cost rate. MARGIN = revenue − cost; MARGIN% = margin / revenue.
+ *
+ * PURE: the caller loads closed time entries with their rate associations
+ * (billingType, task, job, customer, worker.defaultBillingType) and the
+ * worker's cost rate (worker.workerCostRate). No DB. Exact money via
+ * money.js; in-flight entries (teMinutes null) are skipped.
+ */
+
+const money = require('./money.js');
+const rate = require('./rate.js');
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+const numOrNull = (v) => {
+    if (v == null) return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+};
+
+/**
+ * @param entries closed time entries with { teId, teJobId, teMinutes,
+ *   teBillable } + eager-loaded rate associations and worker.workerCostRate.
+ * @returns { jobs[], totals, unresolvedRateEntryIds, entriesMissingCostRate }
+ */
+function buildProfitability(entries) {
+    const map = new Map();
+    const unresolvedRate = [];
+    const noCostRate = [];
+
+    for (const e of entries || []) {
+        if (e.teMinutes == null) continue;
+        const minutes = Number(e.teMinutes) || 0;
+        const hours = minutes / 60;
+        const key = e.teJobId == null ? 'none' : e.teJobId;
+
+        let g = map.get(key);
+        if (!g) {
+            g = {
+                jobId: e.teJobId == null ? null : e.teJobId,
+                jobDesc: e.job ? e.job.jobDesc : null,
+                billableMinutes: 0,
+                totalMinutes: 0,
+                revenueAmounts: [],
+                costAmounts: [],
+            };
+            map.set(key, g);
+        }
+        g.totalMinutes += minutes;
+
+        // Revenue: billable entries only, priced via rate.js.
+        if (e.teBillable) {
+            g.billableMinutes += minutes;
+            const amt = rate.billableAmount(e);
+            if (amt == null) unresolvedRate.push(e.teId);
+            else g.revenueAmounts.push(amt);
+        }
+
+        // Cost: all logged time × the worker's cost rate.
+        const costRate = e.worker ? numOrNull(e.worker.workerCostRate) : null;
+        if (costRate == null) noCostRate.push(e.teId);
+        else g.costAmounts.push(money.multiply(costRate, hours));
+    }
+
+    const jobs = [];
+    let totalRevenue = 0;
+    let totalCost = 0;
+    for (const g of map.values()) {
+        const revenue = money.sum(g.revenueAmounts);
+        const cost = money.sum(g.costAmounts);
+        const margin = money.subtract(revenue, cost);
+        totalRevenue = money.add(totalRevenue, revenue);
+        totalCost = money.add(totalCost, cost);
+        jobs.push({
+            jobId: g.jobId,
+            jobDesc: g.jobDesc,
+            billableMinutes: g.billableMinutes,
+            totalMinutes: g.totalMinutes,
+            revenue,
+            cost,
+            margin,
+            marginPct: revenue > 0 ? round2((margin / revenue) * 100) : null,
+        });
+    }
+    // Most profitable first.
+    jobs.sort((a, b) => b.margin - a.margin);
+
+    const totalMargin = money.subtract(totalRevenue, totalCost);
+    return {
+        jobs,
+        totals: {
+            revenue: totalRevenue,
+            cost: totalCost,
+            margin: totalMargin,
+            marginPct: totalRevenue > 0 ? round2((totalMargin / totalRevenue) * 100) : null,
+        },
+        unresolvedRateEntryIds: unresolvedRate,
+        entriesMissingCostRate: noCostRate,
+    };
+}
+
+module.exports = { buildProfitability };

--- a/tests/api/report-profitability.test.js
+++ b/tests/api/report-profitability.test.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for GET /v1/report/profitability (#436) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {},
+    TimeEntry: { findAll: vi.fn().mockResolvedValue([]) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('GET /v1/report/profitability contract', () => {
+    test('403 without authKey', async () => {
+        expect((await request(app).get('/v1/report/profitability')).status).toBe(403);
+    });
+    test('400 on an unknown query parameter (strict schema)', async () => {
+        expect((await request(app).get('/v1/report/profitability?bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
+    test('400 on a non-integer jobId (schema)', async () => {
+        expect((await request(app).get('/v1/report/profitability?jobId=abc').set('authKey', 'k')).status).toBe(400);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -255,7 +255,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('Worker has the workerTargetMinsPerWeek column (#400)', async () => {
         if (!connected) return;
         const rows = await db.Worker.findAll({
-            attributes: ['workerId', 'workerTargetMinsPerWeek'],
+            attributes: ['workerId', 'workerTargetMinsPerWeek', 'workerCostRate'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/report-profitability.test.js
+++ b/tests/unit/report-profitability.test.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildProfitability } from '../../app/services/report-profitability.js';
+
+// A billing type carrying an hourly rate, as rate.js expects.
+const bt = (r) => ({ btHourlyRate: r });
+
+describe('buildProfitability (#436)', () => {
+    test('nets revenue against cost into margin per job', () => {
+        // Job 1: 60 min billable @ $200/hr rev, worker cost $80/hr.
+        const entries = [
+            { teId: 1, teJobId: 1, teMinutes: 60, teBillable: true, billingType: bt(200), worker: { workerCostRate: 80 }, job: { jobDesc: 'Alpha' } },
+        ];
+        const r = buildProfitability(entries);
+        expect(r.jobs).toHaveLength(1);
+        const j = r.jobs[0];
+        expect(j.revenue).toBe(200);
+        expect(j.cost).toBe(80);
+        expect(j.margin).toBe(120);
+        expect(j.marginPct).toBe(60);
+        expect(r.totals.margin).toBe(120);
+    });
+
+    test('non-billable time adds cost but no revenue', () => {
+        const entries = [
+            { teId: 1, teJobId: 1, teMinutes: 60, teBillable: true, billingType: bt(200), worker: { workerCostRate: 80 } },
+            { teId: 2, teJobId: 1, teMinutes: 60, teBillable: false, worker: { workerCostRate: 80 } },
+        ];
+        const r = buildProfitability(entries);
+        expect(r.jobs[0].revenue).toBe(200);
+        expect(r.jobs[0].cost).toBe(160); // both hours cost
+        expect(r.jobs[0].margin).toBe(40);
+    });
+
+    test('flags entries with no cost rate and no resolvable revenue rate', () => {
+        const entries = [
+            { teId: 1, teJobId: 1, teMinutes: 60, teBillable: true, worker: {} }, // no rate, no cost
+        ];
+        const r = buildProfitability(entries);
+        expect(r.unresolvedRateEntryIds).toContain(1);
+        expect(r.entriesMissingCostRate).toContain(1);
+        expect(r.jobs[0].revenue).toBe(0);
+        expect(r.jobs[0].cost).toBe(0);
+    });
+
+    test('skips in-flight entries (teMinutes null)', () => {
+        const r = buildProfitability([{ teId: 1, teJobId: 1, teMinutes: null, teBillable: true, billingType: bt(200), worker: { workerCostRate: 80 } }]);
+        expect(r.jobs).toHaveLength(0);
+        expect(r.totals.revenue).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Is this project actually making money? Nets what you bill against what the work costs you.

Closes #436.

## Changes

- **Migration `20260614000000`** — `Worker.workerCostRate` (NUMERIC(14,2)), the worker's internal cost per hour. Settable on worker create/update.
- **`GET /v1/report/profitability`** — per job:
  - **revenue** = billable time priced through the full `rate.js` hierarchy (entry → task → project → client → worker)
  - **cost** = **all** logged time (billable *and* non-billable — cost is cost) × the worker's cost rate
  - **margin** = revenue − cost, plus **margin %**, with company-wide totals, sorted most-profitable-first
- **Honest by design** — the response returns `unresolvedRateEntryIds` (billable but no resolvable rate) and `entriesMissingCostRate` (no cost basis) so a partial picture never masquerades as complete.
- Company-scoped (master keys pass `?companyId`), optional `customerId` / `jobId` / `from` / `to`. Pure `report-profitability.js` service; exact-cent via `money.js`.

## Verification

`npm run lint` clean; `npm test` → **1125 passing** (profitability math: revenue-vs-cost, non-billable-adds-cost, missing-rate/cost flags, in-flight skip; route auth + schema; integration column). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/