### PR TITLE
feat(expenses): receipt attachment/upload (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Receipt attachment / upload** (#419). A new `Receipt` entity attached
+  to an expense (#416), migration `20260623000000`. Upload a file as
+  base64 JSON (`POST /v1/receipt`) — the bytes are stored in Postgres
+  (`bytea`), capped at 5 MB decoded, content-type whitelisted; the
+  effective upload size is governed by the `JSON_BODY_LIMIT` env var
+  (default 100kb). `GET /v1/receipt/{id}/download` streams the file;
+  `GET /v1/receipt/{id}` + `GET /v1/receipt/byexpense/{id}` return metadata
+  only (never the bytes); `DELETE` soft-deletes. Expense→company scoped
+  with secure-404. Self-contained (no object-store dependency); an S3
+  backend can drop in behind the controller later.
 - **Password reset** (#446). `POST /v1/password-reset/request` mints a
   one-time token, stores only its SHA-256 + a 1-hour expiry on the user
   (migration `20260622000000`), and emails the token via the mailer (#68);

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -76,6 +76,7 @@ db.RecurringInvoice = require('../models/recurringinvoice.model.js')(sequelize, 
 db.Webhook = require('../models/webhook.model.js')(sequelize, Sequelize);
 db.RateSchedule = require('../models/rateschedule.model.js')(sequelize, Sequelize);
 db.User = require('../models/user.model.js')(sequelize, Sequelize);
+db.Receipt = require('../models/receipt.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -233,5 +234,9 @@ db.RateSchedule.belongsTo(db.Company, { foreignKey: 'rschCompId', as: 'company' 
 // User → Company (userCompId): a person who signs in to a company (#444).
 db.Company.hasMany(db.User,   { foreignKey: 'userCompId', as: 'users' });
 db.User.belongsTo(db.Company, { foreignKey: 'userCompId', as: 'company' });
+
+// Receipt → Expense (rcptExpId): a file attached to an expense (#419).
+db.Expense.hasMany(db.Receipt,   { foreignKey: 'rcptExpId', as: 'receipts' });
+db.Receipt.belongsTo(db.Expense, { foreignKey: 'rcptExpId', as: 'expense' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1463,6 +1463,51 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/receipt': {
+            post: {
+                summary: 'Attach a base64 file to an expense (#419)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { expId: { type: 'integer' }, filename: { type: 'string' }, contentType: { type: 'string' }, dataBase64: { type: 'string' } }, required: ['expId', 'filename', 'contentType', 'dataBase64'] } } } },
+                responses: {
+                    201: { description: 'Attached (metadata; bytes not echoed)' },
+                    400: { description: 'Validation error / bad expense / too large' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
+        '/v1/receipt/byexpense/{id}': {
+            get: {
+                summary: "List an expense's receipts (metadata only)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found (paginated; no file bytes)' }, 404: { description: 'Expense not found / cross-tenant' } },
+            },
+        },
+        '/v1/receipt/{id}/download': {
+            get: {
+                summary: 'Download a receipt file',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: { description: 'The file (Content-Type + Content-Disposition attachment)', content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } },
+                    404: { description: 'Not found' },
+                },
+            },
+        },
+        '/v1/receipt/{id}': {
+            get: {
+                summary: 'Fetch receipt metadata (not the bytes)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a receipt',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/login': {
             post: {
                 summary: 'Sign in a user — returns a JWT (#445)',

--- a/app/controllers/receiptcontroller.js
+++ b/app/controllers/receiptcontroller.js
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { CONTENT_TYPES } = require('../schemas/receipt.schema.js');
+const Receipt = db.Receipt;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB decoded
+// Metadata only — rcptData (the bytes) is deliberately excluded.
+const SAFE_ATTRS = ['rcptId', 'rcptExpId', 'rcptCompId', 'rcptFilename', 'rcptContentType', 'rcptSize', 'rcptArch', 'createdAt', 'updatedAt'];
+
+/** Resolve the caller's company id (or null after responding). Master → null (any). */
+async function callerCompany(req, res) {
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (isMaster) return { isMaster: true, companyId: null };
+    const companyId = await GetCompanyId(req.get('authKey'));
+    if (companyId === -1) {
+        res.status(403).json({ message: "Invalid Authorization Key." });
+        return null;
+    }
+    return { isMaster: false, companyId };
+}
+
+/** Load a receipt and enforce the secure-404 company scope. `withData` includes the bytes. */
+async function findScoped(req, res, withData) {
+    let receipt;
+    try {
+        receipt = await Receipt.findByPk(req.params.id, withData ? undefined : { attributes: SAFE_ATTRS });
+    } catch (error) {
+        log.error({ err: error }, 'Receipt.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!receipt || receipt.rcptArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const scope = await callerCompany(req, res);
+    if (!scope) return null;
+    if (!scope.isMaster && receipt.rcptCompId !== scope.companyId) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    return receipt;
+}
+
+/** POST /v1/receipt — attach a base64 file to an expense. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const body = req.body || {};
+    const expId = Number(body.expId);
+    if (!Number.isInteger(expId) || expId <= 0) {
+        return res.status(400).json({ message: "expId is required and must be an integer." });
+    }
+
+    let expense;
+    try {
+        expense = await db.Expense.findByPk(expId, { attributes: ['expId', 'expCompId'] });
+    } catch (error) {
+        log.error({ err: error }, 'receipt create: Expense.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!expense || expense.expCompId == null) {
+        return res.status(400).json({ message: "expId must reference an expense." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== expense.expCompId) {
+            return res.status(403).json({ message: "Cannot attach a receipt to an expense in a company you do not belong to." });
+        }
+    }
+
+    if (!CONTENT_TYPES.includes(body.contentType)) {
+        return res.status(400).json({ message: "Unsupported contentType." });
+    }
+
+    // The schema already enforces base64 shape; Buffer.from is lenient.
+    const data = Buffer.from(String(body.dataBase64), 'base64');
+    if (data.length === 0) {
+        return res.status(400).json({ message: "Receipt file is empty." });
+    }
+    if (data.length > MAX_BYTES) {
+        return res.status(400).json({ message: "Receipt exceeds the maximum size (5 MB)." });
+    }
+
+    try {
+        const created = await Receipt.create({
+            rcptExpId: expId,
+            rcptCompId: expense.expCompId,
+            rcptFilename: body.filename,
+            rcptContentType: body.contentType,
+            rcptSize: data.length,
+            rcptData: data,
+            rcptArch: false,
+        });
+        return res.status(201).json({
+            message: "Receipt attached.",
+            receipt: {
+                rcptId: created.rcptId, rcptExpId: expId, rcptCompId: expense.expCompId,
+                rcptFilename: created.rcptFilename, rcptContentType: created.rcptContentType, rcptSize: created.rcptSize,
+            },
+        });
+    } catch (error) {
+        log.error({ err: error }, 'Receipt.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/receipt/:id — fetch receipt metadata (not the bytes). Secure-404. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const receipt = await findScoped(req, res, false);
+    if (!receipt) return undefined;
+    return res.status(200).json({ message: "Found.", receipt });
+};
+
+/** GET /v1/receipt/:id/download — stream the receipt file. Secure-404. */
+exports.download = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const receipt = await findScoped(req, res, true);
+    if (!receipt) return undefined;
+    const safeName = String(receipt.rcptFilename || 'receipt').replace(/["\r\n]/g, '');
+    res.setHeader('Content-Type', receipt.rcptContentType || 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${safeName}"`);
+    return res.status(200).send(receipt.rcptData);
+};
+
+/** GET /v1/receipt/byexpense/:id — list an expense's receipts (metadata). */
+exports.listByExpense = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const expId = Number(req.params.id);
+    if (!Number.isInteger(expId) || expId <= 0) {
+        return res.status(400).json({ message: "Invalid expense id." });
+    }
+
+    let expense;
+    try {
+        expense = await db.Expense.findByPk(expId, { attributes: ['expId', 'expCompId'] });
+    } catch (error) {
+        log.error({ err: error }, 'receipt listByExpense: Expense.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!expense) {
+        return res.status(404).json({ message: "Not found." });
+    }
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== expense.expCompId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Receipt.findAndCountAll({
+            where: { rcptExpId: expId },
+            attributes: SAFE_ATTRS,
+            limit,
+            offset,
+            order: [['rcptId', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, receipts: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Receipt.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/receipt/:id — soft-delete (sets rcptArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const receipt = await findScoped(req, res, false);
+    if (!receipt) return undefined;
+
+    try {
+        await receipt.update({ rcptArch: true });
+        return res.status(200).json({ message: "Archived.", id: receipt.rcptId });
+    } catch (error) {
+        log.error({ err: error }, 'Receipt archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260623000000-receipt.js
+++ b/app/migrations/20260623000000-receipt.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Receipt attachment/upload (#419). A Receipt stores a file (rcptData,
+// bytea) attached to an Expense (#416). Company-scoped via rcptCompId
+// (denormalized from the expense) for cheap scoping. Bytes live in
+// Postgres so the API is self-contained; an external object store (S3)
+// can drop in behind the controller later. New table in the increment
+// layer; no FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Receipt', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    rcptId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    rcptExpId: { type: Sequelize.INTEGER, allowNull: false },
+                    rcptCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    rcptFilename: { type: Sequelize.TEXT, allowNull: false },
+                    rcptContentType: { type: Sequelize.TEXT, allowNull: false },
+                    rcptSize: { type: Sequelize.INTEGER, allowNull: false },
+                    rcptData: { type: Sequelize.BLOB, allowNull: false },
+                    rcptArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'Receipt_expId_arch_idx', fields: ['rcptExpId', 'rcptArch'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'Receipt_compId_arch_idx', fields: ['rcptCompId', 'rcptArch'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/receipt.model.js
+++ b/app/models/receipt.model.js
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Receipt — a file attached to an Expense (#419). rcptData holds the raw
+ * bytes (bytea); it is large, so list/fetch endpoints select an explicit
+ * attribute set that EXCLUDES it — only the download endpoint reads it.
+ * Company-scoped via rcptCompId (denormalized from the expense).
+ * Soft-deletes via rcptArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Receipt = sequelize.define('Receipt', {
+        rcptId: {
+            field: 'rcptId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        rcptExpId: {
+            field: 'rcptExpId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rcptCompId: {
+            field: 'rcptCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rcptFilename: {
+            field: 'rcptFilename',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rcptContentType: {
+            field: 'rcptContentType',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rcptSize: {
+            field: 'rcptSize',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rcptData: {
+            field: 'rcptData',
+            type: Sequelize.BLOB,
+            allowNull: false,
+        },
+        rcptArch: {
+            field: 'rcptArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Receipt',
+        timestamps: true,
+        defaultScope: { where: { rcptArch: false } }
+    });
+
+    return Receipt;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -41,6 +41,7 @@ const notification = require('../controllers/notificationcontroller.js');
 const rateSchedule = require('../controllers/rateschedulecontroller.js');
 const user = require('../controllers/usercontroller.js');
 const authController = require('../controllers/authcontroller.js');
+const receipt = require('../controllers/receiptcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -72,6 +73,7 @@ const notificationSchemas = require('../schemas/notification.schema.js');
 const rateScheduleSchemas = require('../schemas/rateschedule.schema.js');
 const userSchemas = require('../schemas/user.schema.js');
 const authSchemas = require('../schemas/auth.schema.js');
+const receiptSchemas = require('../schemas/receipt.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -800,6 +802,35 @@ router.post(
     '/v1/password-reset/confirm',
     v.body(authSchemas.confirmResetBody),
     authController.confirmReset,
+);
+
+// v1 receipt routes (#419). Files attached to expenses; bytes in Postgres.
+// GET /:id/download streams the file; /byexpense/:id lists metadata.
+router.post(
+    '/v1/receipt',
+    v.body(receiptSchemas.createReceiptBody),
+    receipt.create,
+);
+router.get(
+    '/v1/receipt/byexpense/:id',
+    v.params(receiptSchemas.intIdParam),
+    v.query(receiptSchemas.listByExpenseQuery),
+    receipt.listByExpense,
+);
+router.get(
+    '/v1/receipt/:id/download',
+    v.params(receiptSchemas.intIdParam),
+    receipt.download,
+);
+router.get(
+    '/v1/receipt/:id',
+    v.params(receiptSchemas.intIdParam),
+    receipt.getById,
+);
+router.delete(
+    '/v1/receipt/:id',
+    v.params(receiptSchemas.intIdParam),
+    receipt.remove,
 );
 
 // v1 user-account routes (#444). Sign-in users, separate from API keys.

--- a/app/schemas/receipt.schema.js
+++ b/app/schemas/receipt.schema.js
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+// Receipt file types accepted by the upload endpoint.
+const CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/pdf'];
+
+/**
+ * POST /v1/receipt body (#419). The file is base64-encoded in JSON (the
+ * effective max size is governed by the JSON_BODY_LIMIT env var — default
+ * 100kb; raise it to accept larger uploads). The controller also caps the
+ * DECODED size.
+ */
+const createReceiptBody = z.object({
+    expId: z.coerce.number().int().positive(),
+    filename: z.string().min(1).max(255),
+    contentType: z.enum(CONTENT_TYPES),
+    dataBase64: z.string().min(1).max(10_000_000).regex(/^[A-Za-z0-9+/]+={0,2}$/, 'Must be base64.'),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: expId, filename, contentType, dataBase64.',
+});
+
+const listByExpenseQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createReceiptBody,
+    listByExpenseQuery,
+    CONTENT_TYPES,
+};

--- a/tests/api/receipt.test.js
+++ b/tests/api/receipt.test.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/receipt (#419) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, User: {},
+    Receipt: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+// A tiny valid base64 PNG-ish blob.
+const B64 = Buffer.from('hello-receipt').toString('base64');
+const good = { expId: 1, filename: 'lunch.png', contentType: 'image/png', dataBase64: B64 };
+
+describe('Receipt auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/receipt').send(good)).status).toBe(403);
+    });
+    test('POST 400 on missing expId (schema)', async () => {
+        expect((await request(app).post('/v1/receipt').set('authKey', 'k').send({ filename: 'x.png', contentType: 'image/png', dataBase64: B64 })).status).toBe(400);
+    });
+    test('POST 400 on an unsupported contentType (schema enum)', async () => {
+        expect((await request(app).post('/v1/receipt').set('authKey', 'k').send({ ...good, contentType: 'application/x-msdownload' })).status).toBe(400);
+    });
+    test('POST 400 on non-base64 data (schema)', async () => {
+        expect((await request(app).post('/v1/receipt').set('authKey', 'k').send({ ...good, dataBase64: 'not base64!!' })).status).toBe(400);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/receipt/1')).status).toBe(403);
+    });
+    test('GET /:id/download 403 without authKey', async () => {
+        expect((await request(app).get('/v1/receipt/1/download')).status).toBe(403);
+    });
+    test('GET /byexpense/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/receipt/byexpense/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,21 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('Receipt table exists with an expense include (#419)', async () => {
+        if (!connected) return;
+        const rows = await db.Receipt.findAll({
+            attributes: ['rcptId', 'rcptExpId', 'rcptCompId', 'rcptFilename', 'rcptContentType', 'rcptSize'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withExpense = await db.Receipt.findAll({
+            attributes: ['rcptId'],
+            limit: 1,
+            include: [{ model: db.Expense, as: 'expense', required: false }],
+        });
+        expect(Array.isArray(withExpense)).toBe(true);
+    });
+
     test('User table exists with a company include (#444)', async () => {
         if (!connected) return;
         const rows = await db.User.findAll({


### PR DESCRIPTION
## Summary

Attach a receipt file to an expense, and download it back — self-contained, no object store required.

Closes #419.

## Changes

- **Migration `20260623000000`** — a `Receipt` table (`rcptExpId`, `rcptCompId`, `rcptFilename`, `rcptContentType`, `rcptSize`, `rcptData` **bytea**, `rcptArch`) + expense/company indexes.
- **`POST /v1/receipt`** `{ expId, filename, contentType, dataBase64 }` — uploads a file (base64 in JSON) attached to an expense. Bytes are stored **in Postgres**, so the API is self-contained. Guards: **5 MB** decoded cap, content-type **whitelist** (`png/jpeg/gif/webp/pdf`), and the effective request size is governed by the existing **`JSON_BODY_LIMIT`** env var (default 100kb — raise it to accept larger receipts).
- **`GET /v1/receipt/{id}/download`** — streams the file with `Content-Type` + `Content-Disposition`.
- **`GET /v1/receipt/{id}`** and **`GET /v1/receipt/byexpense/{id}`** — metadata only; the bytes column is deliberately **excluded** from these queries.
- **`DELETE /v1/receipt/{id}`** — soft-delete. Everything is **expense→company scoped** with secure-404.

## Design (backend-pluggable)

Bytes-in-Postgres keeps this dependency-free and persistent. The read/write is isolated in the controller, so swapping in an **object store (S3 + presigned URLs)** later is a contained change — the same "self-contained now, backend pluggable" pattern as the mailer (#68).

## Verification

`npm run lint` clean; `npm test` → **1362 passing** (route auth; schema: required `expId`, content-type enum, base64 shape; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/