### PR TITLE
feat(payments): payment reminders / dunning via email (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Payment reminders / dunning** (#10). `POST
+  /v1/invoice/payment-reminders` finds invoices that are overdue (past
+  their due date, or invoice date when none, shifted by `olderThanDays`)
+  **and** carry a balance outstanding (`total − collected`, exact-cent),
+  and emails a dunning digest to `to` — the AR companion to the approval
+  reminders (#442), on the same mail service (#68). Pure
+  `payment-reminders.js` builds the digest; company-scoped (master keys
+  pass `companyId`). No migration.
 - **Approval reminders** (#442). `POST /v1/timeentry/approval-reminders`
   finds time entries stuck in `submitted` past a threshold
   (`olderThanDays`, default 7) and emails an approver (`to`) a digest —

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1333,6 +1333,18 @@ const spec = {
                 },
             },
         },
+        '/v1/invoice/payment-reminders': {
+            post: {
+                summary: 'Email a dunning digest of overdue invoices (#10)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { to: { type: 'string', format: 'email' }, olderThanDays: { type: 'integer' }, companyId: { type: 'integer' } }, required: ['to'] } } } },
+                responses: {
+                    200: { description: 'Digest sent (or none overdue) — {overdue, totalOutstanding, reminded, to}' },
+                    400: { description: 'Master keys must specify companyId / invalid body' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/invoice/rollup': {
             post: {
                 summary: "Generate an invoice from a customer's billable time",

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -15,6 +15,8 @@ const { renderInvoicePdf } = require('../services/invoice-pdf.js');
 const { buildAging } = require('../services/invoice-aging.js');
 const invoiceTax = require('../services/invoice-tax.js');
 const { buildExpenseRollup } = require('../services/expense-rollup.js');
+const { buildDunningDigest } = require('../services/payment-reminders.js');
+const { sendMail } = require('../services/mailer.js');
 const Invoice = db.Invoice;
 
 /** Today as an ISO date (YYYY-MM-DD), UTC. */
@@ -648,6 +650,87 @@ exports.pdf = async (req, res) => {
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="invoice-${safeName}.pdf"`);
     return res.status(200).send(pdf);
+};
+
+/**
+ * POST /v1/invoice/payment-reminders — email a dunning digest of overdue
+ * invoices with a balance outstanding to `to` (#10). Company-scoped
+ * (master keys pass companyId). Bridges AR to the mail service (#68).
+ */
+exports.paymentReminders = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(body.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const olderThanDays = Number.isInteger(body.olderThanDays) && body.olderThanDays >= 0 ? body.olderThanDays : 0;
+
+    let invoices;
+    try {
+        invoices = await db.Invoice.findAll({
+            where: { invArch: false },
+            include: [
+                {
+                    model: db.Customer, as: 'customer', required: true,
+                    where: { custCompId: companyId },
+                    attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
+                },
+                { model: db.CustomerPayment, as: 'payments', required: false },
+            ],
+            order: [['invDueDate', 'ASC']],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'payment reminders: Invoice.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const items = invoices.map((inv) => {
+        const c = inv.customer;
+        return {
+            invId: inv.invId,
+            invNumber: inv.invNumber || null,
+            custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
+            date: inv.invDate ? String(inv.invDate).slice(0, 10) : null,
+            dueDate: inv.invDueDate ? String(inv.invDueDate).slice(0, 10) : null,
+            total: inv.invTotal,
+            collected: money.sum((inv.payments || []).map((p) => p.cpayAmount)),
+        };
+    });
+
+    const digest = buildDunningDigest(items, { today: todayISO(), olderThanDays });
+    let reminded = false;
+    if (digest.count > 0) {
+        try {
+            await sendMail({ to: body.to, subject: digest.subject, text: digest.text });
+            reminded = true;
+        } catch (error) {
+            log.error({ err: error }, 'payment reminders: sendMail failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+    }
+    return res.status(200).json({
+        message: reminded ? "Payment reminder sent." : "No overdue invoices over the threshold.",
+        companyId,
+        overdue: digest.count,
+        totalOutstanding: digest.totalOutstanding,
+        reminded,
+        to: body.to,
+    });
 };
 
 exports.bulkCreate = makeBulkCreateIndirect({

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -424,6 +424,12 @@ router.post(
     v.body(invoiceSchemas.rollupInvoiceBody),
     invoice.rollup,
 );
+// Payment reminders / dunning (#10): email a digest of overdue invoices.
+router.post(
+    '/v1/invoice/payment-reminders',
+    v.body(invoiceSchemas.paymentRemindersBody),
+    invoice.paymentReminders,
+);
 router.get(
     '/v1/invoice/aging',
     v.query(invoiceSchemas.agingQuery),

--- a/app/schemas/invoice.schema.js
+++ b/app/schemas/invoice.schema.js
@@ -121,8 +121,18 @@ const pdfQuery = z.object({
     message: 'Unexpected query parameter. Allowed: format.',
 });
 
+/** POST /v1/invoice/payment-reminders body (#10). */
+const paymentRemindersBody = z.object({
+    to: z.string().email(),
+    olderThanDays: z.coerce.number().int().nonnegative().max(3650).optional(),
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: to, olderThanDays, companyId.',
+});
+
 module.exports = {
     intIdParam,
+    paymentRemindersBody,
     createInvoiceBody,
     updateInvoiceBody,
     listByCustomerQuery,

--- a/app/services/payment-reminders.js
+++ b/app/services/payment-reminders.js
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * payment-reminders.js — build a dunning digest of overdue invoices with
+ * a balance outstanding (#10). An invoice counts when its reference date
+ * (due date, else invoice date) is at least `olderThanDays` days in the
+ * past AND total − collected > 0. Pure: the caller loads invoices with
+ * their payment totals and passes `today`; exact money via money.js.
+ */
+
+const money = require('./money.js');
+
+/** ISO date `days` before `iso` (YYYY-MM-DD), UTC. */
+function minusDays(iso, days) {
+    if (!iso) return null;
+    const d = new Date(iso + 'T00:00:00.000Z');
+    if (Number.isNaN(d.getTime())) return null;
+    d.setUTCDate(d.getUTCDate() - days);
+    return d.toISOString().slice(0, 10);
+}
+
+/**
+ * @param invoices [{ invId, invNumber, custName, date, dueDate, total, collected }]
+ * @param opts { today: 'YYYY-MM-DD', olderThanDays?: number }
+ * @returns { count, totalOutstanding, invoices: [...], subject, text }
+ */
+function buildDunningDigest(invoices, opts = {}) {
+    const today = opts.today || null;
+    const olderThanDays = Number.isInteger(opts.olderThanDays) && opts.olderThanDays >= 0 ? opts.olderThanDays : 0;
+    const cutoff = olderThanDays > 0 ? minusDays(today, olderThanDays) : today;
+
+    const rows = [];
+    for (const inv of invoices || []) {
+        const total = inv.total == null ? 0 : Number(inv.total);
+        const collected = inv.collected == null ? 0 : Number(inv.collected);
+        const outstanding = money.subtract(total, collected);
+        if (outstanding <= 0) continue;
+        const refDate = inv.dueDate || inv.date || null;
+        // Overdue when the reference date is strictly before the cutoff.
+        if (!refDate || !cutoff || refDate >= cutoff) continue;
+        rows.push({
+            invId: inv.invId,
+            invNumber: inv.invNumber || null,
+            custName: inv.custName || null,
+            date: inv.date || null,
+            dueDate: inv.dueDate || null,
+            total,
+            collected,
+            outstanding,
+        });
+    }
+    rows.sort((a, b) => b.outstanding - a.outstanding);
+
+    const count = rows.length;
+    const totalOutstanding = money.sum(rows.map((r) => r.outstanding));
+    const subject = count === 1 ? '1 overdue invoice' : `${count} overdue invoices`;
+    const lines = rows.map((r) => (
+        `- ${r.invNumber || '#' + r.invId}  ${r.custName || 'Unknown'}  `
+        + `due ${r.dueDate || r.date || '?'}  outstanding ${money.toFixedString(r.outstanding)}`
+    ));
+    const text = 'The following invoices are overdue with a balance outstanding:\n\n'
+        + `${lines.join('\n')}\n\n`
+        + `Total outstanding: ${money.toFixedString(totalOutstanding)} across ${count} ${count === 1 ? 'invoice' : 'invoices'}.`;
+
+    return { count, totalOutstanding, invoices: rows, subject, text };
+}
+
+module.exports = { buildDunningDigest };

--- a/tests/api/invoice-payment-reminders.test.js
+++ b/tests/api/invoice-payment-reminders.test.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for POST /v1/invoice/payment-reminders (#10).
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {},
+    Invoice: { findAll: vi.fn().mockResolvedValue([]) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('POST /v1/invoice/payment-reminders contract', () => {
+    test('403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/invoice/payment-reminders').send({ to: 'ap@client.com' })).status).toBe(403);
+    });
+    test('400 on a missing recipient (schema)', async () => {
+        expect((await request(app).post('/v1/invoice/payment-reminders').set('authKey', 'k').send({ olderThanDays: 30 })).status).toBe(400);
+    });
+    test('400 on an invalid email (schema)', async () => {
+        expect((await request(app).post('/v1/invoice/payment-reminders').set('authKey', 'k').send({ to: 'nope' })).status).toBe(400);
+    });
+    test('400 on an unknown field (strict schema)', async () => {
+        expect((await request(app).post('/v1/invoice/payment-reminders').set('authKey', 'k').send({ to: 'a@b.com', bogus: 1 })).status).toBe(400);
+    });
+});

--- a/tests/unit/payment-reminders.test.js
+++ b/tests/unit/payment-reminders.test.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildDunningDigest } from '../../app/services/payment-reminders.js';
+
+const TODAY = '2026-03-01';
+
+describe('buildDunningDigest (#10)', () => {
+    test('includes overdue invoices with an outstanding balance', () => {
+        const d = buildDunningDigest([
+            { invId: 1, invNumber: 'INV-001', custName: 'Globex', dueDate: '2026-02-01', total: 1000, collected: 400 },
+            { invId: 2, invNumber: 'INV-002', custName: 'Initech', dueDate: '2026-02-10', total: 500, collected: 0 },
+        ], { today: TODAY });
+        expect(d.count).toBe(2);
+        expect(d.totalOutstanding).toBe(1100); // 600 + 500
+        expect(d.subject).toBe('2 overdue invoices');
+        // Sorted by outstanding desc: 600 (INV-001) first.
+        expect(d.invoices[0].invNumber).toBe('INV-001');
+        expect(d.text).toContain('outstanding 600.00');
+        expect(d.text).toContain('Total outstanding: 1100.00');
+    });
+
+    test('excludes fully-paid invoices (outstanding 0)', () => {
+        const d = buildDunningDigest([
+            { invId: 1, dueDate: '2026-02-01', total: 1000, collected: 1000 },
+        ], { today: TODAY });
+        expect(d.count).toBe(0);
+    });
+
+    test('excludes not-yet-due invoices', () => {
+        const d = buildDunningDigest([
+            { invId: 1, dueDate: '2026-04-01', total: 1000, collected: 0 },
+        ], { today: TODAY });
+        expect(d.count).toBe(0);
+    });
+
+    test('olderThanDays shifts the cutoff (grace period)', () => {
+        const invs = [{ invId: 1, dueDate: '2026-02-25', total: 100, collected: 0 }]; // 4 days overdue
+        expect(buildDunningDigest(invs, { today: TODAY, olderThanDays: 0 }).count).toBe(1);
+        expect(buildDunningDigest(invs, { today: TODAY, olderThanDays: 30 }).count).toBe(0); // within 30-day grace
+    });
+
+    test('falls back to invoice date when no due date', () => {
+        const d = buildDunningDigest([
+            { invId: 1, date: '2026-01-01', total: 200, collected: 0 },
+        ], { today: TODAY });
+        expect(d.count).toBe(1);
+        expect(d.subject).toBe('1 overdue invoice');
+    });
+});


### PR DESCRIPTION
## Summary

Chase overdue invoices automatically — a digest of who owes what, emailed to whoever handles collections.

Closes #10.

## Changes

- **`POST /v1/invoice/payment-reminders`** `{ to, olderThanDays?, companyId? }` — finds invoices that are **overdue** (reference date = due date, or invoice date when there's no due date, at least `olderThanDays` in the past — default `0` = past due) **and** carry a **balance outstanding** (`invTotal − Σ payments`, exact-cent via `money.js`), then emails a dunning digest to `to` (biggest balance first, with a total).
- **`payment-reminders.js`** — a pure digest builder, unit-tested independently of DB and transport (`today` is injected, so no clock dependency in tests).
- Delivery via **`mailer.sendMail`** (#68) — captured until a real SMTP transport is configured. Company-scoped (master keys pass `companyId`).

## The pair this completes

Approval reminders (#442) nudge *internal* approvers; this nudges *clients* who owe money. Both ride the same mail service, proving the notification foundation across two domains.

## Verification

`npm run lint` clean; `npm test` → **1270 passing** (dunning builder: overdue-with-balance, paid + not-yet-due exclusions, `olderThanDays` grace, invoice-date fallback; route auth + recipient/email/strict schema; the `controller-error-shape` policy test passes). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/