### PR TITLE
feat(auth): API-key rotation & lifecycle endpoints (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **API-key rotation & lifecycle** (#65). Master-only endpoints to manage
+  company credentials: `POST /v1/apikey` (provision), `POST
+  /v1/apikey/{id}/rotate` (replace the secret in place — the old key stops
+  working immediately), `DELETE /v1/apikey/{id}` (revoke), and
+  `GET /v1/apikey/{id}` + `GET /v1/apikey/bycompany/{id}` (metadata). The
+  raw key is generated server-side (256-bit) and returned **exactly once**
+  on create/rotate; only its SHA-256 hash is stored, and **no endpoint
+  ever returns the hash**. No migration — builds on the existing ApiKey
+  table + `auth.hashKey`.
 - **Recurring invoice schedules** (#425). A new customer-scoped
   `RecurringInvoice` entity (cadence, next-run date, active flag),
   migration `20260617000000`. Full REST on `/v1/recurringinvoice` (create,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,55 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/apikey': {
+            post: {
+                summary: 'Provision a new API key for a company (master only)',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Created — returns the raw key ONCE (only its hash is stored)' },
+                    400: { description: 'Validation error' },
+                    403: { description: 'Not a master key' },
+                },
+            },
+        },
+        '/v1/apikey/bycompany/{id}': {
+            get: {
+                summary: "List a company's API keys — metadata only (master only)",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated; never returns the key hash)' }, 403: { description: 'Not a master key' } },
+            },
+        },
+        '/v1/apikey/{id}/rotate': {
+            post: {
+                summary: 'Rotate a key in place — old key invalidated (master only)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: { description: 'Rotated — returns the new raw key ONCE' },
+                    403: { description: 'Not a master key' },
+                    404: { description: 'Not found' },
+                },
+            },
+        },
+        '/v1/apikey/{id}': {
+            get: {
+                summary: 'Fetch API key metadata (master only; never the hash)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 403: { description: 'Not a master key' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Revoke an API key (master only)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Revoked' }, 403: { description: 'Not a master key' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/recurringinvoice': {
             post: {
                 summary: 'Create a recurring invoice schedule',

--- a/app/controllers/apikeycontroller.js
+++ b/app/controllers/apikeycontroller.js
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+// API-key lifecycle (#65): provision, rotate, revoke, and list company
+// API keys. MASTER-ONLY — managing credentials is an admin operation.
+//
+// Only the SHA-256 hash of a key is ever stored (ApiKey.akKEY); the raw
+// key is generated server-side and returned exactly ONCE (on create /
+// rotate). It is never recoverable afterwards, and no endpoint ever
+// returns the stored hash.
+
+const crypto = require('crypto');
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const ApiKey = db.ApiKey;
+
+const IsMaster = auth.isMaster;
+const hashKey = auth.hashKey;
+
+// Metadata only — akKEY (the hash) is deliberately excluded.
+const SAFE_ATTRS = ['akId', 'akCompanyId', 'akArchive', 'akArchiveDate', 'createdAt', 'updatedAt'];
+
+/** A fresh 64-char hex API key (256 bits of entropy). */
+function generateRawKey() {
+    return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * Gate to master keys. Responds (403/500) and returns false when the
+ * caller is not an authenticated master key; returns true otherwise.
+ */
+async function requireMaster(req, res) {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        res.status(403).json({ message: "Authorization key not sent." });
+        return false;
+    }
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'apikey: IsMaster failed');
+        res.status(500).json({ message: "Error!" });
+        return false;
+    }
+    if (!isMaster) {
+        res.status(403).json({ message: "API-key management requires a master key." });
+        return false;
+    }
+    return true;
+}
+
+/** POST /v1/apikey — provision a new key for a company. Returns the raw key once. */
+exports.create = async (req, res) => {
+    if (!(await requireMaster(req, res))) return undefined;
+
+    const akCompanyId = Number((req.body || {}).akCompanyId);
+    if (!Number.isInteger(akCompanyId) || akCompanyId <= 0) {
+        return res.status(400).json({ message: "akCompanyId is required and must be an integer." });
+    }
+
+    const raw = generateRawKey();
+    try {
+        const created = await ApiKey.create({ akKEY: hashKey(raw), akCompanyId, akArchive: false });
+        return res.status(201).json({
+            message: "API key created. Store this key now — it will not be shown again.",
+            apiKey: raw,
+            akId: created.akId,
+            akCompanyId,
+        });
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/apikey/:id/rotate — replace a key's secret in place. The old
+ * key stops working immediately; the new raw key is returned once.
+ */
+exports.rotate = async (req, res) => {
+    if (!(await requireMaster(req, res))) return undefined;
+
+    let key;
+    try {
+        key = await ApiKey.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!key || key.akArchive) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const raw = generateRawKey();
+    try {
+        await key.update({ akKEY: hashKey(raw) });
+        return res.status(200).json({
+            message: "API key rotated. The previous key is now invalid. Store this key now — it will not be shown again.",
+            apiKey: raw,
+            akId: key.akId,
+            akCompanyId: key.akCompanyId,
+        });
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey rotate failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/apikey/:id — revoke a key (soft-delete; fails auth lookups thereafter). */
+exports.revoke = async (req, res) => {
+    if (!(await requireMaster(req, res))) return undefined;
+
+    let key;
+    try {
+        key = await ApiKey.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!key || key.akArchive) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    try {
+        await key.update({ akArchive: true, akArchiveDate: new Date() });
+        return res.status(200).json({ message: "API key revoked.", akId: key.akId });
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey revoke failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/apikey/:id — fetch key metadata (never the hash). */
+exports.getById = async (req, res) => {
+    if (!(await requireMaster(req, res))) return undefined;
+
+    let key;
+    try {
+        key = await ApiKey.findByPk(req.params.id, { attributes: SAFE_ATTRS });
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!key || key.akArchive) {
+        return res.status(404).json({ message: "Not found." });
+    }
+    return res.status(200).json({ message: "Found.", apiKey: key });
+};
+
+/** GET /v1/apikey/bycompany/:id — list a company's keys (metadata only, paginated). */
+exports.listByCompany = async (req, res) => {
+    if (!(await requireMaster(req, res))) return undefined;
+
+    const companyId = Number(req.params.id);
+    if (!Number.isInteger(companyId) || companyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await ApiKey.findAndCountAll({
+            where: { akCompanyId: companyId },
+            attributes: SAFE_ATTRS,
+            limit,
+            offset,
+            order: [['akId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, apiKeys: rows });
+    } catch (error) {
+        log.error({ err: error }, 'ApiKey.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+exports._internals = { generateRawKey };

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -35,6 +35,7 @@ const retainer = require('../controllers/retainercontroller.js');
 const phase = require('../controllers/phasecontroller.js');
 const role = require('../controllers/rolecontroller.js');
 const recurringInvoice = require('../controllers/recurringinvoicecontroller.js');
+const apikey = require('../controllers/apikeycontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -60,6 +61,7 @@ const retainerSchemas = require('../schemas/retainer.schema.js');
 const phaseSchemas = require('../schemas/phase.schema.js');
 const roleSchemas = require('../schemas/role.schema.js');
 const recurringInvoiceSchemas = require('../schemas/recurringinvoice.schema.js');
+const apiKeySchemas = require('../schemas/apikey.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -746,6 +748,34 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 api-key lifecycle routes (master-only; provision / rotate / revoke, #65).
+router.post(
+    '/v1/apikey',
+    v.body(apiKeySchemas.createApiKeyBody),
+    apikey.create,
+);
+router.get(
+    '/v1/apikey/bycompany/:id',
+    v.params(apiKeySchemas.intIdParam),
+    v.query(apiKeySchemas.listByCompanyQuery),
+    apikey.listByCompany,
+);
+router.post(
+    '/v1/apikey/:id/rotate',
+    v.params(apiKeySchemas.intIdParam),
+    apikey.rotate,
+);
+router.get(
+    '/v1/apikey/:id',
+    v.params(apiKeySchemas.intIdParam),
+    apikey.getById,
+);
+router.delete(
+    '/v1/apikey/:id',
+    v.params(apiKeySchemas.intIdParam),
+    apikey.revoke,
 );
 
 // v1 recurring-invoice routes (billing schedules, #425).

--- a/app/schemas/apikey.schema.js
+++ b/app/schemas/apikey.schema.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/apikey body — provision a key for a company. */
+const createApiKeyBody = z.object({
+    akCompanyId: z.coerce.number().int().positive(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: akCompanyId.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createApiKeyBody,
+    listByCompanyQuery,
+};

--- a/tests/api/apikey.test.js
+++ b/tests/api/apikey.test.js
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/apikey (#65) — master-only gate, schema,
+// and the "raw key returned once, hash never exposed" guarantee.
+
+import { describe, test, expect, vi, beforeAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mocks = vi.hoisted(() => ({
+    apiMasterFindOne: vi.fn().mockResolvedValue(null), // default: caller is NOT a master
+    apiKeyCreate: vi.fn().mockResolvedValue({ akId: 5 }),
+}));
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, TimeEntry: {},
+    ApiMaster: { findOne: mocks.apiMasterFindOne },
+    ApiKey: {
+        create: mocks.apiKeyCreate,
+        findOne: vi.fn().mockResolvedValue(null),
+        findByPk: vi.fn().mockResolvedValue(null),
+        findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }),
+    },
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+beforeEach(() => {
+    mocks.apiMasterFindOne.mockResolvedValue(null);
+});
+
+describe('API-key lifecycle contract (#65)', () => {
+    test('POST /v1/apikey 403 without authKey', async () => {
+        expect((await request(app).post('/v1/apikey').send({ akCompanyId: 1 })).status).toBe(403);
+    });
+    test('POST /v1/apikey 403 with a non-master key', async () => {
+        expect((await request(app).post('/v1/apikey').set('authKey', 'scoped').send({ akCompanyId: 1 })).status).toBe(403);
+    });
+    test('POST /v1/apikey 400 on missing akCompanyId (schema)', async () => {
+        expect((await request(app).post('/v1/apikey').set('authKey', 'k').send({})).status).toBe(400);
+    });
+    test('POST /v1/apikey/:id/rotate 403 with a non-master key', async () => {
+        expect((await request(app).post('/v1/apikey/1/rotate').set('authKey', 'scoped')).status).toBe(403);
+    });
+    test('DELETE /v1/apikey/:id 403 with a non-master key', async () => {
+        expect((await request(app).delete('/v1/apikey/1').set('authKey', 'scoped')).status).toBe(403);
+    });
+    test('GET /v1/apikey/:id 403 with a non-master key', async () => {
+        expect((await request(app).get('/v1/apikey/1').set('authKey', 'scoped')).status).toBe(403);
+    });
+    test('GET /v1/apikey/bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/apikey/bycompany/1')).status).toBe(403);
+    });
+});

--- a/tests/unit/apikey-generate.test.js
+++ b/tests/unit/apikey-generate.test.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit test for the raw-key generator (#65). No DB — pulls the internal
+// helper off the controller's _internals export.
+
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    ApiKey: {}, ApiMaster: {}, Sequelize: {},
+}));
+
+const { _internals } = await import('../../app/controllers/apikeycontroller.js');
+const auth = await import('../../app/middleware/auth.js');
+
+describe('generateRawKey (#65)', () => {
+    test('produces a 64-char lowercase hex string (256 bits)', () => {
+        const key = _internals.generateRawKey();
+        expect(key).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test('is unpredictable — successive keys differ', () => {
+        const a = _internals.generateRawKey();
+        const b = _internals.generateRawKey();
+        expect(a).not.toBe(b);
+    });
+
+    test('what gets stored is the HASH of the key, never the raw key itself', () => {
+        // This is the security invariant of create/rotate: akKEY = hashKey(raw).
+        const raw = _internals.generateRawKey();
+        const stored = auth.hashKey(raw);
+        expect(stored).toMatch(/^[0-9a-f]{64}$/);
+        expect(stored).not.toBe(raw);
+        // Deterministic: the same raw always hashes the same (so lookups match).
+        expect(auth.hashKey(raw)).toBe(stored);
+    });
+});


### PR DESCRIPTION
## Summary

Manage API credentials over their lifetime — provision, rotate, and revoke — instead of only ever seeding them by hand in the DB.

Closes #65.

## Endpoints (master key only)

- **`POST /v1/apikey`** — provision a new key for a company.
- **`POST /v1/apikey/{id}/rotate`** — replace a key's secret **in place**; the old key stops authenticating immediately.
- **`DELETE /v1/apikey/{id}`** — revoke (soft-delete `akArchive`; the `defaultScope` then hides it from every auth lookup).
- **`GET /v1/apikey/{id}`** and **`GET /v1/apikey/bycompany/{id}`** — metadata only.

## Security properties

- **Master-only.** Every endpoint 403s a non-master key — credential management is an admin operation.
- **Hash-at-rest, shown once.** The raw key is generated server-side (`crypto.randomBytes(32)` → 256 bits) and returned **exactly once** on create/rotate. Only its **SHA-256 hash** is stored (`ApiKey.akKEY`, via the same `auth.hashKey` the auth path uses), and **no endpoint ever returns the hash** — reads are restricted to a safe attribute set.
- **No migration, no change to the auth flow** — purely additive on the existing `ApiKey` table.

## Verification

`npm run lint` clean; `npm test` → **1202 passing** (raw-key generation is 64-hex + unpredictable + stored-as-hash-not-raw; every route master-gated + schema-validated). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/