### PR TITLE
feat(auth): user accounts foundation (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **User accounts** (#444). A new company-scoped `User` entity (email,
+  name, scrypt-hashed password), migration `20260621000000`, with full
+  admin-provisioned REST on `/v1/user` (create, `bycompany` list,
+  get/patch/delete) and secure-404 scoping. Passwords are hashed with
+  Node's built-in **scrypt** (no dependency; per-hash salt, constant-time
+  verify — pure `password.js`) and the **hash is write-only** — no endpoint
+  returns it; email is unique per company. This is the foundation for
+  login (#445) and password reset (#446); the existing API-key auth is
+  unchanged. No live sign-in yet.
 - **Rate effective-dating** (#414). A new company-scoped `RateSchedule`
   entity (`rschRate` over `rschEffectiveFrom`..`rschEffectiveTo`, the
   latter open-ended when null), migration `20260620000000`. Full REST on

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -75,6 +75,7 @@ db.Role = require('../models/role.model.js')(sequelize, Sequelize);
 db.RecurringInvoice = require('../models/recurringinvoice.model.js')(sequelize, Sequelize);
 db.Webhook = require('../models/webhook.model.js')(sequelize, Sequelize);
 db.RateSchedule = require('../models/rateschedule.model.js')(sequelize, Sequelize);
+db.User = require('../models/user.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -228,5 +229,9 @@ db.Webhook.belongsTo(db.Company, { foreignKey: 'whkCompId', as: 'company' });
 // RateSchedule → Company (rschCompId): effective-dated rates (#414).
 db.Company.hasMany(db.RateSchedule,   { foreignKey: 'rschCompId', as: 'rateSchedules' });
 db.RateSchedule.belongsTo(db.Company, { foreignKey: 'rschCompId', as: 'company' });
+
+// User → Company (userCompId): a person who signs in to a company (#444).
+db.Company.hasMany(db.User,   { foreignKey: 'userCompId', as: 'users' });
+db.User.belongsTo(db.Company, { foreignKey: 'userCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1463,6 +1463,50 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/user': {
+            post: {
+                summary: 'Create a user account (#444)',
+                security: [{ authKey: [] }],
+                responses: {
+                    201: { description: 'Created (password hash never returned)' },
+                    400: { description: 'Validation error; master keys must specify userCompId' },
+                    403: { description: 'Auth failure' },
+                    409: { description: 'Email already in use' },
+                },
+            },
+        },
+        '/v1/user/bycompany/{id}': {
+            get: {
+                summary: "List a company's users — metadata only",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated; never returns the password hash)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/user/{id}': {
+            get: {
+                summary: 'Fetch a user (metadata only)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a user (email / name / password)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a user',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/rateschedule': {
             post: {
                 summary: 'Create an effective-dated rate (#414)',

--- a/app/controllers/usercontroller.js
+++ b/app/controllers/usercontroller.js
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { hashPassword } = require('../services/password.js');
+const User = db.User;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+// userPasswordHash is deliberately excluded — it is write-only.
+const SAFE_ATTRS = ['userId', 'userCompId', 'userEmail', 'userName', 'userArch', 'createdAt', 'updatedAt'];
+
+/** A response-safe view of a user row (never includes the password hash). */
+function safeView(u) {
+    return {
+        userId: u.userId,
+        userCompId: u.userCompId,
+        userEmail: u.userEmail,
+        userName: u.userName,
+        userArch: u.userArch,
+    };
+}
+
+/** Load a user (with hash, if needed) and enforce the secure-404 company scope. */
+async function findScoped(req, res) {
+    let user;
+    try {
+        user = await User.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'User.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!user || user.userArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || user.userCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return user;
+}
+
+/** POST /v1/user — create a user account. Non-master defaults userCompId to its own company. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    let companyId;
+    if (!isMaster) {
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (body.userCompId !== undefined && Number(body.userCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot create a user for a company you do not belong to." });
+        }
+    } else {
+        companyId = Number(body.userCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify userCompId." });
+        }
+    }
+
+    // Enforce email uniqueness within the company (active users only).
+    try {
+        const existing = await User.findOne({ where: { userCompId: companyId, userEmail: body.userEmail } });
+        if (existing) {
+            return res.status(409).json({ message: "A user with that email already exists." });
+        }
+    } catch (error) {
+        log.error({ err: error }, 'User email uniqueness check failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const payload = {
+        userCompId: companyId,
+        userEmail: body.userEmail,
+        userName: body.userName,
+        userPasswordHash: hashPassword(body.password),
+        userArch: false,
+    };
+    try {
+        const created = await User.create(payload);
+        return res.status(201).json({ message: "User created.", user: safeView(created) });
+    } catch (error) {
+        log.error({ err: error }, 'User.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/user/:id — fetch one (metadata only). Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let user;
+    try {
+        user = await User.findByPk(req.params.id, { attributes: SAFE_ATTRS });
+    } catch (error) {
+        log.error({ err: error }, 'User.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!user || user.userArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || user.userCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+    return res.status(200).json({ message: "Found.", user });
+};
+
+/** GET /v1/user/bycompany/:id — list a company's users (metadata only, paginated). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await User.findAndCountAll({
+            where: { userCompId: targetCompanyId },
+            attributes: SAFE_ATTRS,
+            limit,
+            offset,
+            order: [['userId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, users: rows });
+    } catch (error) {
+        log.error({ err: error }, 'User.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** PATCH /v1/user/:id — update email / name / password. userCompId not settable here. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const user = await findScoped(req, res);
+    if (!user) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    if (body.userEmail !== undefined) updates.userEmail = body.userEmail;
+    if (body.userName !== undefined) updates.userName = body.userName;
+    if (body.password !== undefined) updates.userPasswordHash = hashPassword(body.password);
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await user.update(updates);
+        return res.status(200).json({ message: "Updated.", user: safeView(user) });
+    } catch (error) {
+        log.error({ err: error }, 'User.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/user/:id — soft-delete (sets userArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const user = await findScoped(req, res);
+    if (!user) return undefined;
+
+    try {
+        await user.update({ userArch: true });
+        return res.status(200).json({ message: "Archived.", id: user.userId });
+    } catch (error) {
+        log.error({ err: error }, 'User archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260621000000-user.js
+++ b/app/migrations/20260621000000-user.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// User accounts (#444). A User is a person who signs in to a company
+// (userCompId). userPasswordHash stores a scrypt digest (see
+// app/services/password.js) — never a plaintext password. This is the
+// foundation for login (#445) and password reset (#446); it does NOT
+// change the existing API-key auth. New table in the increment layer; no
+// FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'User', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    userId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    userCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    userEmail: { type: Sequelize.TEXT, allowNull: false },
+                    userName: { type: Sequelize.TEXT, allowNull: true },
+                    userPasswordHash: { type: Sequelize.TEXT, allowNull: false },
+                    userArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'User_compId_arch_idx', fields: ['userCompId', 'userArch'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'User_email_idx', fields: ['userEmail'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/user.model.js
+++ b/app/models/user.model.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * User — a person who signs in to a company (#444). Company-scoped via
+ * userCompId. userPasswordHash is a scrypt digest (app/services/password.js)
+ * and is WRITE-ONLY at the API layer — no endpoint ever returns it.
+ * Soft-deletes via userArch. Foundation for login (#445) / reset (#446);
+ * separate from the existing API-key auth.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const User = sequelize.define('User', {
+        userId: {
+            field: 'userId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        userCompId: {
+            field: 'userCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        userEmail: {
+            field: 'userEmail',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        userName: {
+            field: 'userName',
+            type: Sequelize.TEXT,
+        },
+        userPasswordHash: {
+            field: 'userPasswordHash',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        userArch: {
+            field: 'userArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'User',
+        timestamps: true,
+        defaultScope: { where: { userArch: false } }
+    });
+
+    return User;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -39,6 +39,7 @@ const apikey = require('../controllers/apikeycontroller.js');
 const webhook = require('../controllers/webhookcontroller.js');
 const notification = require('../controllers/notificationcontroller.js');
 const rateSchedule = require('../controllers/rateschedulecontroller.js');
+const user = require('../controllers/usercontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -68,6 +69,7 @@ const apiKeySchemas = require('../schemas/apikey.schema.js');
 const webhookSchemas = require('../schemas/webhook.schema.js');
 const notificationSchemas = require('../schemas/notification.schema.js');
 const rateScheduleSchemas = require('../schemas/rateschedule.schema.js');
+const userSchemas = require('../schemas/user.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -772,6 +774,35 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 user-account routes (#444). Sign-in users, separate from API keys.
+router.post(
+    '/v1/user',
+    v.body(userSchemas.createUserBody),
+    user.create,
+);
+router.get(
+    '/v1/user/bycompany/:id',
+    v.params(userSchemas.intIdParam),
+    v.query(userSchemas.listByCompanyQuery),
+    user.listByCompany,
+);
+router.get(
+    '/v1/user/:id',
+    v.params(userSchemas.intIdParam),
+    user.getById,
+);
+router.patch(
+    '/v1/user/:id',
+    v.params(userSchemas.intIdParam),
+    v.body(userSchemas.updateUserBody),
+    user.update,
+);
+router.delete(
+    '/v1/user/:id',
+    v.params(userSchemas.intIdParam),
+    user.remove,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/user.schema.js
+++ b/app/schemas/user.schema.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const password = z.string().min(8).max(200);
+
+/**
+ * POST /v1/user body. Email + password required; userCompId optional for
+ * non-master keys (defaults to the key's company), required for master.
+ */
+const createUserBody = z.object({
+    userEmail: z.string().email().max(320),
+    password: password,
+    userName: z.string().min(1).max(255).optional(),
+    userCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: userEmail, password, userName, userCompId.',
+});
+
+/** PATCH /v1/user/:id — userCompId is not patchable; password optional (re-hash). */
+const updateUserBody = z.object({
+    userEmail: z.string().email().max(320).optional(),
+    userName: z.string().min(1).max(255).nullable().optional(),
+    password: password.optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: userEmail, userName, password.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createUserBody,
+    updateUserBody,
+    listByCompanyQuery,
+};

--- a/app/services/password.js
+++ b/app/services/password.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * password.js — password hashing for user accounts (#444). Uses Node's
+ * built-in scrypt (memory-hard KDF) — NO external dependency. Stored form
+ * is `scrypt$<salt-hex>$<hash-hex>`; each hash carries its own random
+ * salt. verifyPassword is constant-time. PURE (CPU only), unit-testable.
+ */
+
+const crypto = require('crypto');
+
+const KEYLEN = 64;
+const SALT_BYTES = 16;
+
+/** Hash a plaintext password → `scrypt$salt$hash`. */
+function hashPassword(password) {
+    const salt = crypto.randomBytes(SALT_BYTES).toString('hex');
+    const derived = crypto.scryptSync(String(password), salt, KEYLEN).toString('hex');
+    return `scrypt$${salt}$${derived}`;
+}
+
+/** Verify a password against a stored `scrypt$salt$hash`. Constant-time. */
+function verifyPassword(password, stored) {
+    const parts = String(stored || '').split('$');
+    if (parts.length !== 3 || parts[0] !== 'scrypt' || !parts[1] || !parts[2]) return false;
+    const salt = parts[1];
+    let derived;
+    try {
+        derived = crypto.scryptSync(String(password), salt, KEYLEN).toString('hex');
+    } catch (_) {
+        return false;
+    }
+    const a = Buffer.from(parts[2], 'hex');
+    const b = Buffer.from(derived, 'hex');
+    if (a.length !== b.length || a.length === 0) return false;
+    return crypto.timingSafeEqual(a, b);
+}
+
+module.exports = { hashPassword, verifyPassword };

--- a/tests/api/user.test.js
+++ b/tests/api/user.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/user (#444) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {},
+    User: { findByPk: vi.fn().mockResolvedValue(null), findOne: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { userEmail: 'jane@co.com', password: 'hunter2hunter2' };
+
+describe('User account auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/user').send(good)).status).toBe(403);
+    });
+    test('POST 400 on a missing password (schema)', async () => {
+        expect((await request(app).post('/v1/user').set('authKey', 'k').send({ userEmail: 'jane@co.com' })).status).toBe(400);
+    });
+    test('POST 400 on a too-short password (schema)', async () => {
+        expect((await request(app).post('/v1/user').set('authKey', 'k').send({ userEmail: 'jane@co.com', password: 'short' })).status).toBe(400);
+    });
+    test('POST 400 on an invalid email (schema)', async () => {
+        expect((await request(app).post('/v1/user').set('authKey', 'k').send({ userEmail: 'not-an-email', password: 'hunter2hunter2' })).status).toBe(400);
+    });
+    test('POST 400 on an unknown field (strict schema)', async () => {
+        expect((await request(app).post('/v1/user').set('authKey', 'k').send({ ...good, isAdmin: true })).status).toBe(400);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/user/1')).status).toBe(403);
+    });
+    test('GET /bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/user/bycompany/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('User table exists with a company include (#444)', async () => {
+        if (!connected) return;
+        const rows = await db.User.findAll({
+            attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userArch'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.User.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('RateSchedule table exists with a company include (#414)', async () => {
         if (!connected) return;
         const rows = await db.RateSchedule.findAll({

--- a/tests/unit/password.test.js
+++ b/tests/unit/password.test.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { hashPassword, verifyPassword } from '../../app/services/password.js';
+
+describe('password (#444)', () => {
+    test('hash has the scrypt$salt$hash shape and is not the plaintext', () => {
+        const h = hashPassword('correct horse battery staple');
+        expect(h).toMatch(/^scrypt\$[0-9a-f]{32}\$[0-9a-f]{128}$/);
+        expect(h).not.toContain('correct horse');
+    });
+
+    test('verifyPassword accepts the right password, rejects the wrong one', () => {
+        const h = hashPassword('s3cr3t-passw0rd');
+        expect(verifyPassword('s3cr3t-passw0rd', h)).toBe(true);
+        expect(verifyPassword('wrong', h)).toBe(false);
+    });
+
+    test('the same password hashes differently each time (random salt)', () => {
+        expect(hashPassword('samepass')).not.toBe(hashPassword('samepass'));
+    });
+
+    test('verifyPassword is false for a malformed or empty stored value', () => {
+        expect(verifyPassword('x', 'not-a-valid-hash')).toBe(false);
+        expect(verifyPassword('x', '')).toBe(false);
+        expect(verifyPassword('x', null)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

The first piece of the auth epic: user accounts with securely-hashed passwords — the model login (#445) and password reset (#446) build on.

Closes #444.

## Changes

- **Migration `20260621000000`** — a company-scoped `User` table (`userEmail`, `userName?`, `userPasswordHash`, `userArch`) + `(userCompId, userArch)` and email indexes.
- **Full REST** on `/v1/user` — `POST` (master keys pass `userCompId`), `GET /bycompany/{id}`, `GET|PATCH|DELETE /{id}` — company-scoped with secure-404; email is **unique per company** (409 on collision).
- **`password.js`** — hashing via Node's built-in **scrypt** (memory-hard KDF, **no new dependency**): each hash carries its own random salt, stored as `scrypt$salt$hash`; `verifyPassword` is **constant-time** (`timingSafeEqual`). Pure and unit-tested.
- **Hash is write-only** — settable via `password` on create/update, but **no endpoint ever returns `userPasswordHash`** (reads use a safe attribute set; create/update return a hand-built safe view).

## Scope (foundation-first)

This lands the **user + credential model** — accounts can be provisioned with real, safely-hashed passwords — **without touching the existing API-key auth**. Actual **sign-in (session/JWT)** is #445 and **password reset** (using the mailer from #68) is #446, each as its own focused PR so the auth-mechanism choices get careful review.

## Verification

`npm run lint` clean; `npm test` → **1318 passing** (password: hash shape, correct/wrong verify, per-salt uniqueness, malformed-input guard; route auth + email/password schema; the `controller-error-shape` policy test passes). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/