### PR TITLE
feat(approvals): approval reminders via email (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Approval reminders** (#442). `POST /v1/timeentry/approval-reminders`
+  finds time entries stuck in `submitted` past a threshold
+  (`olderThanDays`, default 7) and emails an approver (`to`) a digest —
+  wiring the approval workflow (#440) to the mail service (#68). Pure
+  `approval-reminders.js` builds the subject/body; delivery goes through
+  `mailer.sendMail` (captured, not sent, until a real SMTP transport is
+  configured). Company-scoped (master keys pass `companyId`). No migration.
 - **Email / notification service** (#68). A transport-abstracted mailer
   (`mailer.js`) — the foundation approval/payment reminders and scheduled
   report delivery build on: features call `sendMail({to, subject, text})`

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -836,6 +836,18 @@ const spec = {
                 },
             },
         },
+        '/v1/timeentry/approval-reminders': {
+            post: {
+                summary: 'Email a digest of stale pending approvals (#442)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { to: { type: 'string', format: 'email' }, olderThanDays: { type: 'integer' }, companyId: { type: 'integer' } }, required: ['to'] } } } },
+                responses: {
+                    200: { description: 'Digest sent (or nothing pending) — {pending, reminded, to}' },
+                    400: { description: 'Master keys must specify companyId / invalid body' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/timeentry/{id}/copy': {
             post: {
                 summary: 'Copy a time entry into a fresh entry',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -10,6 +10,8 @@ const { escapeCsvCell } = require('./_csv-escape.js');
 const rate = require('../services/rate.js');
 const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
+const { buildApprovalDigest } = require('../services/approval-reminders.js');
+const { sendMail } = require('../services/mailer.js');
 const TimeEntry = db.TimeEntry;
 
 // Auth helpers used to live inline here — they now share a single
@@ -494,6 +496,74 @@ exports.copy = async (req, res) => {
         log.error({ err: error }, 'copy: TimeEntry.create failed');
         return res.status(500).json({ message: "Error!" });
     }
+};
+
+/**
+ * POST /v1/timeentry/approval-reminders — email a digest of time entries
+ * stuck in "submitted" past a threshold to an approver (#442). Bridges
+ * the approval workflow (#440) to the mail service (#68). Company-scoped
+ * (master keys pass companyId); the recipient is the request's `to`.
+ */
+exports.approvalReminders = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(body.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const olderThanDays = Number.isInteger(body.olderThanDays) && body.olderThanDays > 0 ? body.olderThanDays : 7;
+    const cutoffDate = new Date();
+    cutoffDate.setUTCDate(cutoffDate.getUTCDate() - olderThanDays);
+    const cutoff = cutoffDate.toISOString().slice(0, 10);
+    const Op = db.Sequelize && db.Sequelize.Op;
+
+    let entries;
+    try {
+        const where = { teCompId: companyId, teApprovalStatus: 'submitted' };
+        if (Op) where.teStartedAt = { [Op.lte]: cutoff };
+        entries = await db.TimeEntry.findAll({
+            where,
+            attributes: ['teId', 'teStartedAt', 'teMinutes', 'teWorkerId', 'teApprovalStatus'],
+            include: [{ model: db.Worker, as: 'worker', required: false, attributes: ['workerId', 'workerFName', 'workerLName'] }],
+            order: [['teStartedAt', 'ASC']],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'approval reminders: TimeEntry.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const digest = buildApprovalDigest(entries, { olderThanDays });
+    let reminded = false;
+    if (digest.count > 0) {
+        try {
+            await sendMail({ to: body.to, subject: digest.subject, text: digest.text });
+            reminded = true;
+        } catch (error) {
+            log.error({ err: error }, 'approval reminders: sendMail failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+    }
+    return res.status(200).json({
+        message: reminded ? "Approval reminder sent." : "No pending approvals over the threshold.",
+        companyId,
+        pending: digest.count,
+        reminded,
+        to: body.to,
+    });
 };
 
 /**

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -196,6 +196,12 @@ router.post(
     v.body(timeEntrySchemas.copyTimeEntryBody),
     timeEntry.copy,
 );
+// Approval reminders (#442): email a digest of stale pending approvals.
+router.post(
+    '/v1/timeentry/approval-reminders',
+    v.body(timeEntrySchemas.approvalRemindersBody),
+    timeEntry.approvalReminders,
+);
 // Literal paths declared BEFORE /:id so express doesn't try to
 // parse "export.csv" / "bycompany" as a customer id.
 router.get(

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -126,6 +126,19 @@ const copyTimeEntryBody = z.object({
     { message: 'teEndedAt must be at or after teStartedAt.', path: ['teEndedAt'] },
 );
 
+/**
+ * POST /v1/timeentry/approval-reminders body (#442). `to` is the approver
+ * to email; olderThanDays bounds staleness; companyId is required for
+ * master keys.
+ */
+const approvalRemindersBody = z.object({
+    to: z.string().email(),
+    olderThanDays: z.coerce.number().int().positive().max(3650).optional(),
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: to, olderThanDays, companyId.',
+});
+
 const listByCompanyQuery = z.object({
     customerId: z.coerce.number().int().positive().optional(),
     tag: z.string().min(1).max(64).optional(),
@@ -165,6 +178,7 @@ module.exports = {
     startTimerBody,
     approvalBody,
     copyTimeEntryBody,
+    approvalRemindersBody,
     listByCompanyQuery,
     exportCsvQuery,
 };

--- a/app/services/approval-reminders.js
+++ b/app/services/approval-reminders.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * approval-reminders.js — build a digest email for time entries stuck in
+ * the "submitted" (awaiting approval) state (#442). Pure: the caller
+ * loads the stale submitted entries (with their worker) and this shapes
+ * the subject + body. No DB, no mail transport.
+ */
+
+/**
+ * @param entries submitted time entries with { teId, teStartedAt,
+ *   teMinutes, worker: { workerFName, workerLName } }.
+ * @param opts { olderThanDays? } — informational, for the message text.
+ * @returns { count, totalMinutes, entries: [...], subject, text }.
+ */
+function buildApprovalDigest(entries, opts = {}) {
+    const rows = (entries || []).map((e) => ({
+        teId: e.teId,
+        worker: e.worker
+            ? ([e.worker.workerFName, e.worker.workerLName].filter(Boolean).join(' ') || null)
+            : null,
+        date: e.teStartedAt ? String(e.teStartedAt).slice(0, 10) : null,
+        minutes: e.teMinutes == null ? null : Number(e.teMinutes),
+    }));
+
+    const count = rows.length;
+    const totalMinutes = rows.reduce((s, r) => s + (Number(r.minutes) || 0), 0);
+    const olderThanDays = Number.isInteger(opts.olderThanDays) && opts.olderThanDays > 0 ? opts.olderThanDays : null;
+
+    const subject = count === 1
+        ? '1 time entry awaiting approval'
+        : `${count} time entries awaiting approval`;
+
+    const header = 'The following time entries have been awaiting approval'
+        + (olderThanDays ? ` for more than ${olderThanDays} day(s)` : '') + ':';
+    const lines = rows.map((r) => (
+        `- #${r.teId}  ${r.worker || 'Unknown worker'}  ${r.date || '(no date)'}  `
+        + (r.minutes == null ? '(in progress)' : `${r.minutes} min`)
+    ));
+    const text = `${header}\n\n${lines.join('\n')}\n\n`
+        + `Total: ${count} ${count === 1 ? 'entry' : 'entries'}, ${totalMinutes} minutes.`;
+
+    return { count, totalMinutes, entries: rows, subject, text };
+}
+
+module.exports = { buildApprovalDigest };

--- a/tests/api/timeentry-approval-reminders.test.js
+++ b/tests/api/timeentry-approval-reminders.test.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for POST /v1/timeentry/approval-reminders (#442).
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {},
+    TimeEntry: { findAll: vi.fn().mockResolvedValue([]) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('POST /v1/timeentry/approval-reminders contract', () => {
+    test('403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/timeentry/approval-reminders').send({ to: 'boss@co.com' })).status).toBe(403);
+    });
+    test('400 on a missing recipient (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/approval-reminders').set('authKey', 'k').send({ olderThanDays: 7 })).status).toBe(400);
+    });
+    test('400 on an invalid email (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/approval-reminders').set('authKey', 'k').send({ to: 'nope' })).status).toBe(400);
+    });
+    test('400 on an unknown field (strict schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/approval-reminders').set('authKey', 'k').send({ to: 'a@b.com', bogus: 1 })).status).toBe(400);
+    });
+});

--- a/tests/unit/approval-reminders.test.js
+++ b/tests/unit/approval-reminders.test.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildApprovalDigest } from '../../app/services/approval-reminders.js';
+
+describe('buildApprovalDigest (#442)', () => {
+    test('summarizes submitted entries with count, total, and lines', () => {
+        const d = buildApprovalDigest([
+            { teId: 7, teStartedAt: '2026-01-05T09:00:00Z', teMinutes: 120, worker: { workerFName: 'Ada', workerLName: 'Lovelace' } },
+            { teId: 8, teStartedAt: '2026-01-06T09:00:00Z', teMinutes: 60, worker: { workerFName: 'Bo', workerLName: null } },
+        ], { olderThanDays: 7 });
+        expect(d.count).toBe(2);
+        expect(d.totalMinutes).toBe(180);
+        expect(d.subject).toBe('2 time entries awaiting approval');
+        expect(d.text).toContain('#7  Ada Lovelace  2026-01-05  120 min');
+        expect(d.text).toContain('more than 7 day(s)');
+        expect(d.text).toContain('Total: 2 entries, 180 minutes.');
+    });
+
+    test('singular subject for exactly one entry', () => {
+        const d = buildApprovalDigest([{ teId: 1, teStartedAt: '2026-01-01', teMinutes: 30, worker: null }]);
+        expect(d.subject).toBe('1 time entry awaiting approval');
+        expect(d.text).toContain('Unknown worker');
+    });
+
+    test('handles an in-progress entry (null minutes) and empty input', () => {
+        expect(buildApprovalDigest([{ teId: 2, teStartedAt: '2026-01-01', teMinutes: null, worker: null }]).text).toContain('(in progress)');
+        const empty = buildApprovalDigest([]);
+        expect(empty.count).toBe(0);
+        expect(empty.subject).toBe('0 time entries awaiting approval');
+    });
+});


### PR DESCRIPTION
## Summary

Nudge the approver about timesheets that have been sitting in "submitted" too long — the first feature to actually use the mail service.

Closes #442.

## Changes

- **`POST /v1/timeentry/approval-reminders`** `{ to, olderThanDays?, companyId? }` — finds time entries stuck in **`submitted`** with a start date past the threshold (default **7 days**), builds a digest (count, total minutes, per-entry `#id · worker · date · minutes`), and emails it to **`to`**.
- **`approval-reminders.js`** — a pure digest builder (subject + body), unit-tested independently of DB and transport.
- Delivery goes through **`mailer.sendMail`** (#68) — so with the default capture transport nothing is actually sent yet; wiring a real SMTP transport lights it up with no code change here.
- Company-scoped: master keys pass `companyId`, scoped keys use their own.

## The chain this completes

Approval workflow (#440, `submitted` state) → this reminder → mail service (#68). The same `mailer` now has its first real consumer, validating the foundation.

## Verification

`npm run lint` clean; `npm test` → **1258 passing** (digest builder: count/total, singular vs plural, in-progress + empty; route auth + recipient/email/strict schema; the `controller-error-shape` policy test passes). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/