### PR TITLE
feat(integrations): email / notification service (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Email / notification service** (#68). A transport-abstracted mailer
+  (`mailer.js`) — the foundation approval/payment reminders and scheduled
+  report delivery build on: features call `sendMail({to, subject, text})`
+  and stay decoupled from the transport. The default is a **no-network
+  capture transport** (validates + records; dev/CI/unconfigured-prod
+  safe), with `setTransport()` to drop in a real SMTP adapter behind the
+  same interface (a config follow-up that adds no coupling and no
+  dependency here). Master-only `POST /v1/notification/test` verifies
+  delivery and reports the active transport. No migration.
 - **Outbound webhooks** (#69). A new company-scoped `Webhook` registry
   (URL, event, optional signing secret, active flag), migration
   `20260618000000`. Full REST on `/v1/webhook` (create, `bycompany` list,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1426,6 +1426,18 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/notification/test': {
+            post: {
+                summary: 'Send a test email to verify the mail transport (master only)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { to: { type: 'string', format: 'email' }, subject: { type: 'string' }, text: { type: 'string' } }, required: ['to'] } } } },
+                responses: {
+                    200: { description: 'Sent (or captured) — returns the active transport name' },
+                    400: { description: 'Invalid recipient / body' },
+                    403: { description: 'Not a master key' },
+                },
+            },
+        },
         '/v1/webhook': {
             post: {
                 summary: 'Register an outbound webhook',

--- a/app/controllers/notificationcontroller.js
+++ b/app/controllers/notificationcontroller.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { sendMail, currentTransport } = require('../services/mailer.js');
+
+const IsMaster = auth.isMaster;
+
+/**
+ * POST /v1/notification/test — send a test email to verify the mail
+ * transport end to end. MASTER-ONLY (transport config is an admin op).
+ * With the default capture transport, nothing is actually sent — the
+ * response reports which transport handled it.
+ */
+exports.test = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'notification: IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!isMaster) {
+        return res.status(403).json({ message: "Notification management requires a master key." });
+    }
+
+    const body = req.body || {};
+    try {
+        await sendMail({
+            to: body.to,
+            subject: body.subject || 'TimeTrackerAPI test notification',
+            text: body.text || 'This is a test notification from TimeTrackerAPI.',
+        });
+        return res.status(200).json({ message: "Test notification sent.", to: body.to, transport: currentTransport() });
+    } catch (error) {
+        if (error && error.code === 'EMAIL_INVALID') {
+            // Defensive: the schema already validates `to`. Return a fixed
+            // message — never echo the raw error (see controller-error-shape).
+            return res.status(400).json({ message: "Invalid recipient." });
+        }
+        log.error({ err: error }, 'notification test send failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -37,6 +37,7 @@ const role = require('../controllers/rolecontroller.js');
 const recurringInvoice = require('../controllers/recurringinvoicecontroller.js');
 const apikey = require('../controllers/apikeycontroller.js');
 const webhook = require('../controllers/webhookcontroller.js');
+const notification = require('../controllers/notificationcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -64,6 +65,7 @@ const roleSchemas = require('../schemas/role.schema.js');
 const recurringInvoiceSchemas = require('../schemas/recurringinvoice.schema.js');
 const apiKeySchemas = require('../schemas/apikey.schema.js');
 const webhookSchemas = require('../schemas/webhook.schema.js');
+const notificationSchemas = require('../schemas/notification.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -750,6 +752,13 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 notification route (email service test send, master-only, #68).
+router.post(
+    '/v1/notification/test',
+    v.body(notificationSchemas.testNotificationBody),
+    notification.test,
 );
 
 // v1 webhook routes (outbound event subscriptions, #69).

--- a/app/schemas/notification.schema.js
+++ b/app/schemas/notification.schema.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+/** POST /v1/notification/test body — send a test email to verify delivery. */
+const testNotificationBody = z.object({
+    to: z.string().email(),
+    subject: z.string().min(1).max(255).optional(),
+    text: z.string().max(10000).optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: to, subject, text.',
+});
+
+module.exports = {
+    testNotificationBody,
+};

--- a/app/services/mailer.js
+++ b/app/services/mailer.js
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * mailer.js — the email/notification service (#68). Foundational for
+ * approval/payment reminders and scheduled report delivery: those
+ * features call `sendMail(...)` and stay decoupled from the transport.
+ *
+ * Transport is pluggable. The DEFAULT is a no-network "capture" transport
+ * that validates + records messages (dev/CI/unconfigured-prod safe —
+ * nothing is actually emailed). A real SMTP transport drops in behind the
+ * same `send(message)` interface via `setTransport()` (e.g. a thin
+ * nodemailer adapter wired from SMTP_* env vars — a config follow-up that
+ * adds no coupling here).
+ */
+
+const log = require('../config/logger.js');
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+const MAX_CAPTURED = 100;
+const captured = [];
+
+/** No-network transport: records the message so it can be inspected/tested. */
+function captureTransport() {
+    return {
+        name: 'capture',
+        async send(message) {
+            captured.push({ to: message.to, subject: message.subject, at: new Date().toISOString() });
+            if (captured.length > MAX_CAPTURED) captured.shift();
+            log.info({ to: message.to, subject: message.subject }, 'email captured (no SMTP transport configured)');
+            return { accepted: [message.to], transport: 'capture' };
+        },
+    };
+}
+
+let _transport = captureTransport();
+
+/** Swap the transport (e.g. an SMTP adapter). Passing null restores capture. */
+function setTransport(t) {
+    _transport = (t && typeof t.send === 'function') ? t : captureTransport();
+}
+
+/** Name of the active transport (for diagnostics / the test endpoint). */
+function currentTransport() {
+    return _transport && _transport.name ? _transport.name : 'unknown';
+}
+
+function validate(message) {
+    if (!message || typeof message !== 'object') return 'message is required';
+    if (!message.to || !EMAIL_RE.test(String(message.to))) return 'a valid "to" address is required';
+    if (!message.subject) return 'subject is required';
+    return null;
+}
+
+/**
+ * Send (or capture) an email. Rejects with an Error whose `code` is
+ * 'EMAIL_INVALID' on a bad message, so callers can map it to a 400.
+ * @param message { to, subject, text?, html?, from? }
+ */
+async function sendMail(message) {
+    const err = validate(message);
+    if (err) {
+        const e = new Error(err);
+        e.code = 'EMAIL_INVALID';
+        throw e;
+    }
+    const from = message.from || process.env.SMTP_FROM || 'no-reply@timetracker.local';
+    return _transport.send({
+        from,
+        to: message.to,
+        subject: message.subject,
+        text: message.text || '',
+        html: message.html,
+    });
+}
+
+// Test seam — recent captured messages (newest last).
+function _captured() {
+    return captured.slice();
+}
+
+module.exports = { sendMail, setTransport, currentTransport, _captured };

--- a/tests/api/notification.test.js
+++ b/tests/api/notification.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for POST /v1/notification/test (#68) — master-gate + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {},
+    ApiKey: {}, ApiMaster: { findOne: vi.fn().mockResolvedValue(null) }, // caller is not a master
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('POST /v1/notification/test contract', () => {
+    test('403 without authKey', async () => {
+        expect((await request(app).post('/v1/notification/test').send({ to: 'a@b.com' })).status).toBe(403);
+    });
+    test('403 with a non-master key', async () => {
+        expect((await request(app).post('/v1/notification/test').set('authKey', 'scoped').send({ to: 'a@b.com' })).status).toBe(403);
+    });
+    test('400 on a missing recipient (schema)', async () => {
+        expect((await request(app).post('/v1/notification/test').set('authKey', 'k').send({ subject: 'hi' })).status).toBe(400);
+    });
+    test('400 on an invalid email (schema)', async () => {
+        expect((await request(app).post('/v1/notification/test').set('authKey', 'k').send({ to: 'not-an-email' })).status).toBe(400);
+    });
+});

--- a/tests/unit/mailer.test.js
+++ b/tests/unit/mailer.test.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect, beforeEach } from 'vitest';
+import { sendMail, setTransport, currentTransport, _captured } from '../../app/services/mailer.js';
+
+describe('mailer (#68)', () => {
+    beforeEach(() => setTransport(null)); // restore the capture default
+
+    test('defaults to the no-network capture transport', () => {
+        expect(currentTransport()).toBe('capture');
+    });
+
+    test('sendMail captures a valid message (no network)', async () => {
+        const before = _captured().length;
+        const res = await sendMail({ to: 'a@b.com', subject: 'Hi', text: 'yo' });
+        expect(res.transport).toBe('capture');
+        const cap = _captured();
+        expect(cap.length).toBe(before + 1);
+        expect(cap[cap.length - 1]).toMatchObject({ to: 'a@b.com', subject: 'Hi' });
+    });
+
+    test('rejects an invalid recipient with code EMAIL_INVALID', async () => {
+        await expect(sendMail({ to: 'nope', subject: 'x' })).rejects.toMatchObject({ code: 'EMAIL_INVALID' });
+    });
+
+    test('rejects a missing subject', async () => {
+        await expect(sendMail({ to: 'a@b.com' })).rejects.toMatchObject({ code: 'EMAIL_INVALID' });
+    });
+
+    test('setTransport swaps the transport and sendMail uses it', async () => {
+        const seen = [];
+        setTransport({ name: 'stub', async send(m) { seen.push(m); return { ok: true }; } });
+        expect(currentTransport()).toBe('stub');
+        await sendMail({ to: 'a@b.com', subject: 'S', text: 'T', from: 'me@x.com' });
+        expect(seen).toHaveLength(1);
+        expect(seen[0]).toMatchObject({ to: 'a@b.com', subject: 'S', text: 'T', from: 'me@x.com' });
+    });
+});


### PR DESCRIPTION
## Summary

The notification foundation the reminder features build on — a mail service other code calls, decoupled from how mail actually leaves the box.

Closes #68.

## Changes

- **`mailer.js`** — a transport-abstracted email service. Features call `sendMail({ to, subject, text })` and never touch the transport.
  - **Default: a no-network "capture" transport** that validates and records messages. Safe in dev, CI, and unconfigured production — nothing is actually emailed, so there's no way to accidentally spam or leak.
  - **`setTransport()`** drops a real SMTP adapter in behind the same `send(message)` interface.
- **`POST /v1/notification/test`** (master only) — sends a test message and reports which transport handled it, so you can verify delivery end to end.

## Why no SMTP library in this PR

A mailer dependency (nodemailer) currently ships **high-severity advisories** in the versions I could vet, and adding it would trigger the Snyk manifest scan. Rather than take that on blind, this PR lands the **service + interface** (which is what unblocks #442 / #10 / #57) with **zero new dependencies and no manifest change**. Wiring a concrete SMTP transport is then a small, isolated `setTransport()` config change once a vetted library + real SMTP credentials are in place.

## Verification

`npm run lint` clean; `npm test` → **1248 passing** (capture-transport default, recipient/subject validation, transport-swap; route master-gate + schema; the `controller-error-shape` policy test passes — no raw error is echoed). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/