### PR TITLE
feat(structure): project phases / billing stages (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Project phases / billing stages** (#408). A new `Phase` model under a
+  Job (`phaseName`, `phaseStartDate`, `phaseEndDate`, `phaseBudgetAmount`),
+  migration `20260615000000` — a date-bounded, budgeted stage, the unit of
+  milestone billing (distinct from a task/activity). Full REST:
+  `POST /v1/phase`, `GET /v1/phase/byjob/{id}` (paginated, ordered by start
+  date), `GET|PATCH|DELETE /v1/phase/{id}`, all job→company scoped with
+  secure-404 + soft-delete (`phaseArch`); end-date validated on or after
+  the start.
 - **Worker utilization report** (#53). `GET /v1/report/utilization`:
   per worker, **billable hours vs capacity** (`workerTargetMinsPerWeek` ×
   weeks in the range) → utilization %, plus the billable ratio

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -70,6 +70,7 @@ db.Expense = require('../models/expense.model.js')(sequelize, Sequelize);
 db.AuditLog = require('../models/auditlog.model.js')(sequelize, Sequelize);
 db.Task = require('../models/task.model.js')(sequelize, Sequelize);
 db.Retainer = require('../models/retainer.model.js')(sequelize, Sequelize);
+db.Phase = require('../models/phase.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -201,5 +202,9 @@ db.TimeEntry.belongsTo(db.Task, { foreignKey: 'teTaskId', as: 'task' });
 // Retainer → Customer (retCustId): a client prepayment (#426).
 db.Customer.hasMany(db.Retainer,   { foreignKey: 'retCustId', as: 'retainers' });
 db.Retainer.belongsTo(db.Customer, { foreignKey: 'retCustId', as: 'customer' });
+
+// Phase → Job (phaseJobId): a date-bounded billing stage of a project (#408).
+db.Job.hasMany(db.Phase,   { foreignKey: 'phaseJobId', as: 'phases' });
+db.Phase.belongsTo(db.Job, { foreignKey: 'phaseJobId', as: 'job' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,49 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/phase': {
+            post: {
+                summary: 'Create a phase / billing stage under a job',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Created' },
+                    400: { description: 'Validation error or bad phaseJobId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
+        '/v1/phase/byjob/{id}': {
+            get: {
+                summary: "List a job's phases",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 404: { description: 'Job not found / cross-tenant' } },
+            },
+        },
+        '/v1/phase/{id}': {
+            get: {
+                summary: 'Fetch a phase',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a phase',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a phase',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/task': {
             post: {
                 summary: 'Create a task / activity under a job',

--- a/app/controllers/phasecontroller.js
+++ b/app/controllers/phasecontroller.js
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const Phase = db.Phase;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
+
+const ALLOWED_FIELDS_CREATE = ['phaseJobId', 'phaseName', 'phaseStartDate', 'phaseEndDate', 'phaseBudgetAmount'];
+const ALLOWED_FIELDS_UPDATE = ['phaseName', 'phaseStartDate', 'phaseEndDate', 'phaseBudgetAmount'];
+
+/**
+ * POST /v1/phase — create a phase under a job. The job's company
+ * (resolved through phaseJobId → Job → Customer) must be the caller's
+ * company (master keys may target any).
+ */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const phaseJobId = Number(body.phaseJobId);
+    if (!Number.isInteger(phaseJobId) || phaseJobId <= 0) {
+        return res.status(400).json({ message: "phaseJobId is required and must be an integer." });
+    }
+
+    let jobCompanyId;
+    try {
+        jobCompanyId = await GetCompanyIdByJobId(phaseJobId);
+    } catch (error) {
+        log.error({ err: error }, 'phase create: job company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (jobCompanyId === -1) {
+        return res.status(400).json({ message: "phaseJobId must reference a job." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== jobCompanyId) {
+            return res.status(403).json({ message: "Cannot create a phase for a job in a company you do not belong to." });
+        }
+    }
+
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+    payload.phaseArch = false;
+
+    try {
+        const created = await Phase.create(payload);
+        return res.status(201).json({ message: "Phase created.", phase: created });
+    } catch (error) {
+        log.error({ err: error }, 'Phase.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * GET /v1/phase/:id — fetch one phase. Secure-404 scoped through its
+ * job's company: a cross-tenant id reads as 404.
+ */
+exports.getById = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let phase;
+    try {
+        phase = await Phase.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Phase.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!phase || phase.phaseArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        let phaseCompanyId;
+        try {
+            phaseCompanyId = await GetCompanyIdByJobId(phase.phaseJobId);
+        } catch (error) {
+            log.error({ err: error }, 'phase getById: company resolve failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1 || phaseCompanyId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+    return res.status(200).json({ message: "Found.", phase });
+};
+
+/**
+ * GET /v1/phase/byjob/:id — list a job's phases. Secure-404 scoped
+ * through the job's company (a job in another tenant reads as 404).
+ */
+exports.listByJob = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const jobId = Number(req.params.id);
+    if (!Number.isInteger(jobId) || jobId <= 0) {
+        return res.status(400).json({ message: "Invalid job id." });
+    }
+
+    let jobCompanyId;
+    try {
+        jobCompanyId = await GetCompanyIdByJobId(jobId);
+    } catch (error) {
+        log.error({ err: error }, 'phase listByJob: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (jobCompanyId === -1) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== jobCompanyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Phase.findAndCountAll({
+            where: { phaseJobId: jobId },
+            limit,
+            offset,
+            order: [['phaseStartDate', 'ASC'], ['phaseId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, phases: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Phase.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** Load a phase and enforce the secure-404 scope. Returns the phase or null (after responding). */
+async function findScoped(req, res) {
+    let phase;
+    try {
+        phase = await Phase.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Phase.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!phase || phase.phaseArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        let phaseCompanyId;
+        try {
+            phaseCompanyId = await GetCompanyIdByJobId(phase.phaseJobId);
+        } catch (error) {
+            log.error({ err: error }, 'phase scope: company resolve failed');
+            res.status(500).json({ message: "Error!" });
+            return null;
+        }
+        if (companyId === -1 || phaseCompanyId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return phase;
+}
+
+/** PATCH /v1/phase/:id — partial update. phaseJobId / phaseArch not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const phase = await findScoped(req, res);
+    if (!phase) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await phase.update(updates);
+        return res.status(200).json({ message: "Updated.", phase });
+    } catch (error) {
+        log.error({ err: error }, 'Phase.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/phase/:id — soft-delete (sets phaseArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const phase = await findScoped(req, res);
+    if (!phase) return undefined;
+
+    try {
+        await phase.update({ phaseArch: true });
+        return res.status(200).json({ message: "Archived.", id: phase.phaseId });
+    } catch (error) {
+        log.error({ err: error }, 'Phase archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260615000000-phase.js
+++ b/app/migrations/20260615000000-phase.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Project phase / milestone entity (#408): a date-bounded, budgeted
+// billing stage of a Job. Distinct from a Task (an activity) — a Phase
+// carries a start/end and a budget amount, the unit of milestone billing.
+// Scoped to a company through phaseJobId → Job → Customer. A new table in
+// the increment layer; no FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Phase', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    phaseId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    phaseJobId: { type: Sequelize.INTEGER, allowNull: false },
+                    phaseName: { type: Sequelize.TEXT, allowNull: false },
+                    phaseStartDate: { type: Sequelize.DATEONLY, allowNull: true },
+                    phaseEndDate: { type: Sequelize.DATEONLY, allowNull: true },
+                    phaseBudgetAmount: { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+                    phaseArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, {
+                name: 'Phase_jobId_arch_idx',
+                fields: ['phaseJobId', 'phaseArch'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/phase.model.js
+++ b/app/models/phase.model.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Phase — a date-bounded, budgeted stage of a Job (#408); the unit of
+ * milestone billing. Scope resolves through phaseJobId → Job →
+ * Customer.custCompId (see auth.getCompanyIdByJobId). Soft-deletes via
+ * phaseArch. phaseBudgetAmount is NUMERIC(14,2) with a Number getter.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Phase = sequelize.define('Phase', {
+        phaseId: {
+            field: 'phaseId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        phaseJobId: {
+            field: 'phaseJobId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        phaseName: {
+            field: 'phaseName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        phaseStartDate: {
+            field: 'phaseStartDate',
+            type: Sequelize.DATEONLY,
+        },
+        phaseEndDate: {
+            field: 'phaseEndDate',
+            type: Sequelize.DATEONLY,
+        },
+        phaseBudgetAmount: {
+            field: 'phaseBudgetAmount',
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('phaseBudgetAmount');
+                return v == null ? null : Number(v);
+            },
+        },
+        phaseArch: {
+            field: 'phaseArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Phase',
+        timestamps: true,
+        defaultScope: { where: { phaseArch: false } }
+    });
+
+    return Phase;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -32,6 +32,7 @@ const expense = require('../controllers/expensecontroller.js');
 const auditlog = require('../controllers/auditlogcontroller.js');
 const task = require('../controllers/taskcontroller.js');
 const retainer = require('../controllers/retainercontroller.js');
+const phase = require('../controllers/phasecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -54,6 +55,7 @@ const expenseSchemas = require('../schemas/expense.schema.js');
 const auditlogSchemas = require('../schemas/auditlog.schema.js');
 const taskSchemas = require('../schemas/task.schema.js');
 const retainerSchemas = require('../schemas/retainer.schema.js');
+const phaseSchemas = require('../schemas/phase.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -740,6 +742,35 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 phase routes (date-bounded billing stages under jobs, #408).
+router.post(
+    '/v1/phase',
+    v.body(phaseSchemas.createPhaseBody),
+    phase.create,
+);
+router.get(
+    '/v1/phase/byjob/:id',
+    v.params(phaseSchemas.intIdParam),
+    v.query(phaseSchemas.listByJobQuery),
+    phase.listByJob,
+);
+router.get(
+    '/v1/phase/:id',
+    v.params(phaseSchemas.intIdParam),
+    phase.getById,
+);
+router.patch(
+    '/v1/phase/:id',
+    v.params(phaseSchemas.intIdParam),
+    v.body(phaseSchemas.updatePhaseBody),
+    phase.update,
+);
+router.delete(
+    '/v1/phase/:id',
+    v.params(phaseSchemas.intIdParam),
+    phase.remove,
 );
 
 // v1 task routes (activities under jobs, #407).

--- a/app/schemas/phase.schema.js
+++ b/app/schemas/phase.schema.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+// YYYY-MM-DD calendar date.
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+
+/** POST /v1/phase body. phaseJobId + phaseName required. */
+const createPhaseBody = z.object({
+    phaseJobId: z.coerce.number().int().positive(),
+    phaseName: z.string().min(1).max(255),
+    phaseStartDate: isoDate.optional(),
+    phaseEndDate: isoDate.optional(),
+    phaseBudgetAmount: z.coerce.number().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: phaseJobId, phaseName, phaseStartDate, phaseEndDate, phaseBudgetAmount.',
+}).refine(
+    (d) => !(d.phaseStartDate && d.phaseEndDate) || d.phaseEndDate >= d.phaseStartDate,
+    { message: 'phaseEndDate must be on or after phaseStartDate.', path: ['phaseEndDate'] },
+);
+
+/** PATCH /v1/phase/:id — phaseJobId is not re-parentable here. */
+const updatePhaseBody = z.object({
+    phaseName: z.string().min(1).max(255).optional(),
+    phaseStartDate: isoDate.nullable().optional(),
+    phaseEndDate: isoDate.nullable().optional(),
+    phaseBudgetAmount: z.coerce.number().positive().nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: phaseName, phaseStartDate, phaseEndDate, phaseBudgetAmount.',
+}).refine(
+    (d) => !(d.phaseStartDate && d.phaseEndDate) || d.phaseEndDate >= d.phaseStartDate,
+    { message: 'phaseEndDate must be on or after phaseStartDate.', path: ['phaseEndDate'] },
+);
+
+const listByJobQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createPhaseBody,
+    updatePhaseBody,
+    listByJobQuery,
+};

--- a/tests/api/phase.test.js
+++ b/tests/api/phase.test.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/phase (#408) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, TimeEntry: {},
+    Phase: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Phase auth + schema contract', () => {
+    test('POST /v1/phase 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/phase').send({ phaseJobId: 1, phaseName: 'Discovery' })).status).toBe(403);
+    });
+    test('POST /v1/phase 400 on missing phaseName (schema)', async () => {
+        expect((await request(app).post('/v1/phase').set('authKey', 'k').send({ phaseJobId: 1 })).status).toBe(400);
+    });
+    test('POST /v1/phase 400 on inverted dates (schema refine)', async () => {
+        const res = await request(app).post('/v1/phase').set('authKey', 'k')
+            .send({ phaseJobId: 1, phaseName: 'X', phaseStartDate: '2026-03-01', phaseEndDate: '2026-02-01' });
+        expect(res.status).toBe(400);
+    });
+    test('POST /v1/phase 400 on an unknown field (strict schema)', async () => {
+        expect((await request(app).post('/v1/phase').set('authKey', 'k').send({ phaseJobId: 1, phaseName: 'X', bogus: 1 })).status).toBe(400);
+    });
+    test('GET /v1/phase/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/phase/1')).status).toBe(403);
+    });
+    test('GET /v1/phase/byjob/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/phase/byjob/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -229,6 +229,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(withCustomer)).toBe(true);
     });
 
+    test('Phase table exists with a job include (#408)', async () => {
+        if (!connected) return;
+        const rows = await db.Phase.findAll({
+            attributes: ['phaseId', 'phaseJobId', 'phaseName', 'phaseStartDate', 'phaseEndDate', 'phaseBudgetAmount'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withJob = await db.Phase.findAll({
+            limit: 1,
+            include: [{ model: db.Job, as: 'job', required: false }],
+        });
+        expect(Array.isArray(withJob)).toBe(true);
+    });
+
     test('Task table exists with a job include (#407)', async () => {
         if (!connected) return;
         const rows = await db.Task.findAll({


### PR DESCRIPTION
## Summary

Break a project into date-bounded, budgeted stages — the unit of milestone billing.

Closes #408.

## Changes

- **Migration `20260615000000`** — creates the `Phase` table (`phaseId`, `phaseJobId`, `phaseName`, `phaseStartDate?`, `phaseEndDate?`, `phaseBudgetAmount?`, `phaseArch`) + a `(phaseJobId, phaseArch)` index.
- **Model / associations** — a `Phase` belongs to a `Job` (`phaseJobId`); `phaseBudgetAmount` carries a Number getter, dates are `DATEONLY`. Soft-delete via `phaseArch`.
- **Full REST** on `/v1/phase` — `POST`, `GET /byjob/{id}` (paginated, ordered by start date), `GET|PATCH|DELETE /{id}` — **job→company scoped** via `getCompanyIdByJobId` with **secure-404**, end date validated **on or after** the start.

## How it differs from tasks (#407)

A **task** is an activity you log time against; a **phase** is a time-boxed, budgeted stage of the project (Discovery, Build, Launch…) — the anchor for milestone/fixed-fee billing.

## Verification

`npm run lint` clean; `npm test` → **1147 passing** (6 route auth + schema cases incl. the inverted-date refine; integration table/association check). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/