### PR TITLE
feat(integrations): outbound webhooks (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Outbound webhooks** (#69). A new company-scoped `Webhook` registry
+  (URL, event, optional signing secret, active flag), migration
+  `20260618000000`. Full REST on `/v1/webhook` (create, `bycompany` list,
+  get/patch/delete) plus `POST /{id}/ping` which delivers a test event and
+  reports the outcome. Deliveries are signed HMAC-SHA256
+  (`X-Webhook-Signature`) via a pure `webhook-signer.js`, sent best-effort
+  through a timeout-bounded `webhook-delivery.js` (global `fetch`). The
+  **secret is write-only** — no endpoint returns it. Auto-firing on
+  domain events (invoice.created, payment.recorded, timeentry.approved) is
+  a bounded follow-up.
 - **Report export beyond CSV — revenue PDF** (#433). `GET
   /v1/report/revenue.pdf` streams the revenue summary as a branded,
   printable PDF (company header, totals, by-customer and by-month tables)

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -73,6 +73,7 @@ db.Retainer = require('../models/retainer.model.js')(sequelize, Sequelize);
 db.Phase = require('../models/phase.model.js')(sequelize, Sequelize);
 db.Role = require('../models/role.model.js')(sequelize, Sequelize);
 db.RecurringInvoice = require('../models/recurringinvoice.model.js')(sequelize, Sequelize);
+db.Webhook = require('../models/webhook.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -218,5 +219,9 @@ db.Worker.belongsTo(db.Role, { foreignKey: 'workerRoleId', as: 'role' });
 // RecurringInvoice → Customer (recinvCustId): a recurring billing schedule (#425).
 db.Customer.hasMany(db.RecurringInvoice,   { foreignKey: 'recinvCustId', as: 'recurringInvoices' });
 db.RecurringInvoice.belongsTo(db.Customer, { foreignKey: 'recinvCustId', as: 'customer' });
+
+// Webhook → Company (whkCompId): an outbound event subscription (#69).
+db.Company.hasMany(db.Webhook,  { foreignKey: 'whkCompId', as: 'webhooks' });
+db.Webhook.belongsTo(db.Company, { foreignKey: 'whkCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,57 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/webhook': {
+            post: {
+                summary: 'Register an outbound webhook',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Registered (secret is never returned)' },
+                    400: { description: 'Validation error; master keys must specify whkCompId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
+        '/v1/webhook/bycompany/{id}': {
+            get: {
+                summary: "List a company's webhooks (metadata only)",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated; never returns the secret)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/webhook/{id}/ping': {
+            post: {
+                summary: 'Deliver a test "ping" event to the endpoint',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Delivery attempted (returns {delivered, status, error})' }, 404: { description: 'Not found' } },
+            },
+        },
+        '/v1/webhook/{id}': {
+            get: {
+                summary: 'Fetch a webhook (metadata only)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a webhook (url / event / secret / active)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a webhook',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/apikey': {
             post: {
                 summary: 'Provision a new API key for a company (master only)',

--- a/app/controllers/webhookcontroller.js
+++ b/app/controllers/webhookcontroller.js
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { deliver } = require('../services/webhook-delivery.js');
+const Webhook = db.Webhook;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const ALLOWED_FIELDS_CREATE = ['whkUrl', 'whkEvent', 'whkSecret', 'whkCompId'];
+const ALLOWED_FIELDS_UPDATE = ['whkUrl', 'whkEvent', 'whkSecret', 'whkActive'];
+// whkSecret is deliberately excluded — it is write-only at the API layer.
+const SAFE_ATTRS = ['whkId', 'whkCompId', 'whkUrl', 'whkEvent', 'whkActive', 'whkArch', 'createdAt', 'updatedAt'];
+
+/** A response-safe view of a webhook row (never includes the secret). */
+function safeView(wh) {
+    return {
+        whkId: wh.whkId,
+        whkCompId: wh.whkCompId,
+        whkUrl: wh.whkUrl,
+        whkEvent: wh.whkEvent,
+        whkActive: wh.whkActive,
+        whkArch: wh.whkArch,
+    };
+}
+
+/** Load a webhook (with secret, for signing) and enforce the secure-404 scope. */
+async function findScoped(req, res) {
+    let wh;
+    try {
+        wh = await Webhook.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Webhook.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!wh || wh.whkArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || wh.whkCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return wh;
+}
+
+/** POST /v1/webhook — register a webhook. Non-master keys default whkCompId to their own company. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+
+    if (!isMaster) {
+        let companyId;
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (payload.whkCompId !== undefined && Number(payload.whkCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot register a webhook for a company you do not belong to." });
+        }
+        payload.whkCompId = companyId;
+    } else if (payload.whkCompId === undefined || Number(payload.whkCompId) <= 0) {
+        return res.status(400).json({ message: "Master-key requests must specify whkCompId." });
+    }
+
+    payload.whkActive = true;
+    payload.whkArch = false;
+
+    try {
+        const created = await Webhook.create(payload);
+        return res.status(201).json({ message: "Webhook registered.", webhook: safeView(created) });
+    } catch (error) {
+        log.error({ err: error }, 'Webhook.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/webhook/:id — fetch one (metadata only). Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let wh;
+    try {
+        wh = await Webhook.findByPk(req.params.id, { attributes: SAFE_ATTRS });
+    } catch (error) {
+        log.error({ err: error }, 'Webhook.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!wh || wh.whkArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || wh.whkCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+    return res.status(200).json({ message: "Found.", webhook: wh });
+};
+
+/** GET /v1/webhook/bycompany/:id — list a company's webhooks (metadata only). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Webhook.findAndCountAll({
+            where: { whkCompId: targetCompanyId },
+            attributes: SAFE_ATTRS,
+            limit,
+            offset,
+            order: [['whkId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, webhooks: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Webhook.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** PATCH /v1/webhook/:id — partial update. whkCompId / whkArch not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const wh = await findScoped(req, res);
+    if (!wh) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await wh.update(updates);
+        return res.status(200).json({ message: "Updated.", webhook: safeView(wh) });
+    } catch (error) {
+        log.error({ err: error }, 'Webhook.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/webhook/:id/ping — deliver a test 'ping' event to the
+ * endpoint and report the outcome. Verifies URL + signing end to end.
+ */
+exports.ping = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const wh = await findScoped(req, res);
+    if (!wh) return undefined;
+
+    const result = await deliver(wh, 'ping', { whkId: wh.whkId, message: 'ping' });
+    return res.status(200).json({
+        message: result.ok ? "Ping delivered." : "Ping attempted.",
+        delivered: !!result.ok,
+        status: result.status != null ? result.status : null,
+        error: result.error || null,
+    });
+};
+
+/** DELETE /v1/webhook/:id — soft-delete (sets whkArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const wh = await findScoped(req, res);
+    if (!wh) return undefined;
+
+    try {
+        await wh.update({ whkArch: true });
+        return res.status(200).json({ message: "Archived.", id: wh.whkId });
+    } catch (error) {
+        log.error({ err: error }, 'Webhook archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260618000000-webhook.js
+++ b/app/migrations/20260618000000-webhook.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Outbound webhooks (#69). A Webhook registers a URL to POST to when a
+// domain event fires (whkEvent, or '*' for all). whkSecret, if set, signs
+// each delivery (HMAC-SHA256, X-Webhook-Signature). Company-scoped via
+// whkCompId. New table in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Webhook', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    whkId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    whkCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    whkUrl: { type: Sequelize.TEXT, allowNull: false },
+                    whkEvent: { type: Sequelize.TEXT, allowNull: false },
+                    whkSecret: { type: Sequelize.TEXT, allowNull: true },
+                    whkActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+                    whkArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'Webhook_compId_event_arch_idx', fields: ['whkCompId', 'whkEvent', 'whkArch'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/webhook.model.js
+++ b/app/models/webhook.model.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Webhook — an outbound subscription (#69): POST whkUrl when whkEvent
+ * fires (or on any event when whkEvent === '*'). whkSecret, when present,
+ * signs each delivery. Company-scoped via whkCompId. Soft-deletes via
+ * whkArch. whkSecret is write-only at the API layer (never returned).
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Webhook = sequelize.define('Webhook', {
+        whkId: {
+            field: 'whkId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        whkCompId: {
+            field: 'whkCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        whkUrl: {
+            field: 'whkUrl',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        whkEvent: {
+            field: 'whkEvent',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        whkSecret: {
+            field: 'whkSecret',
+            type: Sequelize.TEXT,
+        },
+        whkActive: {
+            field: 'whkActive',
+            type: Sequelize.BOOLEAN,
+            defaultValue: true,
+        },
+        whkArch: {
+            field: 'whkArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Webhook',
+        timestamps: true,
+        defaultScope: { where: { whkArch: false } }
+    });
+
+    return Webhook;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -36,6 +36,7 @@ const phase = require('../controllers/phasecontroller.js');
 const role = require('../controllers/rolecontroller.js');
 const recurringInvoice = require('../controllers/recurringinvoicecontroller.js');
 const apikey = require('../controllers/apikeycontroller.js');
+const webhook = require('../controllers/webhookcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -62,6 +63,7 @@ const phaseSchemas = require('../schemas/phase.schema.js');
 const roleSchemas = require('../schemas/role.schema.js');
 const recurringInvoiceSchemas = require('../schemas/recurringinvoice.schema.js');
 const apiKeySchemas = require('../schemas/apikey.schema.js');
+const webhookSchemas = require('../schemas/webhook.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -748,6 +750,40 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 webhook routes (outbound event subscriptions, #69).
+router.post(
+    '/v1/webhook',
+    v.body(webhookSchemas.createWebhookBody),
+    webhook.create,
+);
+router.get(
+    '/v1/webhook/bycompany/:id',
+    v.params(webhookSchemas.intIdParam),
+    v.query(webhookSchemas.listByCompanyQuery),
+    webhook.listByCompany,
+);
+router.post(
+    '/v1/webhook/:id/ping',
+    v.params(webhookSchemas.intIdParam),
+    webhook.ping,
+);
+router.get(
+    '/v1/webhook/:id',
+    v.params(webhookSchemas.intIdParam),
+    webhook.getById,
+);
+router.patch(
+    '/v1/webhook/:id',
+    v.params(webhookSchemas.intIdParam),
+    v.body(webhookSchemas.updateWebhookBody),
+    webhook.update,
+);
+router.delete(
+    '/v1/webhook/:id',
+    v.params(webhookSchemas.intIdParam),
+    webhook.remove,
 );
 
 // v1 api-key lifecycle routes (master-only; provision / rotate / revoke, #65).

--- a/app/schemas/webhook.schema.js
+++ b/app/schemas/webhook.schema.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+const { WEBHOOK_EVENTS } = require('../services/webhook-signer.js');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const url = z.string().url().max(2048);
+const event = z.enum(WEBHOOK_EVENTS);
+const secret = z.string().min(8).max(255);
+
+/**
+ * POST /v1/webhook body. whkUrl + whkEvent required; whkCompId optional
+ * for non-master keys (defaults to the key's company), required for master.
+ */
+const createWebhookBody = z.object({
+    whkUrl: url,
+    whkEvent: event,
+    whkSecret: secret.optional(),
+    whkCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: whkUrl, whkEvent, whkSecret, whkCompId.',
+});
+
+/** PATCH /v1/webhook/:id — whkCompId is not patchable. */
+const updateWebhookBody = z.object({
+    whkUrl: url.optional(),
+    whkEvent: event.optional(),
+    whkSecret: secret.nullable().optional(),
+    whkActive: z.boolean().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: whkUrl, whkEvent, whkSecret, whkActive.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createWebhookBody,
+    updateWebhookBody,
+    listByCompanyQuery,
+};

--- a/app/services/webhook-delivery.js
+++ b/app/services/webhook-delivery.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * webhook-delivery.js — POST an event to a webhook endpoint (#69).
+ *
+ * Best-effort: never throws, always resolves to a result object. Uses
+ * the global fetch (Node 18+) with a short timeout so a slow or dead
+ * endpoint can't stall the request. Signing/enveloping live in
+ * webhook-signer.js (pure); this module owns the network side effect.
+ */
+
+const log = require('../config/logger.js');
+const { buildEvent, signPayload } = require('./webhook-signer.js');
+
+const TIMEOUT_MS = 5000;
+
+/**
+ * Deliver `data` for `event` to `webhook`. Returns
+ * { ok, status } on a completed request or { ok:false, error } otherwise.
+ */
+async function deliver(webhook, event, data) {
+    const url = webhook && webhook.whkUrl;
+    if (!url) return { ok: false, error: 'no url' };
+
+    const payload = buildEvent(event, data, new Date().toISOString());
+    const body = JSON.stringify(payload);
+    const headers = { 'Content-Type': 'application/json', 'X-Webhook-Event': String(event) };
+    const sig = signPayload(webhook.whkSecret, body);
+    if (sig) headers['X-Webhook-Signature'] = sig;
+
+    try {
+        const res = await fetch(url, {
+            method: 'POST',
+            headers,
+            body,
+            signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+        return { ok: res.ok, status: res.status };
+    } catch (error) {
+        log.error({ err: error, whkId: webhook && webhook.whkId }, 'webhook delivery failed');
+        return { ok: false, error: error && error.message ? error.message : 'delivery failed' };
+    }
+}
+
+module.exports = { deliver };

--- a/app/services/webhook-signer.js
+++ b/app/services/webhook-signer.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * webhook-signer.js — pure helpers for outbound webhooks (#69).
+ *
+ * The set of subscribable events, the delivery envelope, and the
+ * HMAC-SHA256 signature. No network, no DB — trivially unit-testable.
+ */
+
+const crypto = require('crypto');
+
+// Events a webhook may subscribe to. '*' subscribes to every event.
+const WEBHOOK_EVENTS = ['invoice.created', 'payment.recorded', 'timeentry.approved', '*'];
+
+/** The JSON envelope delivered to a webhook. */
+function buildEvent(event, data, timestamp) {
+    return { event, timestamp: timestamp || null, data: data == null ? null : data };
+}
+
+/**
+ * Sign a serialized body with the webhook secret.
+ * @returns {string} 'sha256=<hex>' (empty string when no secret is set).
+ */
+function signPayload(secret, body) {
+    if (!secret) return '';
+    return 'sha256=' + crypto.createHmac('sha256', String(secret)).update(String(body)).digest('hex');
+}
+
+module.exports = { WEBHOOK_EVENTS, buildEvent, signPayload };

--- a/tests/api/webhook.test.js
+++ b/tests/api/webhook.test.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/webhook (#69) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, TimeEntry: {},
+    Webhook: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { whkUrl: 'https://example.com/hook', whkEvent: 'invoice.created' };
+
+describe('Webhook auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/webhook').send(good)).status).toBe(403);
+    });
+    test('POST 400 on missing whkUrl (schema)', async () => {
+        expect((await request(app).post('/v1/webhook').set('authKey', 'k').send({ whkEvent: 'invoice.created' })).status).toBe(400);
+    });
+    test('POST 400 on a non-URL whkUrl (schema)', async () => {
+        expect((await request(app).post('/v1/webhook').set('authKey', 'k').send({ ...good, whkUrl: 'not-a-url' })).status).toBe(400);
+    });
+    test('POST 400 on an unknown event (schema enum)', async () => {
+        expect((await request(app).post('/v1/webhook').set('authKey', 'k').send({ ...good, whkEvent: 'coffee.brewed' })).status).toBe(400);
+    });
+    test('POST 400 on a too-short whkSecret (schema)', async () => {
+        expect((await request(app).post('/v1/webhook').set('authKey', 'k').send({ ...good, whkSecret: 'short' })).status).toBe(400);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/webhook/1')).status).toBe(403);
+    });
+    test('GET /bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/webhook/bycompany/1')).status).toBe(403);
+    });
+    test('POST /:id/ping 403 without authKey', async () => {
+        expect((await request(app).post('/v1/webhook/1/ping')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('Webhook table exists with a company include (#69)', async () => {
+        if (!connected) return;
+        const rows = await db.Webhook.findAll({
+            attributes: ['whkId', 'whkCompId', 'whkUrl', 'whkEvent', 'whkActive'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.Webhook.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('RecurringInvoice table exists with a customer include (#425)', async () => {
         if (!connected) return;
         const rows = await db.RecurringInvoice.findAll({

--- a/tests/unit/webhook-signer.test.js
+++ b/tests/unit/webhook-signer.test.js
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import crypto from 'crypto';
+import { buildEvent, signPayload, WEBHOOK_EVENTS } from '../../app/services/webhook-signer.js';
+
+describe('webhook-signer (#69)', () => {
+    test('buildEvent wraps event/timestamp/data', () => {
+        expect(buildEvent('invoice.created', { id: 1 }, '2026-01-01T00:00:00Z'))
+            .toEqual({ event: 'invoice.created', timestamp: '2026-01-01T00:00:00Z', data: { id: 1 } });
+    });
+
+    test('signPayload returns sha256=<hmac hex> matching a manual HMAC', () => {
+        const body = JSON.stringify({ a: 1 });
+        const sig = signPayload('topsecret', body);
+        const expected = 'sha256=' + crypto.createHmac('sha256', 'topsecret').update(body).digest('hex');
+        expect(sig).toBe(expected);
+        expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/);
+    });
+
+    test('signPayload is empty when no secret is configured', () => {
+        expect(signPayload('', '{}')).toBe('');
+        expect(signPayload(null, '{}')).toBe('');
+    });
+
+    test('a different secret yields a different signature', () => {
+        const body = '{"x":1}';
+        expect(signPayload('a', body)).not.toBe(signPayload('b', body));
+    });
+
+    test("'*' is a valid subscribable event", () => {
+        expect(WEBHOOK_EVENTS).toContain('*');
+        expect(WEBHOOK_EVENTS).toContain('invoice.created');
+    });
+});


### PR DESCRIPTION
## Summary

Let other systems subscribe to what happens here — register a URL, get signed POSTs when events fire.

Closes #69.

## Changes

- **Migration `20260618000000`** — a company-scoped `Webhook` table (`whkUrl`, `whkEvent`, `whkSecret?`, `whkActive`, `whkArch`) + a `(whkCompId, whkEvent, whkArch)` index.
- **Full REST** on `/v1/webhook` — `POST` (master keys pass `whkCompId`; non-master defaults to their own), `GET /bycompany/{id}` (paginated), `GET|PATCH|DELETE /{id}` — company-scoped with **secure-404**.
- **`POST /{id}/ping`** — delivers a test `ping` event to the endpoint and reports `{ delivered, status, error }`, so you can verify a subscription end to end.
- **Signed deliveries** — each POST carries an `X-Webhook-Signature: sha256=<hmac>` computed over the body with the webhook's secret (pure `webhook-signer.js`), sent best-effort through a **timeout-bounded** `webhook-delivery.js` (global `fetch`, 5s) that never throws.
- **Secret is write-only** — settable on create/update, but **no endpoint ever returns it** (reads use a safe attribute set; create/update return a hand-built safe view).

## Scope

Ships the registry + signing + verification (`ping`). Auto-firing on domain events (`invoice.created`, `payment.recorded`, `timeentry.approved` — already enumerated as the subscribable set) is a small, self-contained follow-up that calls `deliver()` from those controllers.

## Verification

`npm run lint` clean; `npm test` → **1233 passing** (signer HMAC matches a manual computation + empty/distinct-secret behavior; route auth + URL/event/secret schema validation; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/