### PR TITLE
feat(billing-rates): rate effective-dating (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Rate effective-dating** (#414). A new company-scoped `RateSchedule`
+  entity (`rschRate` over `rschEffectiveFrom`..`rschEffectiveTo`, the
+  latter open-ended when null), migration `20260620000000`. Full REST on
+  `/v1/rateschedule` (create, `bycompany` list, get/patch/delete) plus
+  `GET /v1/rateschedule/resolve?date=` which returns the rate in effect on
+  that date via a pure `rate-schedule.js` resolver (latest applicable
+  `effectiveFrom` wins). Lands the model + a queryable resolver; wiring
+  date-aware selection into `rate.js`'s live billing resolution is a
+  follow-up (keeps the well-tested resolver untouched).
 - **Milestone billing** (#428). `POST /v1/invoice/from-phase` generates
   an invoice for a project phase's fixed budget (`phaseBudgetAmount`) as a
   single line on the phase's job — reusing the roll-up's numbering, tax,

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -74,6 +74,7 @@ db.Phase = require('../models/phase.model.js')(sequelize, Sequelize);
 db.Role = require('../models/role.model.js')(sequelize, Sequelize);
 db.RecurringInvoice = require('../models/recurringinvoice.model.js')(sequelize, Sequelize);
 db.Webhook = require('../models/webhook.model.js')(sequelize, Sequelize);
+db.RateSchedule = require('../models/rateschedule.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -223,5 +224,9 @@ db.RecurringInvoice.belongsTo(db.Customer, { foreignKey: 'recinvCustId', as: 'cu
 // Webhook → Company (whkCompId): an outbound event subscription (#69).
 db.Company.hasMany(db.Webhook,  { foreignKey: 'whkCompId', as: 'webhooks' });
 db.Webhook.belongsTo(db.Company, { foreignKey: 'whkCompId', as: 'company' });
+
+// RateSchedule → Company (rschCompId): effective-dated rates (#414).
+db.Company.hasMany(db.RateSchedule,   { foreignKey: 'rschCompId', as: 'rateSchedules' });
+db.RateSchedule.belongsTo(db.Company, { foreignKey: 'rschCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1463,6 +1463,56 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/rateschedule': {
+            post: {
+                summary: 'Create an effective-dated rate (#414)',
+                security: [{ authKey: [] }],
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error; master keys must specify rschCompId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/rateschedule/resolve': {
+            get: {
+                summary: 'Resolve the effective rate on a given date',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'date', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                ],
+                responses: { 200: { description: 'Effective rate — {companyId, date, rate}' }, 400: { description: 'Missing date / companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/rateschedule/bycompany/{id}': {
+            get: {
+                summary: "List a company's rate schedules",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/rateschedule/{id}': {
+            get: {
+                summary: 'Fetch a rate schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a rate schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a rate schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/notification/test': {
             post: {
                 summary: 'Send a test email to verify the mail transport (master only)',

--- a/app/controllers/rateschedulecontroller.js
+++ b/app/controllers/rateschedulecontroller.js
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { rateOnDate } = require('../services/rate-schedule.js');
+const RateSchedule = db.RateSchedule;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const ALLOWED_FIELDS_CREATE = ['rschName', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo', 'rschCompId'];
+const ALLOWED_FIELDS_UPDATE = ['rschName', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo'];
+
+/** Load a schedule and enforce the secure-404 company scope. */
+async function findScoped(req, res) {
+    let rs;
+    try {
+        rs = await RateSchedule.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!rs || rs.rschArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || rs.rschCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return rs;
+}
+
+/** POST /v1/rateschedule — create a dated rate. Non-master defaults rschCompId to its own company. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (body[f] !== undefined) payload[f] = body[f];
+    }
+
+    if (!isMaster) {
+        let companyId;
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (payload.rschCompId !== undefined && Number(payload.rschCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot create a rate schedule for a company you do not belong to." });
+        }
+        payload.rschCompId = companyId;
+    } else if (payload.rschCompId === undefined || Number(payload.rschCompId) <= 0) {
+        return res.status(400).json({ message: "Master-key requests must specify rschCompId." });
+    }
+
+    payload.rschArch = false;
+
+    try {
+        const created = await RateSchedule.create(payload);
+        return res.status(201).json({ message: "Rate schedule created.", rateSchedule: created });
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/rateschedule/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rs = await findScoped(req, res);
+    if (!rs) return undefined;
+    return res.status(200).json({ message: "Found.", rateSchedule: rs });
+};
+
+/** GET /v1/rateschedule/bycompany/:id — list a company's schedules (paginated). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await RateSchedule.findAndCountAll({
+            where: { rschCompId: targetCompanyId },
+            limit,
+            offset,
+            order: [['rschEffectiveFrom', 'ASC'], ['rschId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, rateSchedules: rows });
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * GET /v1/rateschedule/resolve?date=YYYY-MM-DD — the company's effective
+ * rate on that date (the latest schedule whose range contains it).
+ */
+exports.resolve = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const date = String(req.query.date);
+    let schedules;
+    try {
+        schedules = await RateSchedule.findAll({
+            where: { rschCompId: companyId },
+            attributes: ['rschId', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo'],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule.findAll (resolve) failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    const rate = rateOnDate(
+        schedules.map((s) => ({ effectiveFrom: s.rschEffectiveFrom, effectiveTo: s.rschEffectiveTo, rate: s.rschRate })),
+        date,
+    );
+    return res.status(200).json({ message: "Effective rate resolved.", companyId, date, rate });
+};
+
+/** PATCH /v1/rateschedule/:id — partial update. rschCompId / rschArch not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rs = await findScoped(req, res);
+    if (!rs) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await rs.update(updates);
+        return res.status(200).json({ message: "Updated.", rateSchedule: rs });
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/rateschedule/:id — soft-delete (sets rschArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rs = await findScoped(req, res);
+    if (!rs) return undefined;
+
+    try {
+        await rs.update({ rschArch: true });
+        return res.status(200).json({ message: "Archived.", id: rs.rschId });
+    } catch (error) {
+        log.error({ err: error }, 'RateSchedule archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260620000000-rate-schedule.js
+++ b/app/migrations/20260620000000-rate-schedule.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Rate effective-dating (#414). A RateSchedule is a named rate that
+// applies over a date range (rschEffectiveFrom .. rschEffectiveTo, the
+// latter open-ended when NULL). Company-scoped via rschCompId. This lands
+// the model + a queryable resolver (see rate-schedule.js); wiring
+// date-aware selection into rate.js's live billing resolution is a
+// follow-up. New table in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'RateSchedule', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    rschId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    rschCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    rschName: { type: Sequelize.TEXT, allowNull: false },
+                    rschRate: { type: Sequelize.DECIMAL(14, 2), allowNull: false },
+                    rschEffectiveFrom: { type: Sequelize.DATEONLY, allowNull: false },
+                    rschEffectiveTo: { type: Sequelize.DATEONLY, allowNull: true },
+                    rschArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, {
+                name: 'RateSchedule_compId_from_arch_idx',
+                fields: ['rschCompId', 'rschEffectiveFrom', 'rschArch'],
+                transaction: t,
+            });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/rateschedule.model.js
+++ b/app/models/rateschedule.model.js
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * RateSchedule — a named rate effective over a date range (#414).
+ * rschEffectiveTo is NULL for an open-ended (current) rate. Company-scoped
+ * via rschCompId; the effective rate on a given day is resolved by
+ * app/services/rate-schedule.js. rschRate is NUMERIC(14,2) with a Number
+ * getter. Soft-deletes via rschArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const RateSchedule = sequelize.define('RateSchedule', {
+        rschId: {
+            field: 'rschId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        rschCompId: {
+            field: 'rschCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rschName: {
+            field: 'rschName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rschRate: {
+            field: 'rschRate',
+            type: Sequelize.DECIMAL(14, 2),
+            allowNull: false,
+            get() {
+                const v = this.getDataValue('rschRate');
+                return v == null ? null : Number(v);
+            },
+        },
+        rschEffectiveFrom: {
+            field: 'rschEffectiveFrom',
+            type: Sequelize.DATEONLY,
+            allowNull: false,
+        },
+        rschEffectiveTo: {
+            field: 'rschEffectiveTo',
+            type: Sequelize.DATEONLY,
+        },
+        rschArch: {
+            field: 'rschArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'RateSchedule',
+        timestamps: true,
+        defaultScope: { where: { rschArch: false } }
+    });
+
+    return RateSchedule;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -38,6 +38,7 @@ const recurringInvoice = require('../controllers/recurringinvoicecontroller.js')
 const apikey = require('../controllers/apikeycontroller.js');
 const webhook = require('../controllers/webhookcontroller.js');
 const notification = require('../controllers/notificationcontroller.js');
+const rateSchedule = require('../controllers/rateschedulecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -66,6 +67,7 @@ const recurringInvoiceSchemas = require('../schemas/recurringinvoice.schema.js')
 const apiKeySchemas = require('../schemas/apikey.schema.js');
 const webhookSchemas = require('../schemas/webhook.schema.js');
 const notificationSchemas = require('../schemas/notification.schema.js');
+const rateScheduleSchemas = require('../schemas/rateschedule.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -770,6 +772,41 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 rate-schedule routes (effective-dated rates, #414).
+// GET /resolve is declared before GET /:id so "resolve" isn't parsed as an id.
+router.post(
+    '/v1/rateschedule',
+    v.body(rateScheduleSchemas.createRateScheduleBody),
+    rateSchedule.create,
+);
+router.get(
+    '/v1/rateschedule/resolve',
+    v.query(rateScheduleSchemas.resolveQuery),
+    rateSchedule.resolve,
+);
+router.get(
+    '/v1/rateschedule/bycompany/:id',
+    v.params(rateScheduleSchemas.intIdParam),
+    v.query(rateScheduleSchemas.listByCompanyQuery),
+    rateSchedule.listByCompany,
+);
+router.get(
+    '/v1/rateschedule/:id',
+    v.params(rateScheduleSchemas.intIdParam),
+    rateSchedule.getById,
+);
+router.patch(
+    '/v1/rateschedule/:id',
+    v.params(rateScheduleSchemas.intIdParam),
+    v.body(rateScheduleSchemas.updateRateScheduleBody),
+    rateSchedule.update,
+);
+router.delete(
+    '/v1/rateschedule/:id',
+    v.params(rateScheduleSchemas.intIdParam),
+    rateSchedule.remove,
 );
 
 // v1 notification route (email service test send, master-only, #68).

--- a/app/schemas/rateschedule.schema.js
+++ b/app/schemas/rateschedule.schema.js
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+
+function refineToAfterFrom(d) {
+    if (!d.rschEffectiveFrom || !d.rschEffectiveTo) return true;
+    return d.rschEffectiveTo >= d.rschEffectiveFrom;
+}
+const TO_BEFORE_FROM = { message: 'rschEffectiveTo must be on or after rschEffectiveFrom.', path: ['rschEffectiveTo'] };
+
+/**
+ * POST /v1/rateschedule body. Name + rate + effectiveFrom required;
+ * rschCompId optional for non-master keys, required for master.
+ */
+const createRateScheduleBody = z.object({
+    rschName: z.string().min(1).max(255),
+    rschRate: z.coerce.number().positive(),
+    rschEffectiveFrom: isoDate,
+    rschEffectiveTo: isoDate.optional(),
+    rschCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: rschName, rschRate, rschEffectiveFrom, rschEffectiveTo, rschCompId.',
+}).refine(refineToAfterFrom, TO_BEFORE_FROM);
+
+/** PATCH /v1/rateschedule/:id — rschCompId is not patchable. */
+const updateRateScheduleBody = z.object({
+    rschName: z.string().min(1).max(255).optional(),
+    rschRate: z.coerce.number().positive().optional(),
+    rschEffectiveFrom: isoDate.optional(),
+    rschEffectiveTo: isoDate.nullable().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: rschName, rschRate, rschEffectiveFrom, rschEffectiveTo.',
+}).refine(refineToAfterFrom, TO_BEFORE_FROM);
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+/** GET /v1/rateschedule/resolve query. date required; companyId for master keys. */
+const resolveQuery = z.object({
+    date: isoDate,
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: date, companyId.',
+});
+
+module.exports = {
+    intIdParam,
+    createRateScheduleBody,
+    updateRateScheduleBody,
+    listByCompanyQuery,
+    resolveQuery,
+};

--- a/app/services/rate-schedule.js
+++ b/app/services/rate-schedule.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * rate-schedule.js — resolve the rate effective on a given date from a
+ * set of dated rate schedules (#414). PURE: no DB. A schedule applies on
+ * `date` when effectiveFrom <= date <= effectiveTo (or effectiveTo is
+ * null = open-ended). When several apply, the one with the latest
+ * effectiveFrom wins (the most recently-introduced rate). Dates are
+ * 'YYYY-MM-DD' strings, compared lexicographically (== chronologically).
+ */
+
+function numOrNull(v) {
+    if (v == null) return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * @param schedules array of { effectiveFrom, effectiveTo, rate }.
+ * @param date 'YYYY-MM-DD'.
+ * @returns the effective rate (Number) or null when none applies.
+ */
+function rateOnDate(schedules, date) {
+    if (!date) return null;
+    let best = null;
+    for (const s of schedules || []) {
+        const from = s.effectiveFrom || null;
+        const to = s.effectiveTo || null;
+        if (!from || date < from) continue;   // not yet effective
+        if (to && date > to) continue;        // expired
+        if (!best || from > best.from) best = { from, rate: numOrNull(s.rate) };
+    }
+    return best ? best.rate : null;
+}
+
+module.exports = { rateOnDate };

--- a/tests/api/rateschedule.test.js
+++ b/tests/api/rateschedule.test.js
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/rateschedule (#414) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {},
+    RateSchedule: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), findAll: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { rschName: 'Standard 2026', rschRate: 175, rschEffectiveFrom: '2026-01-01' };
+
+describe('RateSchedule auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/rateschedule').send(good)).status).toBe(403);
+    });
+    test('POST 400 on missing rschRate (schema)', async () => {
+        expect((await request(app).post('/v1/rateschedule').set('authKey', 'k').send({ rschName: 'X', rschEffectiveFrom: '2026-01-01' })).status).toBe(400);
+    });
+    test('POST 400 on effectiveTo before effectiveFrom (schema refine)', async () => {
+        const res = await request(app).post('/v1/rateschedule').set('authKey', 'k')
+            .send({ ...good, rschEffectiveTo: '2025-06-01' });
+        expect(res.status).toBe(400);
+    });
+    test('GET /resolve 403 without authKey (date present)', async () => {
+        expect((await request(app).get('/v1/rateschedule/resolve?date=2026-06-01')).status).toBe(403);
+    });
+    test('GET /resolve 400 without a date (schema)', async () => {
+        expect((await request(app).get('/v1/rateschedule/resolve').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /resolve does not collide with GET /:id (route ordering)', async () => {
+        // "resolve" hits the resolve handler (403 no-auth), not the :id route.
+        expect((await request(app).get('/v1/rateschedule/resolve?date=2026-06-01')).status).toBe(403);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/rateschedule/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('RateSchedule table exists with a company include (#414)', async () => {
+        if (!connected) return;
+        const rows = await db.RateSchedule.findAll({
+            attributes: ['rschId', 'rschCompId', 'rschName', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.RateSchedule.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('Webhook table exists with a company include (#69)', async () => {
         if (!connected) return;
         const rows = await db.Webhook.findAll({

--- a/tests/unit/rate-schedule.test.js
+++ b/tests/unit/rate-schedule.test.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { rateOnDate } from '../../app/services/rate-schedule.js';
+
+const SCHEDULES = [
+    { effectiveFrom: '2025-01-01', effectiveTo: '2025-12-31', rate: 150 },
+    { effectiveFrom: '2026-01-01', effectiveTo: null, rate: 175 }, // open-ended current rate
+];
+
+describe('rateOnDate (#414)', () => {
+    test('picks the rate whose range contains the date', () => {
+        expect(rateOnDate(SCHEDULES, '2025-06-15')).toBe(150);
+        expect(rateOnDate(SCHEDULES, '2026-06-15')).toBe(175);
+    });
+
+    test('open-ended schedule applies to any date on/after its start', () => {
+        expect(rateOnDate(SCHEDULES, '2030-01-01')).toBe(175);
+    });
+
+    test('returns null before any schedule starts', () => {
+        expect(rateOnDate(SCHEDULES, '2024-12-31')).toBeNull();
+    });
+
+    test('when several apply, the latest effectiveFrom wins', () => {
+        const overlapping = [
+            { effectiveFrom: '2026-01-01', effectiveTo: null, rate: 100 },
+            { effectiveFrom: '2026-06-01', effectiveTo: null, rate: 200 }, // supersedes from June
+        ];
+        expect(rateOnDate(overlapping, '2026-03-01')).toBe(100);
+        expect(rateOnDate(overlapping, '2026-07-01')).toBe(200);
+    });
+
+    test('null date or empty schedules → null', () => {
+        expect(rateOnDate(SCHEDULES, null)).toBeNull();
+        expect(rateOnDate([], '2026-01-01')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Rates that change over time — record a rate with a date range, and ask "what rate was in effect on this day?"

Closes #414.

## Changes

- **Migration `20260620000000`** — a company-scoped `RateSchedule` table (`rschName`, `rschRate`, `rschEffectiveFrom`, `rschEffectiveTo?`, `rschArch`) + a `(rschCompId, rschEffectiveFrom, rschArch)` index. `rschEffectiveTo` null = open-ended / current.
- **Full REST** on `/v1/rateschedule` — `POST` (master keys pass `rschCompId`), `GET /bycompany/{id}`, `GET|PATCH|DELETE /{id}` — company-scoped with secure-404; `effectiveTo >= effectiveFrom` enforced.
- **`GET /v1/rateschedule/resolve?date=YYYY-MM-DD`** — returns the rate in effect on that date, via a pure `rate-schedule.js` resolver: a schedule applies when `from <= date <= to` (or open-ended), and when several overlap the **latest `effectiveFrom` wins**.

## Scope (foundation-first)

This lands the **model + a queryable resolver** — you can store historical/future rates and ask for the effective one on any date. **Wiring date-aware selection into `rate.js`'s live billing resolution is a deliberate follow-up**, to avoid surgery on the well-tested six-tier resolver in the same change.

## Verification

`npm run lint` clean; `npm test` → **1298 passing** (`rateOnDate`: range match, open-ended, before-any-start, latest-`from`-wins, null guards; route auth + schema incl. the range refine; `/resolve` route-ordering vs `/:id`; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/