### PR TITLE
feat(invoicing): recurring invoice schedules (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Recurring invoice schedules** (#425). A new customer-scoped
+  `RecurringInvoice` entity (cadence, next-run date, active flag),
+  migration `20260617000000`. Full REST on `/v1/recurringinvoice` (create,
+  `bycustomer` list, get/patch/delete) plus `GET /due` (active schedules
+  whose next run is ≤ today, company-scoped) and `POST /{id}/run` which
+  stamps `recinvLastRun` and advances `recinvNextRun` by the cadence via a
+  pure, unit-tested date helper (weekly/monthly/quarterly/yearly, with
+  end-of-month clamping). Secure-404 scoped; soft-delete via `recinvArch`.
+  Generating the invoice document itself reuses the roll-up (follow-up).
 - **Role-based rates** (#412). A new company-scoped `Role` entity
   (`roleName` + `roleRate`) and a `Worker.workerRoleId` link (migration
   `20260616000000`). The role rate slots into `rate.js` between the client

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -72,6 +72,7 @@ db.Task = require('../models/task.model.js')(sequelize, Sequelize);
 db.Retainer = require('../models/retainer.model.js')(sequelize, Sequelize);
 db.Phase = require('../models/phase.model.js')(sequelize, Sequelize);
 db.Role = require('../models/role.model.js')(sequelize, Sequelize);
+db.RecurringInvoice = require('../models/recurringinvoice.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -213,5 +214,9 @@ db.Company.hasMany(db.Role,  { foreignKey: 'roleCompId', as: 'roles' });
 db.Role.belongsTo(db.Company, { foreignKey: 'roleCompId', as: 'company' });
 db.Role.hasMany(db.Worker,   { foreignKey: 'workerRoleId', as: 'workers' });
 db.Worker.belongsTo(db.Role, { foreignKey: 'workerRoleId', as: 'role' });
+
+// RecurringInvoice → Customer (recinvCustId): a recurring billing schedule (#425).
+db.Customer.hasMany(db.RecurringInvoice,   { foreignKey: 'recinvCustId', as: 'recurringInvoices' });
+db.RecurringInvoice.belongsTo(db.Customer, { foreignKey: 'recinvCustId', as: 'customer' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,61 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/recurringinvoice': {
+            post: {
+                summary: 'Create a recurring invoice schedule',
+                security: [{ authKey: [] }],
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error or bad customer' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/recurringinvoice/due': {
+            get: {
+                summary: 'List schedules due for invoicing (next run ≤ today)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 400: { description: 'Master keys must specify companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/recurringinvoice/bycustomer/{id}': {
+            get: {
+                summary: "List a customer's schedules",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found (paginated)' }, 404: { description: 'Customer not found / cross-tenant' } },
+            },
+        },
+        '/v1/recurringinvoice/{id}/run': {
+            post: {
+                summary: 'Advance a schedule by its cadence',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Advanced (returns previousRun + nextRun)' }, 404: { description: 'Not found' }, 409: { description: 'Schedule is not active' } },
+            },
+        },
+        '/v1/recurringinvoice/{id}': {
+            get: {
+                summary: 'Fetch a schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a schedule (cadence / next run / active / note)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/role': {
             post: {
                 summary: 'Create a billing role (name + rate)',

--- a/app/controllers/recurringinvoicecontroller.js
+++ b/app/controllers/recurringinvoicecontroller.js
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { advanceDate } = require('../services/recurring-schedule.js');
+const RecurringInvoice = db.RecurringInvoice;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
+
+const ALLOWED_FIELDS_UPDATE = ['recinvCadence', 'recinvNextRun', 'recinvActive', 'recinvNote'];
+
+/** Today as 'YYYY-MM-DD' (UTC). */
+function todayISO() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+/** Load a schedule and enforce the secure-404 scope (through its customer's company). */
+async function findScoped(req, res) {
+    let sched;
+    try {
+        sched = await RecurringInvoice.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!sched || sched.recinvArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        let schedCompanyId;
+        try {
+            schedCompanyId = await GetCompanyIdByCustomerId(sched.recinvCustId);
+        } catch (error) {
+            log.error({ err: error }, 'recurringinvoice scope: company resolve failed');
+            res.status(500).json({ message: "Error!" });
+            return null;
+        }
+        if (companyId === -1 || schedCompanyId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return sched;
+}
+
+/**
+ * POST /v1/recurringinvoice — create a schedule for a customer. The
+ * customer's company must be the caller's (master keys may target any).
+ */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const recinvCustId = Number(body.recinvCustId);
+    if (!Number.isInteger(recinvCustId) || recinvCustId <= 0) {
+        return res.status(400).json({ message: "recinvCustId is required and must be an integer." });
+    }
+
+    let custCompanyId;
+    try {
+        custCompanyId = await GetCompanyIdByCustomerId(recinvCustId);
+    } catch (error) {
+        log.error({ err: error }, 'recurringinvoice create: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (custCompanyId === -1) {
+        return res.status(400).json({ message: "recinvCustId must reference a customer." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== custCompanyId) {
+            return res.status(403).json({ message: "Cannot schedule invoices for a customer in a company you do not belong to." });
+        }
+    }
+
+    const payload = {
+        recinvCustId,
+        recinvCadence: body.recinvCadence,
+        recinvNextRun: body.recinvNextRun,
+        recinvNote: body.recinvNote,
+        recinvActive: true,
+        recinvArch: false,
+    };
+    try {
+        const created = await RecurringInvoice.create(payload);
+        return res.status(201).json({ message: "Recurring invoice scheduled.", recurringInvoice: created });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/recurringinvoice/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+    return res.status(200).json({ message: "Found.", recurringInvoice: sched });
+};
+
+/** GET /v1/recurringinvoice/bycustomer/:id — a customer's schedules. Secure-404 scoped. */
+exports.listByCustomer = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const custId = Number(req.params.id);
+    if (!Number.isInteger(custId) || custId <= 0) {
+        return res.status(400).json({ message: "Invalid customer id." });
+    }
+
+    let custCompanyId;
+    try {
+        custCompanyId = await GetCompanyIdByCustomerId(custId);
+    } catch (error) {
+        log.error({ err: error }, 'recurringinvoice listByCustomer: company resolve failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (custCompanyId === -1) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== custCompanyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await RecurringInvoice.findAndCountAll({
+            where: { recinvCustId: custId },
+            limit,
+            offset,
+            order: [['recinvNextRun', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, recurringInvoices: rows });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * GET /v1/recurringinvoice/due — active schedules whose next run is on or
+ * before today, across the caller's company (master keys pass companyId).
+ */
+exports.listDue = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await RecurringInvoice.findAndCountAll({
+            where: { recinvActive: true, recinvNextRun: { [Op.lte]: todayISO() } },
+            include: [{
+                model: db.Customer, as: 'customer', required: true,
+                where: { custCompId: companyId },
+                attributes: ['custId', 'custCompId', 'custCompanyName'],
+            }],
+            limit,
+            offset,
+            order: [['recinvNextRun', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Recurring invoices due.", companyId, count, limit, offset, recurringInvoices: rows });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice due query failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** PATCH /v1/recurringinvoice/:id — partial update. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await sched.update(updates);
+        return res.status(200).json({ message: "Updated.", recurringInvoice: sched });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/recurringinvoice/:id/run — mark the schedule as fired: stamp
+ * recinvLastRun with the current due date and advance recinvNextRun by
+ * the cadence. 409 if the schedule is inactive. (Generating the invoice
+ * document itself reuses the roll-up and is a follow-up.)
+ */
+exports.run = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    if (!sched.recinvActive) {
+        return res.status(409).json({ message: "Schedule is not active." });
+    }
+
+    const previousRun = sched.recinvNextRun;
+    const nextRun = advanceDate(previousRun, sched.recinvCadence);
+    if (!nextRun) {
+        log.error({ recinvId: sched.recinvId, cadence: sched.recinvCadence }, 'advanceDate returned null');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    try {
+        await sched.update({ recinvLastRun: previousRun, recinvNextRun: nextRun });
+        return res.status(200).json({ message: "Schedule advanced.", previousRun, nextRun, recurringInvoice: sched });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice run failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/recurringinvoice/:id — soft-delete (sets recinvArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    try {
+        await sched.update({ recinvArch: true });
+        return res.status(200).json({ message: "Archived.", id: sched.recinvId });
+    } catch (error) {
+        log.error({ err: error }, 'RecurringInvoice archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260617000000-recurring-invoice.js
+++ b/app/migrations/20260617000000-recurring-invoice.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Recurring invoice schedules (#425). A RecurringInvoice records WHO to
+// bill (recinvCustId) on what CADENCE, and WHEN it next falls due
+// (recinvNextRun). Running it advances the schedule by its cadence and
+// stamps recinvLastRun. Scoped to a company through recinvCustId →
+// Customer. New table in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'RecurringInvoice', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    recinvId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    recinvCustId: { type: Sequelize.INTEGER, allowNull: false },
+                    recinvCadence: { type: Sequelize.TEXT, allowNull: false },
+                    recinvNextRun: { type: Sequelize.DATEONLY, allowNull: false },
+                    recinvLastRun: { type: Sequelize.DATEONLY, allowNull: true },
+                    recinvActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+                    recinvNote: { type: Sequelize.TEXT, allowNull: true },
+                    recinvArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'RecurringInvoice_custId_arch_idx', fields: ['recinvCustId', 'recinvArch'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'RecurringInvoice_due_idx', fields: ['recinvNextRun', 'recinvActive'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/recurringinvoice.model.js
+++ b/app/models/recurringinvoice.model.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * RecurringInvoice — a schedule that says "bill this customer every
+ * <cadence>, next due <recinvNextRun>" (#425). Running it advances
+ * recinvNextRun by the cadence and stamps recinvLastRun. Scope resolves
+ * through recinvCustId → Customer.custCompId. Soft-deletes via recinvArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const RecurringInvoice = sequelize.define('RecurringInvoice', {
+        recinvId: {
+            field: 'recinvId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        recinvCustId: {
+            field: 'recinvCustId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        recinvCadence: {
+            field: 'recinvCadence',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        recinvNextRun: {
+            field: 'recinvNextRun',
+            type: Sequelize.DATEONLY,
+            allowNull: false,
+        },
+        recinvLastRun: {
+            field: 'recinvLastRun',
+            type: Sequelize.DATEONLY,
+        },
+        recinvActive: {
+            field: 'recinvActive',
+            type: Sequelize.BOOLEAN,
+            defaultValue: true,
+        },
+        recinvNote: {
+            field: 'recinvNote',
+            type: Sequelize.TEXT,
+        },
+        recinvArch: {
+            field: 'recinvArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'RecurringInvoice',
+        timestamps: true,
+        defaultScope: { where: { recinvArch: false } }
+    });
+
+    return RecurringInvoice;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -34,6 +34,7 @@ const task = require('../controllers/taskcontroller.js');
 const retainer = require('../controllers/retainercontroller.js');
 const phase = require('../controllers/phasecontroller.js');
 const role = require('../controllers/rolecontroller.js');
+const recurringInvoice = require('../controllers/recurringinvoicecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -58,6 +59,7 @@ const taskSchemas = require('../schemas/task.schema.js');
 const retainerSchemas = require('../schemas/retainer.schema.js');
 const phaseSchemas = require('../schemas/phase.schema.js');
 const roleSchemas = require('../schemas/role.schema.js');
+const recurringInvoiceSchemas = require('../schemas/recurringinvoice.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -744,6 +746,46 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 recurring-invoice routes (billing schedules, #425).
+// GET /due is declared before GET /:id so "due" isn't parsed as an id.
+router.post(
+    '/v1/recurringinvoice',
+    v.body(recurringInvoiceSchemas.createRecurringInvoiceBody),
+    recurringInvoice.create,
+);
+router.get(
+    '/v1/recurringinvoice/due',
+    v.query(recurringInvoiceSchemas.dueQuery),
+    recurringInvoice.listDue,
+);
+router.get(
+    '/v1/recurringinvoice/bycustomer/:id',
+    v.params(recurringInvoiceSchemas.intIdParam),
+    v.query(recurringInvoiceSchemas.listByCustomerQuery),
+    recurringInvoice.listByCustomer,
+);
+router.post(
+    '/v1/recurringinvoice/:id/run',
+    v.params(recurringInvoiceSchemas.intIdParam),
+    recurringInvoice.run,
+);
+router.get(
+    '/v1/recurringinvoice/:id',
+    v.params(recurringInvoiceSchemas.intIdParam),
+    recurringInvoice.getById,
+);
+router.patch(
+    '/v1/recurringinvoice/:id',
+    v.params(recurringInvoiceSchemas.intIdParam),
+    v.body(recurringInvoiceSchemas.updateRecurringInvoiceBody),
+    recurringInvoice.update,
+);
+router.delete(
+    '/v1/recurringinvoice/:id',
+    v.params(recurringInvoiceSchemas.intIdParam),
+    recurringInvoice.remove,
 );
 
 // v1 role routes (role rate cards, #412).

--- a/app/schemas/recurringinvoice.schema.js
+++ b/app/schemas/recurringinvoice.schema.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+const { CADENCES } = require('../services/recurring-schedule.js');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+const cadence = z.enum(CADENCES);
+
+/** POST /v1/recurringinvoice body. */
+const createRecurringInvoiceBody = z.object({
+    recinvCustId: z.coerce.number().int().positive(),
+    recinvCadence: cadence,
+    recinvNextRun: isoDate,
+    recinvNote: z.string().max(10000).optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: recinvCustId, recinvCadence, recinvNextRun, recinvNote.',
+});
+
+/** PATCH /v1/recurringinvoice/:id — recinvCustId is not re-parentable. */
+const updateRecurringInvoiceBody = z.object({
+    recinvCadence: cadence.optional(),
+    recinvNextRun: isoDate.optional(),
+    recinvActive: z.boolean().optional(),
+    recinvNote: z.string().max(10000).nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: recinvCadence, recinvNextRun, recinvActive, recinvNote.',
+});
+
+const listByCustomerQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+/** GET /v1/recurringinvoice/due query. companyId required for master keys. */
+const dueQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createRecurringInvoiceBody,
+    updateRecurringInvoiceBody,
+    listByCustomerQuery,
+    dueQuery,
+};

--- a/app/services/recurring-schedule.js
+++ b/app/services/recurring-schedule.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * recurring-schedule.js — cadence date math for recurring invoices (#425).
+ *
+ * PURE: given a 'YYYY-MM-DD' date and a cadence, returns the next
+ * occurrence. Month-based cadences clamp the day to the target month's
+ * last day (Jan 31 + 1 month → Feb 28/29), so end-of-month schedules
+ * never skip a month. All arithmetic is in UTC to avoid TZ drift.
+ */
+
+const CADENCES = ['weekly', 'monthly', 'quarterly', 'yearly'];
+const MONTHS_FOR = { monthly: 1, quarterly: 3, yearly: 12 };
+
+/**
+ * @param {string} iso a 'YYYY-MM-DD' date.
+ * @param {string} cadence one of CADENCES.
+ * @returns {string|null} the next 'YYYY-MM-DD', or null on bad input.
+ */
+function advanceDate(iso, cadence) {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(iso || ''));
+    if (!m) return null;
+    const year = Number(m[1]);
+    const month = Number(m[2]) - 1; // 0-based
+    const day = Number(m[3]);
+
+    if (cadence === 'weekly') {
+        const d = new Date(Date.UTC(year, month, day + 7));
+        return d.toISOString().slice(0, 10);
+    }
+
+    const addMonths = MONTHS_FOR[cadence];
+    if (!addMonths) return null;
+
+    const total = month + addMonths;
+    const newYear = year + Math.floor(total / 12);
+    const newMonth = ((total % 12) + 12) % 12;
+    // Clamp to the last day of the target month.
+    const lastDay = new Date(Date.UTC(newYear, newMonth + 1, 0)).getUTCDate();
+    const newDay = Math.min(day, lastDay);
+    const d = new Date(Date.UTC(newYear, newMonth, newDay));
+    return d.toISOString().slice(0, 10);
+}
+
+module.exports = { advanceDate, CADENCES };

--- a/tests/api/recurringinvoice.test.js
+++ b/tests/api/recurringinvoice.test.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/recurringinvoice (#425) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, TimeEntry: {},
+    RecurringInvoice: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { recinvCustId: 1, recinvCadence: 'monthly', recinvNextRun: '2026-02-01' };
+
+describe('RecurringInvoice auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/recurringinvoice').send(good)).status).toBe(403);
+    });
+    test('POST 400 on missing recinvCadence (schema)', async () => {
+        expect((await request(app).post('/v1/recurringinvoice').set('authKey', 'k').send({ recinvCustId: 1, recinvNextRun: '2026-02-01' })).status).toBe(400);
+    });
+    test('POST 400 on an invalid cadence enum (schema)', async () => {
+        expect((await request(app).post('/v1/recurringinvoice').set('authKey', 'k').send({ ...good, recinvCadence: 'fortnightly' })).status).toBe(400);
+    });
+    test('POST 400 on a bad recinvNextRun date (schema)', async () => {
+        expect((await request(app).post('/v1/recurringinvoice').set('authKey', 'k').send({ ...good, recinvNextRun: 'soon' })).status).toBe(400);
+    });
+    test('GET /due 403 without authKey', async () => {
+        expect((await request(app).get('/v1/recurringinvoice/due')).status).toBe(403);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/recurringinvoice/1')).status).toBe(403);
+    });
+    test('POST /:id/run 403 without authKey', async () => {
+        expect((await request(app).post('/v1/recurringinvoice/1/run')).status).toBe(403);
+    });
+    test('GET /due does not collide with GET /:id (route ordering)', async () => {
+        // "due" must hit listDue (403 no-auth), NOT the :id param route (which
+        // would 400 on a non-integer id).
+        expect((await request(app).get('/v1/recurringinvoice/due')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('RecurringInvoice table exists with a customer include (#425)', async () => {
+        if (!connected) return;
+        const rows = await db.RecurringInvoice.findAll({
+            attributes: ['recinvId', 'recinvCustId', 'recinvCadence', 'recinvNextRun', 'recinvLastRun', 'recinvActive'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCustomer = await db.RecurringInvoice.findAll({
+            limit: 1,
+            include: [{ model: db.Customer, as: 'customer', required: false }],
+        });
+        expect(Array.isArray(withCustomer)).toBe(true);
+    });
+
     test('Retainer table exists with a customer include (#426)', async () => {
         if (!connected) return;
         const rows = await db.Retainer.findAll({

--- a/tests/unit/recurring-schedule.test.js
+++ b/tests/unit/recurring-schedule.test.js
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { advanceDate } from '../../app/services/recurring-schedule.js';
+
+describe('advanceDate (#425)', () => {
+    test('weekly adds 7 days', () => {
+        expect(advanceDate('2026-01-01', 'weekly')).toBe('2026-01-08');
+    });
+    test('monthly adds a month', () => {
+        expect(advanceDate('2026-01-15', 'monthly')).toBe('2026-02-15');
+    });
+    test('monthly clamps end-of-month (Jan 31 → Feb 28)', () => {
+        expect(advanceDate('2026-01-31', 'monthly')).toBe('2026-02-28');
+    });
+    test('quarterly adds 3 months', () => {
+        expect(advanceDate('2026-01-15', 'quarterly')).toBe('2026-04-15');
+    });
+    test('yearly rolls the year and handles Feb 29 → Feb 28', () => {
+        expect(advanceDate('2028-02-29', 'yearly')).toBe('2029-02-28');
+    });
+    test('monthly crossing a year boundary', () => {
+        expect(advanceDate('2026-12-10', 'monthly')).toBe('2027-01-10');
+    });
+    test('returns null on bad date or cadence', () => {
+        expect(advanceDate('nope', 'monthly')).toBeNull();
+        expect(advanceDate('2026-01-01', 'fortnightly')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Put a client on a billing cadence — know what's due, and roll the schedule forward when you invoice.

Closes #425.

## Changes

- **Migration `20260617000000`** — `RecurringInvoice` table (`recinvCustId`, `recinvCadence`, `recinvNextRun`, `recinvLastRun`, `recinvActive`, `recinvNote`, `recinvArch`) + a due-lookup index.
- **`recurring-schedule.js`** — a pure `advanceDate(iso, cadence)` helper: `weekly` (+7d), `monthly`/`quarterly`/`yearly` (+N months) with **end-of-month clamping** (Jan 31 → Feb 28) so month-end schedules never skip a month. UTC math, no TZ drift.
- **Full REST** on `/v1/recurringinvoice` — `POST`, `GET /bycustomer/{id}`, `GET|PATCH|DELETE /{id}` — customer→company scoped with **secure-404**.
- **`GET /due`** — active schedules whose next run is **≤ today**, across the caller's company (master keys pass `?companyId`).
- **`POST /{id}/run`** — stamps `recinvLastRun` and advances `recinvNextRun` by the cadence; **409** if the schedule is inactive.
- Route ordering: `/due` is declared before `/:id` so it isn't parsed as an id.

## Scope

This ships the **schedule + cadence engine**. Generating the invoice *document* on run reuses the existing time→invoice roll-up and is a focused follow-up.

## Verification

`npm run lint` clean; `npm test` → **1187 passing** (cadence math incl. end-of-month clamp, year boundary, leap-day; route auth + schema incl. cadence enum + date; route-ordering; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/