### PR TITLE
feat(auth): user login with JWT (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **User login (JWT)** (#445). `POST /v1/login` verifies a user's email +
+  password within a company and issues a short-lived (12h) **HS256 JWT**;
+  `GET /v1/me` returns the signed-in user for a `Bearer` token. Tokens are
+  signed with Node's built-in crypto HMAC (**no dependency**; constant-time
+  verify, `exp` enforced — pure `jwt.js`), keyed by the `JWT_SECRET` env
+  var (sign-in returns **503** when unset). Invalid credentials return a
+  **generic 401** (no email enumeration). This is a second, optional auth
+  path — the existing API-key auth is unchanged. No migration.
 - **User accounts** (#444). A new company-scoped `User` entity (email,
   name, scrypt-hashed password), migration `20260621000000`, with full
   admin-provisioned REST on `/v1/user` (create, `bycompany` list,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1463,6 +1463,29 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/login': {
+            post: {
+                summary: 'Sign in a user — returns a JWT (#445)',
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { userEmail: { type: 'string', format: 'email' }, password: { type: 'string' }, companyId: { type: 'integer' } }, required: ['userEmail', 'password', 'companyId'] } } } },
+                responses: {
+                    200: { description: 'Signed in — {token, tokenType, expiresIn, user}' },
+                    400: { description: 'Validation error' },
+                    401: { description: 'Invalid credentials' },
+                    503: { description: 'Sign-in not configured (JWT_SECRET unset)' },
+                },
+            },
+        },
+        '/v1/me': {
+            get: {
+                summary: 'Return the signed-in user for a Bearer token (#445)',
+                parameters: [{ name: 'Authorization', in: 'header', schema: { type: 'string' }, description: 'Bearer <jwt>' }],
+                responses: {
+                    200: { description: 'The signed-in user' },
+                    401: { description: 'Missing / invalid / expired token' },
+                    503: { description: 'Sign-in not configured' },
+                },
+            },
+        },
         '/v1/user': {
             post: {
                 summary: 'Create a user account (#444)',

--- a/app/controllers/authcontroller.js
+++ b/app/controllers/authcontroller.js
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+// User sign-in (#445): POST /v1/login issues a short-lived HS256 JWT for
+// a User (#444); GET /v1/me returns the signed-in user. This is a SECOND,
+// optional auth path — the existing API-key auth is unchanged. Signing
+// requires the JWT_SECRET env var; when it's unset, sign-in returns 503.
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const jwt = require('../services/jwt.js');
+const { verifyPassword } = require('../services/password.js');
+
+const TOKEN_TTL_SEC = 12 * 60 * 60; // 12 hours
+
+function secret() {
+    return process.env.JWT_SECRET || '';
+}
+
+function safeUser(u) {
+    return { userId: u.userId, userCompId: u.userCompId, userEmail: u.userEmail, userName: u.userName };
+}
+
+/** POST /v1/login — verify email + password (within a company), issue a JWT. */
+exports.login = async (req, res) => {
+    const s = secret();
+    if (!s) {
+        return res.status(503).json({ message: "Sign-in is not configured." });
+    }
+
+    const body = req.body || {};
+    const companyId = Number(body.companyId);
+
+    let user;
+    try {
+        user = await db.User.findOne({ where: { userEmail: body.userEmail, userCompId: companyId } });
+    } catch (error) {
+        log.error({ err: error }, 'login: User.findOne failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    // Generic 401 — never reveal whether the email exists (anti-enumeration).
+    if (!user || user.userArch || !verifyPassword(body.password, user.userPasswordHash)) {
+        return res.status(401).json({ message: "Invalid credentials." });
+    }
+
+    const token = jwt.sign({ sub: user.userId, userCompId: user.userCompId }, s, TOKEN_TTL_SEC);
+    return res.status(200).json({
+        message: "Signed in.",
+        token,
+        tokenType: "Bearer",
+        expiresIn: TOKEN_TTL_SEC,
+        user: safeUser(user),
+    });
+};
+
+/** GET /v1/me — return the user for a valid Bearer token. */
+exports.me = async (req, res) => {
+    const s = secret();
+    if (!s) {
+        return res.status(503).json({ message: "Sign-in is not configured." });
+    }
+
+    const authz = req.get('authorization') || '';
+    const m = /^Bearer\s+(.+)$/i.exec(authz);
+    if (!m) {
+        return res.status(401).json({ message: "Bearer token required." });
+    }
+    const payload = jwt.verify(m[1], s);
+    if (!payload || !payload.sub) {
+        return res.status(401).json({ message: "Invalid or expired token." });
+    }
+
+    let user;
+    try {
+        user = await db.User.findByPk(payload.sub, { attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userArch'] });
+    } catch (error) {
+        log.error({ err: error }, 'me: User.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!user || user.userArch) {
+        return res.status(401).json({ message: "Invalid or expired token." });
+    }
+    return res.status(200).json({ message: "OK.", user: safeUser(user) });
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -40,6 +40,7 @@ const webhook = require('../controllers/webhookcontroller.js');
 const notification = require('../controllers/notificationcontroller.js');
 const rateSchedule = require('../controllers/rateschedulecontroller.js');
 const user = require('../controllers/usercontroller.js');
+const authController = require('../controllers/authcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -70,6 +71,7 @@ const webhookSchemas = require('../schemas/webhook.schema.js');
 const notificationSchemas = require('../schemas/notification.schema.js');
 const rateScheduleSchemas = require('../schemas/rateschedule.schema.js');
 const userSchemas = require('../schemas/user.schema.js');
+const authSchemas = require('../schemas/auth.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -774,6 +776,18 @@ router.delete(
     '/v1/retainer/:id',
     v.params(retainerSchemas.intIdParam),
     retainer.remove,
+);
+
+// v1 sign-in routes (#445). Public — POST /login issues a JWT for a User;
+// GET /me returns the signed-in user. Separate from the API-key auth.
+router.post(
+    '/v1/login',
+    v.body(authSchemas.loginBody),
+    authController.login,
+);
+router.get(
+    '/v1/me',
+    authController.me,
 );
 
 // v1 user-account routes (#444). Sign-in users, separate from API keys.

--- a/app/schemas/auth.schema.js
+++ b/app/schemas/auth.schema.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+/** POST /v1/login body — sign in a user within a company (#445). */
+const loginBody = z.object({
+    userEmail: z.string().email().max(320),
+    password: z.string().min(1).max(200),
+    companyId: z.coerce.number().int().positive(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: userEmail, password, companyId.',
+});
+
+module.exports = {
+    loginBody,
+};

--- a/app/services/jwt.js
+++ b/app/services/jwt.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * jwt.js — minimal HS256 JSON Web Tokens for user sign-in (#445). Uses
+ * Node's built-in crypto HMAC — NO external dependency. Signs a compact
+ * `header.payload.signature`; `verify` is constant-time and enforces the
+ * `exp` claim. PURE (crypto only), unit-testable.
+ */
+
+const crypto = require('crypto');
+
+function b64url(input) {
+    return Buffer.from(input).toString('base64url');
+}
+
+/** Sign a payload → a compact JWS string. expiresInSec defaults to 1h. */
+function sign(payload, secret, expiresInSec) {
+    const now = Math.floor(Date.now() / 1000);
+    const header = { alg: 'HS256', typ: 'JWT' };
+    const ttl = Number(expiresInSec);
+    const body = Object.assign({}, payload, { iat: now, exp: now + (Number.isFinite(ttl) ? ttl : 3600) });
+    const data = b64url(JSON.stringify(header)) + '.' + b64url(JSON.stringify(body));
+    const sig = crypto.createHmac('sha256', String(secret)).update(data).digest('base64url');
+    return data + '.' + sig;
+}
+
+/** Verify + decode a token. Returns the payload, or null if invalid/expired. */
+function verify(token, secret) {
+    const parts = String(token || '').split('.');
+    if (parts.length !== 3) return null;
+    const data = parts[0] + '.' + parts[1];
+    const expected = crypto.createHmac('sha256', String(secret)).update(data).digest('base64url');
+    const a = Buffer.from(parts[2]);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || a.length === 0) return null;
+    if (!crypto.timingSafeEqual(a, b)) return null;
+    let body;
+    try {
+        body = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    } catch (_) {
+        return null;
+    }
+    if (body && body.exp && Math.floor(Date.now() / 1000) > body.exp) return null;
+    return body;
+}
+
+module.exports = { sign, verify };

--- a/tests/api/login.test.js
+++ b/tests/api/login.test.js
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP tests for user sign-in (#445) — POST /v1/login + GET /v1/me.
+//
+// The db mock factory must be a PURE literal (a require/hoisted ref makes
+// vitest fall through to the real db.config). So the stored password hash
+// is a precomputed literal: scrypt`hashPassword('rightpass99')` — the salt
+// is embedded, so `verifyPassword('rightpass99', ...)` stays true.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const RIGHT = 'rightpass99';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {},
+    User: {
+        findOne: vi.fn().mockResolvedValue({ userId: 1, userCompId: 5, userEmail: 'jane@co.com', userName: 'Jane', userArch: false, userPasswordHash: 'scrypt$8c920aff01e6e7e1ad165beecaa5f7c3$da3138220239821dc7c23d0218cc015a104d1668fe2e74f32b479807f22ed5a8dec765e96c98e104f816375ec8badb737a0b6f2f62b57ca9817b8f4e146e4a9c' }),
+        findByPk: vi.fn().mockResolvedValue({ userId: 1, userCompId: 5, userEmail: 'jane@co.com', userName: 'Jane', userArch: false }),
+    },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    process.env.JWT_SECRET = 'unit-test-jwt-secret';
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('POST /v1/login + GET /v1/me (#445)', () => {
+    test('400 on a missing password (schema)', async () => {
+        expect((await request(app).post('/v1/login').send({ userEmail: 'jane@co.com', companyId: 5 })).status).toBe(400);
+    });
+    test('400 on a bad email (schema)', async () => {
+        expect((await request(app).post('/v1/login').send({ userEmail: 'nope', password: 'x', companyId: 5 })).status).toBe(400);
+    });
+
+    // NOTE: the happy-path (200 + JWT) and wrong-password (401) branches
+    // exercise db.User.findOne, which this repo's api-test db mock cannot
+    // reach (it applies to ESM importers but not the controller's CJS
+    // require — every other api test only asserts pre-db 4xx). That
+    // credential compose (findOne → verifyPassword → jwt.sign) is instead
+    // covered by the jwt (#445) and password (#444) unit tests plus the
+    // in-repo controller repro; here we cover the boundary behavior.
+
+    test('GET /v1/me 401 without a token', async () => {
+        expect((await request(app).get('/v1/me')).status).toBe(401);
+    });
+    test('GET /v1/me 401 with a garbage token', async () => {
+        expect((await request(app).get('/v1/me').set('Authorization', 'Bearer not.a.jwt')).status).toBe(401);
+    });
+
+    test('503 when JWT_SECRET is unset', async () => {
+        const saved = process.env.JWT_SECRET;
+        delete process.env.JWT_SECRET;
+        try {
+            const res = await request(app).post('/v1/login').send({ userEmail: 'jane@co.com', password: RIGHT, companyId: 5 });
+            expect(res.status).toBe(503);
+        } finally {
+            process.env.JWT_SECRET = saved;
+        }
+    });
+});

--- a/tests/unit/jwt.test.js
+++ b/tests/unit/jwt.test.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { sign, verify } from '../../app/services/jwt.js';
+
+const SECRET = 'unit-test-secret';
+
+describe('jwt (#445)', () => {
+    test('sign → verify round-trips the payload and adds iat/exp', () => {
+        const token = sign({ sub: 42, userCompId: 7 }, SECRET, 3600);
+        expect(token.split('.')).toHaveLength(3);
+        const payload = verify(token, SECRET);
+        expect(payload.sub).toBe(42);
+        expect(payload.userCompId).toBe(7);
+        expect(typeof payload.iat).toBe('number');
+        expect(payload.exp).toBeGreaterThan(payload.iat);
+    });
+
+    test('verify rejects a wrong secret', () => {
+        const token = sign({ sub: 1 }, SECRET, 3600);
+        expect(verify(token, 'different-secret')).toBeNull();
+    });
+
+    test('verify rejects a tampered payload', () => {
+        const token = sign({ sub: 1 }, SECRET, 3600);
+        const parts = token.split('.');
+        const forged = Buffer.from(JSON.stringify({ sub: 999, exp: 9999999999 })).toString('base64url');
+        expect(verify(`${parts[0]}.${forged}.${parts[2]}`, SECRET)).toBeNull();
+    });
+
+    test('verify rejects an expired token', () => {
+        const token = sign({ sub: 1 }, SECRET, -10); // already expired
+        expect(verify(token, SECRET)).toBeNull();
+    });
+
+    test('verify rejects malformed input', () => {
+        expect(verify('not.a.jwt', SECRET)).toBeNull();
+        expect(verify('', SECRET)).toBeNull();
+        expect(verify(null, SECRET)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Users can sign in — verify email + password, get a token, and identify themselves with it.

Closes #445.

## Changes

- **`POST /v1/login`** `{ userEmail, password, companyId }` — verifies the user's password (scrypt, from #444) within a company and returns a short-lived (**12h**) **HS256 JWT** plus the user.
- **`GET /v1/me`** — returns the signed-in user for an `Authorization: Bearer <jwt>` header.
- **`jwt.js`** — minimal HS256 tokens via Node's built-in crypto HMAC (**no dependency**): compact `header.payload.signature`, **constant-time** verify, `exp` enforced. Pure and unit-tested.
- Signing is keyed by the **`JWT_SECRET`** env var; when it's unset, sign-in returns **503** (fails safe — no login without a configured secret).
- **Anti-enumeration**: bad credentials always return a generic **401**, never revealing whether the email exists.

## Design

A **second, optional auth path** that sits beside the existing API-key auth without changing it. Password reset (#446) — using the mailer from #68 — is the next PR.

## Verification

`npm run lint` clean; `npm test` → **1334 passing** (jwt: sign/verify round-trip, wrong-secret, tampered-payload, expiry, malformed; login: schema, 503-when-unconfigured, `/me` missing/garbage-token 401s). The credential compose (`findOne → verifyPassword → sign`) reaches `db.User`, which this repo's api-test db mock can't inject into the controller's CJS require — so it's covered by the `jwt` + `password` unit tests (and an in-repo controller repro) rather than an HTTP test. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/