### PR TITLE
feat(reporting): worker utilization report (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Worker utilization report** (#53). `GET /v1/report/utilization`:
+  per worker, **billable hours vs capacity** (`workerTargetMinsPerWeek` ×
+  weeks in the range) → utilization %, plus the billable ratio
+  (billable / total logged), with team-wide totals. Company-scoped,
+  `from`/`to` required, optional `workerId`. Pure
+  `report-utilization.js` service.
 - **Project profitability & margin** (#436). A new `Worker.workerCostRate`
   (internal cost/hour, migration `20260614000000`) plus
   `GET /v1/report/profitability`: per job, **revenue** (billable time

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1598,6 +1598,23 @@ const spec = {
                 },
             },
         },
+        '/v1/report/utilization': {
+            get: {
+                summary: 'Worker utilization (billable hours vs capacity)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'workerId', in: 'query', schema: { type: 'integer' } },
+                    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                ],
+                responses: {
+                    200: { description: 'Per-worker {capacity, billable, utilizationPct, billableRatioPct} + team totals' },
+                    400: { description: 'from/to required; master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/report/revenue': {
             get: {
                 summary: 'Revenue & earnings summary (by customer and month)',

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -20,6 +20,7 @@ const { buildTimesheet } = require('../services/report-timesheet.js');
 const { buildBudget } = require('../services/report-budget.js');
 const { buildTargets, weeksBetween } = require('../services/report-targets.js');
 const { buildProfitability } = require('../services/report-profitability.js');
+const { buildUtilization } = require('../services/report-utilization.js');
 const rate = require('../services/rate.js');
 
 const IsMaster = auth.isMaster;
@@ -592,6 +593,86 @@ exports.targets = async (req, res) => {
 
     const report = buildTargets(rows, weeksBetween(fromISO, toISO));
     return res.status(200).json({ message: "Targets vs actuals.", companyId, ...report });
+};
+
+/**
+ * GET /v1/report/utilization — worker utilization (#53): billable hours
+ * vs capacity (workerTargetMinsPerWeek × weeks) and billable ratio, per
+ * worker + team totals. Company-scoped; from/to required, optional
+ * workerId.
+ */
+exports.utilization = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    req.authKey = authKey;
+
+    const scope = await resolveCompany(req);
+    if (scope.error) {
+        return res.status(scope.error.status).json({ message: scope.error.message });
+    }
+    const { companyId } = scope;
+
+    const fromISO = req.query.from;
+    const toISO = req.query.to;
+    const from = parseDate(fromISO, false);
+    const to = parseDate(toISO, true);
+    const Op = db.Sequelize && db.Sequelize.Op;
+
+    const workerWhere = { workerCompId: companyId };
+    const workerFilter = Number(req.query.workerId);
+    if (Number.isInteger(workerFilter) && workerFilter > 0) workerWhere.workerId = workerFilter;
+
+    let workers;
+    try {
+        workers = await db.Worker.findAll({
+            where: workerWhere,
+            attributes: ['workerId', 'workerFName', 'workerLName', 'workerTargetMinsPerWeek'],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'utilization: Worker.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (workers.length === 0) {
+        return res.status(200).json({
+            message: "Worker utilization.", companyId,
+            weeks: weeksBetween(fromISO, toISO), workers: [], count: 0,
+            totals: { capacityMinutes: 0, billableMinutes: 0, totalMinutes: 0, utilizationPct: null, billableRatioPct: null },
+        });
+    }
+
+    const workerIds = workers.map((w) => w.workerId);
+    let entries;
+    try {
+        const where = { teCompId: companyId, teWorkerId: { [Op.in]: workerIds } };
+        if (Op && from) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.gte]: from });
+        if (Op && to) where.teStartedAt = Object.assign(where.teStartedAt || {}, { [Op.lte]: to });
+        entries = await db.TimeEntry.findAll({ where, attributes: ['teWorkerId', 'teMinutes', 'teBillable'] });
+    } catch (error) {
+        log.error({ err: error }, 'utilization: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const billable = new Map();
+    const total = new Map();
+    for (const e of entries) {
+        if (e.teWorkerId == null || e.teMinutes == null) continue;
+        const m = Number(e.teMinutes) || 0;
+        total.set(e.teWorkerId, (total.get(e.teWorkerId) || 0) + m);
+        if (e.teBillable) billable.set(e.teWorkerId, (billable.get(e.teWorkerId) || 0) + m);
+    }
+
+    const rows = workers.map((w) => ({
+        workerId: w.workerId,
+        workerName: [w.workerFName, w.workerLName].filter(Boolean).join(' ') || null,
+        targetMinsPerWeek: w.workerTargetMinsPerWeek,
+        billableMins: billable.get(w.workerId) || 0,
+        totalMins: total.get(w.workerId) || 0,
+    }));
+
+    const report = buildUtilization(rows, weeksBetween(fromISO, toISO));
+    return res.status(200).json({ message: "Worker utilization.", companyId, ...report });
 };
 
 exports._internals = { resolveCompany, parseDate };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -835,6 +835,11 @@ router.get(
     report.profitability,
 );
 router.get(
+    '/v1/report/utilization',
+    v.query(reportSchemas.utilizationQuery),
+    report.utilization,
+);
+router.get(
     '/v1/report/timesheet',
     v.query(reportSchemas.timesheetQuery),
     report.timesheet,

--- a/app/schemas/report.schema.js
+++ b/app/schemas/report.schema.js
@@ -114,4 +114,17 @@ const profitabilityQuery = z.object({
     message: 'Unexpected query parameter. Allowed: companyId, customerId, jobId, from, to.',
 });
 
-module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery, targetsQuery, profitabilityQuery };
+/**
+ * GET /v1/report/utilization query. companyId required for master keys.
+ * from/to required (capacity is defined over a range). Optional workerId.
+ */
+const utilizationQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    workerId: z.coerce.number().int().positive().optional(),
+    from: isoDate,
+    to: isoDate,
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, workerId, from, to.',
+});
+
+module.exports = { unbilledQuery, hoursQuery, revenueQuery, billableSummaryQuery, timesheetQuery, budgetQuery, targetsQuery, profitabilityQuery, utilizationQuery };

--- a/app/services/report-utilization.js
+++ b/app/services/report-utilization.js
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-utilization.js — worker utilization (#53): how much of each
+ * worker's capacity is billable. Two ratios per worker:
+ *   - utilization  = billable minutes / capacity minutes
+ *     (capacity = workerTargetMinsPerWeek × weeks in the range)
+ *   - billableRatio = billable minutes / total logged minutes
+ * plus team-wide totals.
+ *
+ * PURE: the caller loads workers (with a weekly target + summed billable
+ * and total minutes) and the week count. No DB. Hours-based, not money.
+ */
+
+const round2 = (n) => Math.round((Number(n) || 0) * 100) / 100;
+
+/**
+ * @param workers array of { workerId, workerName, targetMinsPerWeek,
+ *   billableMins, totalMins }.
+ * @param weeks number of weeks the weekly target applies over.
+ * @returns { weeks, workers: [...rows], count, totals }.
+ */
+function buildUtilization(workers, weeks) {
+    const w = Math.max(1, Math.round(Number(weeks) || 1));
+    let teamBillable = 0;
+    let teamTotal = 0;
+    let teamCapacity = 0;
+
+    const rows = (workers || []).map((x) => {
+        const perWeek = x.targetMinsPerWeek == null ? null : Number(x.targetMinsPerWeek);
+        const capacityMins = perWeek == null ? null : perWeek * w;
+        const billableMins = Number(x.billableMins) || 0;
+        const totalMins = Number(x.totalMins) || 0;
+
+        teamBillable += billableMins;
+        teamTotal += totalMins;
+        if (capacityMins != null) teamCapacity += capacityMins;
+
+        const utilization = (capacityMins == null || capacityMins <= 0) ? null : billableMins / capacityMins;
+        const billableRatio = totalMins > 0 ? billableMins / totalMins : null;
+        return {
+            workerId: x.workerId,
+            workerName: x.workerName || null,
+            capacityMinutes: capacityMins,
+            capacityHours: capacityMins == null ? null : round2(capacityMins / 60),
+            billableMinutes: billableMins,
+            billableHours: round2(billableMins / 60),
+            totalMinutes: totalMins,
+            totalHours: round2(totalMins / 60),
+            utilizationPct: utilization == null ? null : round2(utilization * 100),
+            billableRatioPct: billableRatio == null ? null : round2(billableRatio * 100),
+        };
+    }).sort((a, b) => a.workerId - b.workerId);
+
+    return {
+        weeks: w,
+        workers: rows,
+        count: rows.length,
+        totals: {
+            capacityMinutes: teamCapacity,
+            billableMinutes: teamBillable,
+            totalMinutes: teamTotal,
+            utilizationPct: teamCapacity > 0 ? round2((teamBillable / teamCapacity) * 100) : null,
+            billableRatioPct: teamTotal > 0 ? round2((teamBillable / teamTotal) * 100) : null,
+        },
+    };
+}
+
+module.exports = { buildUtilization };

--- a/tests/api/report-utilization.test.js
+++ b/tests/api/report-utilization.test.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for GET /v1/report/utilization (#53) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {},
+    TimeEntry: { findAll: vi.fn().mockResolvedValue([]) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('GET /v1/report/utilization contract', () => {
+    test('403 without authKey (from/to present)', async () => {
+        expect((await request(app).get('/v1/report/utilization?from=2026-01-01&to=2026-01-31')).status).toBe(403);
+    });
+    test('400 when from/to are missing (schema requires them)', async () => {
+        expect((await request(app).get('/v1/report/utilization').set('authKey', 'k')).status).toBe(400);
+    });
+    test('400 on an unknown query parameter (strict schema)', async () => {
+        const res = await request(app).get('/v1/report/utilization?from=2026-01-01&to=2026-01-31&bogus=1').set('authKey', 'k');
+        expect(res.status).toBe(400);
+    });
+});

--- a/tests/unit/report-utilization.test.js
+++ b/tests/unit/report-utilization.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildUtilization } from '../../app/services/report-utilization.js';
+
+describe('buildUtilization (#53)', () => {
+    test('utilization = billable / capacity over the week span', () => {
+        // 2400 min/week target × 2 weeks = 4800 min capacity; 2400 billable → 50%.
+        const r = buildUtilization(
+            [{ workerId: 1, workerName: 'Ada', targetMinsPerWeek: 2400, billableMins: 2400, totalMins: 3000 }],
+            2,
+        );
+        const w = r.workers[0];
+        expect(w.capacityMinutes).toBe(4800);
+        expect(w.utilizationPct).toBe(50);
+        expect(w.billableRatioPct).toBe(80); // 2400 / 3000
+        expect(r.totals.utilizationPct).toBe(50);
+    });
+
+    test('a worker with no target has null utilization but a real billable ratio', () => {
+        const r = buildUtilization(
+            [{ workerId: 2, workerName: 'Bo', targetMinsPerWeek: null, billableMins: 300, totalMins: 600 }],
+            1,
+        );
+        expect(r.workers[0].utilizationPct).toBeNull();
+        expect(r.workers[0].billableRatioPct).toBe(50);
+        expect(r.totals.utilizationPct).toBeNull(); // no capacity across the team
+    });
+
+    test('team totals aggregate across workers', () => {
+        const r = buildUtilization([
+            { workerId: 1, targetMinsPerWeek: 600, billableMins: 300, totalMins: 600 },
+            { workerId: 2, targetMinsPerWeek: 600, billableMins: 600, totalMins: 600 },
+        ], 1);
+        // capacity 1200, billable 900 → 75%
+        expect(r.totals.capacityMinutes).toBe(1200);
+        expect(r.totals.utilizationPct).toBe(75);
+    });
+});


### PR DESCRIPTION
## Summary

The classic consulting metric: how much of each person's capacity turns into billable work.

Closes #53.

## Changes

- **`GET /v1/report/utilization`** — per worker over a date range:
  - **utilization %** = billable minutes / **capacity** (`workerTargetMinsPerWeek` × weeks in range)
  - **billable ratio %** = billable minutes / total logged minutes
  - hours + minutes for capacity / billable / total
  - **team totals** aggregating across the roster
- A worker with no weekly target reports `null` utilization (no capacity basis) but still a real billable ratio — honest about what it can and can't compute.
- Company-scoped (master keys pass `?companyId`); `from`/`to` required (capacity is defined over a range); optional `workerId`. Pure `report-utilization.js` service; **no new columns** — it builds on the target hours from #400.

## Verification

`npm run lint` clean; `npm test` → **1134 passing** (utilization math: billable-vs-capacity, no-target→null, team totals; route auth + required-from/to + strict schema). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/