### PR TITLE
feat(billing-rates): role-based rates (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Role-based rates** (#412). A new company-scoped `Role` entity
+  (`roleName` + `roleRate`) and a `Worker.workerRoleId` link (migration
+  `20260616000000`). The role rate slots into `rate.js` between the client
+  rate and the worker default: entry → task → project → client → **role**
+  → worker. Full REST on `/v1/role` (create, `bycompany` list,
+  get/patch/delete) with secure-404; `workerRoleId` settable on worker
+  create/update. It rides the already-eager-loaded worker association, so
+  every billing path resolves it.
 - **Project phases / billing stages** (#408). A new `Phase` model under a
   Job (`phaseName`, `phaseStartDate`, `phaseEndDate`, `phaseBudgetAmount`),
   migration `20260615000000` — a date-bounded, budgeted stage, the unit of

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -71,6 +71,7 @@ db.AuditLog = require('../models/auditlog.model.js')(sequelize, Sequelize);
 db.Task = require('../models/task.model.js')(sequelize, Sequelize);
 db.Retainer = require('../models/retainer.model.js')(sequelize, Sequelize);
 db.Phase = require('../models/phase.model.js')(sequelize, Sequelize);
+db.Role = require('../models/role.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -206,5 +207,11 @@ db.Retainer.belongsTo(db.Customer, { foreignKey: 'retCustId', as: 'customer' });
 // Phase → Job (phaseJobId): a date-bounded billing stage of a project (#408).
 db.Job.hasMany(db.Phase,   { foreignKey: 'phaseJobId', as: 'phases' });
 db.Phase.belongsTo(db.Job, { foreignKey: 'phaseJobId', as: 'job' });
+
+// Role → Company (roleCompId) + Worker → Role (workerRoleId): role rate card (#412).
+db.Company.hasMany(db.Role,  { foreignKey: 'roleCompId', as: 'roles' });
+db.Role.belongsTo(db.Company, { foreignKey: 'roleCompId', as: 'company' });
+db.Role.hasMany(db.Worker,   { foreignKey: 'workerRoleId', as: 'workers' });
+db.Worker.belongsTo(db.Role, { foreignKey: 'workerRoleId', as: 'role' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,49 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/role': {
+            post: {
+                summary: 'Create a billing role (name + rate)',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Created' },
+                    400: { description: 'Validation error; master keys must specify roleCompId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
+        '/v1/role/bycompany/{id}': {
+            get: {
+                summary: "List a company's roles",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/role/{id}': {
+            get: {
+                summary: 'Fetch a role',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a role',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a role',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/phase': {
             post: {
                 summary: 'Create a phase / billing stage under a job',

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -331,7 +331,7 @@ exports.rollup = async (req, res) => {
                 { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
                 {
                     model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },

--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -97,7 +97,7 @@ exports.unbilled = async (req, res) => {
                 { model: db.BillingType, as: 'billingType', required: false },
                 {
                     model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc', 'jobFlatRate'] },
                 {
@@ -312,7 +312,7 @@ exports.billableSummary = async (req, res) => {
                 { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
                 {
                     model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
@@ -368,7 +368,7 @@ exports.profitability = async (req, res) => {
                 { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobDesc', 'jobFlatRate'] },
                 {
                     model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
                 { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
@@ -481,7 +481,7 @@ exports.budget = async (req, res) => {
                 { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
                 {
                     model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },

--- a/app/controllers/rolecontroller.js
+++ b/app/controllers/rolecontroller.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const Role = db.Role;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const ALLOWED_FIELDS_CREATE = ['roleName', 'roleRate', 'roleCompId'];
+const ALLOWED_FIELDS_UPDATE = ['roleName', 'roleRate'];
+
+/**
+ * POST /v1/role — create a billing role in a company. Master keys must
+ * supply roleCompId; non-master keys default it to their own company
+ * (a different one is a 403).
+ */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+
+    if (!isMaster) {
+        let companyId;
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (payload.roleCompId !== undefined && Number(payload.roleCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot create a role for a company you do not belong to." });
+        }
+        payload.roleCompId = companyId;
+    } else if (payload.roleCompId === undefined || Number(payload.roleCompId) <= 0) {
+        return res.status(400).json({ message: "Master-key requests must specify roleCompId." });
+    }
+
+    payload.roleArch = false;
+
+    try {
+        const created = await Role.create(payload);
+        return res.status(201).json({ message: "Role created.", role: created });
+    } catch (error) {
+        log.error({ err: error }, 'Role.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** Load a role and enforce the secure-404 scope. Returns the role or null (after responding). */
+async function findScoped(req, res) {
+    let role;
+    try {
+        role = await Role.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Role.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!role || role.roleArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        // Cross-tenant single-entity reads are 404, not 403 (anti-enumeration).
+        if (companyId === -1 || role.roleCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return role;
+}
+
+/** GET /v1/role/:id — fetch one role. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const role = await findScoped(req, res);
+    if (!role) return undefined;
+    return res.status(200).json({ message: "Found.", role });
+};
+
+/** GET /v1/role/bycompany/:id — list a company's roles (paginated). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Role.findAndCountAll({
+            where: { roleCompId: targetCompanyId },
+            limit,
+            offset,
+            order: [['roleId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, roles: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Role.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** PATCH /v1/role/:id — partial update. roleCompId / roleArch not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const role = await findScoped(req, res);
+    if (!role) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await role.update(updates);
+        return res.status(200).json({ message: "Updated.", role });
+    } catch (error) {
+        log.error({ err: error }, 'Role.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/role/:id — soft-delete (sets roleArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const role = await findScoped(req, res);
+    if (!role) return undefined;
+
+    try {
+        await role.update({ roleArch: true });
+        return res.status(200).json({ message: "Archived.", id: role.roleId });
+    } catch (error) {
+        log.error({ err: error }, 'Role archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -524,7 +524,7 @@ exports.getById = async (req, res) => {
                     model: db.Worker,
                     as: 'worker',
                     required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }],
+                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
                 },
                 // Client rate card (#413) — resolveHourlyRate reads entry.customer.
                 { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -14,10 +14,10 @@ const GetCompanyId = auth.getCompanyId;
 
 const ALLOWED_FIELDS_CREATE = [
     'workerFName', 'workerLName', 'workerTitle',
-    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek', 'workerCostRate',
+    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId',
 ];
 const ALLOWED_FIELDS_UPDATE = [
-    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek', 'workerCostRate',
+    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId',
 ];
 
 /**

--- a/app/migrations/20260616000000-role.js
+++ b/app/migrations/20260616000000-role.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Role-based rates (#412). A Role (e.g. "Senior Consultant") carries a
+// default hourly rate; a Worker is linked to a Role via workerRoleId.
+// The role rate is a tier of rate resolution between the client rate and
+// the worker's own default (see app/services/rate.js). New table +
+// nullable Worker column in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const ROLE = { tableName: 'Role', schema: SCHEMA };
+const WORKER = { tableName: 'Worker', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                ROLE,
+                {
+                    roleId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    roleCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    roleName: { type: Sequelize.TEXT, allowNull: false },
+                    roleRate: { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+                    roleArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(ROLE, {
+                name: 'Role_compId_arch_idx',
+                fields: ['roleCompId', 'roleArch'],
+                transaction: t,
+            });
+            await queryInterface.addColumn(WORKER, 'workerRoleId', { type: Sequelize.INTEGER, allowNull: true }, { transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.removeColumn(WORKER, 'workerRoleId', { transaction: t });
+            await queryInterface.dropTable(ROLE, { transaction: t });
+        });
+    },
+};

--- a/app/models/role.model.js
+++ b/app/models/role.model.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Role — a named billing role (e.g. "Senior Consultant") with a default
+ * hourly rate (#412). Company-scoped via roleCompId; a Worker links to a
+ * Role via workerRoleId, and the role rate is a tier of rate resolution
+ * between the client rate and the worker default (see rate.js).
+ * roleRate is NUMERIC(14,2) with a Number getter. Soft-deletes via roleArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Role = sequelize.define('Role', {
+        roleId: {
+            field: 'roleId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        roleCompId: {
+            field: 'roleCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        roleName: {
+            field: 'roleName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        roleRate: {
+            field: 'roleRate',
+            type: Sequelize.DECIMAL(14, 2),
+            get() {
+                const v = this.getDataValue('roleRate');
+                return v == null ? null : Number(v);
+            },
+        },
+        roleArch: {
+            field: 'roleArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Role',
+        timestamps: true,
+        defaultScope: { where: { roleArch: false } }
+    });
+
+    return Role;
+};

--- a/app/models/worker.model.js
+++ b/app/models/worker.model.js
@@ -67,6 +67,12 @@ module.exports = (sequelize, Sequelize) => {
                 return v == null ? null : Number(v);
             },
         },
+        workerRoleId: {
+            field: 'workerRoleId',
+            // Nullable link to a Role (#412); its roleRate is a rate tier
+            // between the client rate and the worker's own default.
+            type: Sequelize.INTEGER,
+        },
     }, {
         tableName: 'Worker',
         timestamps: true,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -33,6 +33,7 @@ const auditlog = require('../controllers/auditlogcontroller.js');
 const task = require('../controllers/taskcontroller.js');
 const retainer = require('../controllers/retainercontroller.js');
 const phase = require('../controllers/phasecontroller.js');
+const role = require('../controllers/rolecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -56,6 +57,7 @@ const auditlogSchemas = require('../schemas/auditlog.schema.js');
 const taskSchemas = require('../schemas/task.schema.js');
 const retainerSchemas = require('../schemas/retainer.schema.js');
 const phaseSchemas = require('../schemas/phase.schema.js');
+const roleSchemas = require('../schemas/role.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -742,6 +744,35 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 role routes (role rate cards, #412).
+router.post(
+    '/v1/role',
+    v.body(roleSchemas.createRoleBody),
+    role.create,
+);
+router.get(
+    '/v1/role/bycompany/:id',
+    v.params(roleSchemas.intIdParam),
+    v.query(roleSchemas.listByCompanyQuery),
+    role.listByCompany,
+);
+router.get(
+    '/v1/role/:id',
+    v.params(roleSchemas.intIdParam),
+    role.getById,
+);
+router.patch(
+    '/v1/role/:id',
+    v.params(roleSchemas.intIdParam),
+    v.body(roleSchemas.updateRoleBody),
+    role.update,
+);
+router.delete(
+    '/v1/role/:id',
+    v.params(roleSchemas.intIdParam),
+    role.remove,
 );
 
 // v1 phase routes (date-bounded billing stages under jobs, #408).

--- a/app/schemas/role.schema.js
+++ b/app/schemas/role.schema.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/**
+ * POST /v1/role body. roleName required; roleCompId optional for
+ * non-master keys (defaults to the key's company), required for master.
+ */
+const createRoleBody = z.object({
+    roleName: z.string().min(1).max(255),
+    roleRate: z.coerce.number().positive().optional(),
+    roleCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: roleName, roleRate, roleCompId.',
+});
+
+/** PATCH /v1/role/:id — roleCompId is not patchable. */
+const updateRoleBody = z.object({
+    roleName: z.string().min(1).max(255).optional(),
+    roleRate: z.coerce.number().positive().nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: roleName, roleRate.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createRoleBody,
+    updateRoleBody,
+    listByCompanyQuery,
+};

--- a/app/schemas/worker.schema.js
+++ b/app/schemas/worker.schema.js
@@ -24,8 +24,9 @@ const createWorkerBody = z.object({
     workerCompId: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().optional(),
     workerCostRate: z.coerce.number().positive().optional(),
+    workerRoleId: z.coerce.number().int().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',
 });
 
 /**
@@ -41,8 +42,9 @@ const updateWorkerBody = z.object({
     workerDefaultBillType: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().nullable().optional(),
     workerCostRate: z.coerce.number().positive().nullable().optional(),
+    workerRoleId: z.coerce.number().int().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',
 });
 
 const listByCompanyQuery = z.object({

--- a/app/services/rate.js
+++ b/app/services/rate.js
@@ -12,12 +12,13 @@
  *   3. the entry's Job's flat rate (jobFlatRate — a per-project rate, #410)
  *   4. the entry's Customer's default rate (custDefaultRate — a client
  *      rate card, #413)
- *   5. the entry's Worker's default BillingType (workerDefaultBillType)
+ *   5. the entry's Worker's Role rate (roleRate — a role rate card, #412)
+ *   6. the entry's Worker's default BillingType (workerDefaultBillType)
  *
  * These functions are PURE: the caller eager-loads the associations
- * (entry.billingType, entry.task, entry.job, entry.customer and
- * entry.worker.defaultBillingType) so rate.js never touches the database
- * and stays trivially unit-testable.
+ * (entry.billingType, entry.task, entry.job, entry.customer,
+ * entry.worker.role and entry.worker.defaultBillingType) so rate.js never
+ * touches the database and stays trivially unit-testable.
  */
 
 const money = require('./money.js');
@@ -48,6 +49,11 @@ function taskRateOf(task) {
     return task ? numOrNull(task.taskRate) : null;
 }
 
+/** The role rate on a Worker's linked Role, or null if absent. */
+function roleRateOf(worker) {
+    return worker && worker.role ? numOrNull(worker.role.roleRate) : null;
+}
+
 /**
  * The effective hourly rate for a time entry, or null when none can be
  * resolved. Expects eager-loaded `entry.billingType` (per-entry),
@@ -65,6 +71,8 @@ function resolveHourlyRate(entry) {
     if (project != null) return project;
     const client = clientRateOf(entry.customer);
     if (client != null) return client;
+    const role = roleRateOf(entry.worker);
+    if (role != null) return role;
     return rateOf(entry.worker && entry.worker.defaultBillingType);
 }
 

--- a/tests/api/role.test.js
+++ b/tests/api/role.test.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/role (#412) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, TimeEntry: {},
+    Role: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Role auth + schema contract', () => {
+    test('POST /v1/role 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/role').send({ roleName: 'Senior Consultant', roleRate: 250 })).status).toBe(403);
+    });
+    test('POST /v1/role 400 on missing roleName (schema)', async () => {
+        expect((await request(app).post('/v1/role').set('authKey', 'k').send({ roleRate: 250 })).status).toBe(400);
+    });
+    test('POST /v1/role 400 on a non-positive roleRate (schema)', async () => {
+        expect((await request(app).post('/v1/role').set('authKey', 'k').send({ roleName: 'X', roleRate: 0 })).status).toBe(400);
+    });
+    test('POST /v1/role 400 on an unknown field (strict schema)', async () => {
+        expect((await request(app).post('/v1/role').set('authKey', 'k').send({ roleName: 'X', bogus: 1 })).status).toBe(400);
+    });
+    test('GET /v1/role/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/role/1')).status).toBe(403);
+    });
+    test('GET /v1/role/bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/role/bycompany/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -269,10 +269,21 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('Worker has the workerTargetMinsPerWeek column (#400)', async () => {
         if (!connected) return;
         const rows = await db.Worker.findAll({
-            attributes: ['workerId', 'workerTargetMinsPerWeek', 'workerCostRate'],
+            attributes: ['workerId', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);
+    });
+
+    test('Role table exists with a company include + worker role link (#412)', async () => {
+        if (!connected) return;
+        const roles = await db.Role.findAll({ attributes: ['roleId', 'roleCompId', 'roleName', 'roleRate'], limit: 1 });
+        expect(Array.isArray(roles)).toBe(true);
+        const withRole = await db.Worker.findAll({
+            limit: 1,
+            include: [{ model: db.Role, as: 'role', required: false }],
+        });
+        expect(Array.isArray(withRole)).toBe(true);
     });
 
     test('/healthz reports a non-null migration name (dbo-qualified read)', async () => {

--- a/tests/unit/rate.test.js
+++ b/tests/unit/rate.test.js
@@ -57,6 +57,18 @@ describe('rate.resolveHourlyRate — precedence', () => {
         expect(rate.resolveHourlyRate(entry)).toBe(100);
     });
 
+    test('client rate wins over the role rate', () => {
+        expect(rate.resolveHourlyRate({ customer: { custDefaultRate: 175 }, worker: { role: { roleRate: 150 } } })).toBe(175);
+    });
+
+    test('role rate wins over the worker default', () => {
+        expect(rate.resolveHourlyRate({ worker: { role: { roleRate: 150 }, defaultBillingType: bt(100) } })).toBe(150);
+    });
+
+    test('falls through a null role rate to the worker default', () => {
+        expect(rate.resolveHourlyRate({ worker: { role: { roleRate: null }, defaultBillingType: bt(100) } })).toBe(100);
+    });
+
     test('falls through a null project flat rate to the worker default', () => {
         const entry = { billingType: null, job: { jobFlatRate: null }, worker: { defaultBillingType: bt(100) } };
         expect(rate.resolveHourlyRate(entry)).toBe(100);


### PR DESCRIPTION
## Summary

A rate that attaches to a role (e.g. "Senior Consultant = \$250/hr"), applied to any worker in that role.

Closes #412.

## Changes

- **Migration `20260616000000`** — a new company-scoped `Role` table (`roleName`, `roleRate`) + a `Worker.workerRoleId` link.
- **`rate.js`** — the role rate slots between the client rate and the worker's own default (first match wins):
  1. the entry's own `BillingType` (per-entry override)
  2. the **task** rate (#411)
  3. the **project** flat rate (#410)
  4. the **client** default rate (#413)
  5. the **role** rate ← new
  6. the **worker** default `BillingType`
- **Full REST** on `/v1/role` — `POST` (master keys pass `roleCompId`; non-master defaults to their own), `GET /bycompany/{id}` (paginated), `GET|PATCH|DELETE /{id}` — with **secure-404** on single reads. `workerRoleId` is settable on worker create/update.
- **No new eager-load sites** — the role rides the worker association that every billing path already loads (`worker.role`), so getById / roll-up / all four reports resolve it for free.

## Verification

`npm run lint` clean; `npm test` → **1163 passing** (client-vs-role-vs-worker precedence + null-fallthrough; role route auth + schema incl. non-positive rate; integration table/association checks for `Role` + `Worker.workerRoleId`). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/