### PR TITLE
feat(reporting): scheduled report delivery (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Scheduled report delivery** (#57). A new company-scoped
+  `ReportSchedule` entity (report, recipient, cadence, next-run),
+  migration `20260624000000`. Full REST on `/v1/reportschedule` (create,
+  `bycompany` list, get/patch/delete) plus `GET /due` (schedules due ≤
+  today) and `POST /{id}/run` which **renders the report** (revenue
+  summary via `report-revenue.js`), **emails it** through the mailer
+  (#68), then advances `rptschNextRun` by the cadence (via the #425
+  engine). Pure `report-email.js` formatter. First v2.0 item — ties
+  together the reporting, mail, and cadence subsystems.
 - **Receipt attachment / upload** (#419). A new `Receipt` entity attached
   to an expense (#416), migration `20260623000000`. Upload a file as
   base64 JSON (`POST /v1/receipt`) — the bytes are stored in Postgres

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -77,6 +77,7 @@ db.Webhook = require('../models/webhook.model.js')(sequelize, Sequelize);
 db.RateSchedule = require('../models/rateschedule.model.js')(sequelize, Sequelize);
 db.User = require('../models/user.model.js')(sequelize, Sequelize);
 db.Receipt = require('../models/receipt.model.js')(sequelize, Sequelize);
+db.ReportSchedule = require('../models/reportschedule.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -238,5 +239,9 @@ db.User.belongsTo(db.Company, { foreignKey: 'userCompId', as: 'company' });
 // Receipt → Expense (rcptExpId): a file attached to an expense (#419).
 db.Expense.hasMany(db.Receipt,   { foreignKey: 'rcptExpId', as: 'receipts' });
 db.Receipt.belongsTo(db.Expense, { foreignKey: 'rcptExpId', as: 'expense' });
+
+// ReportSchedule → Company (rptschCompId): scheduled report delivery (#57).
+db.Company.hasMany(db.ReportSchedule,   { foreignKey: 'rptschCompId', as: 'reportSchedules' });
+db.ReportSchedule.belongsTo(db.Company, { foreignKey: 'rptschCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1463,6 +1463,61 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/reportschedule': {
+            post: {
+                summary: 'Schedule a report for email delivery (#57)',
+                security: [{ authKey: [] }],
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error; master keys must specify rptschCompId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/reportschedule/due': {
+            get: {
+                summary: 'List report schedules due (next run ≤ today)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                    { name: 'limit', in: 'query', schema: { type: 'integer' } },
+                    { name: 'offset', in: 'query', schema: { type: 'integer' } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 400: { description: 'Master keys must specify companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/reportschedule/bycompany/{id}': {
+            get: {
+                summary: "List a company's report schedules",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/reportschedule/{id}/run': {
+            post: {
+                summary: 'Render the report, email it, and advance the schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Delivered (returns previousRun + nextRun)' }, 404: { description: 'Not found' }, 409: { description: 'Schedule is not active' } },
+            },
+        },
+        '/v1/reportschedule/{id}': {
+            get: {
+                summary: 'Fetch a report schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a report schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a report schedule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/receipt': {
             post: {
                 summary: 'Attach a base64 file to an expense (#419)',

--- a/app/controllers/reportschedulecontroller.js
+++ b/app/controllers/reportschedulecontroller.js
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const money = require('../services/money.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { advanceDate } = require('../services/recurring-schedule.js');
+const { buildRevenue } = require('../services/report-revenue.js');
+const { formatReport } = require('../services/report-email.js');
+const { sendMail } = require('../services/mailer.js');
+const ReportSchedule = db.ReportSchedule;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const ALLOWED_FIELDS_UPDATE = ['rptschReport', 'rptschTo', 'rptschCadence', 'rptschNextRun', 'rptschActive'];
+
+function todayISO() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+/** Load a schedule and enforce the secure-404 company scope. */
+async function findScoped(req, res) {
+    let sched;
+    try {
+        sched = await ReportSchedule.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!sched || sched.rptschArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || sched.rptschCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return sched;
+}
+
+/** POST /v1/reportschedule — schedule a report for delivery. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    let companyId;
+    if (!isMaster) {
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (body.rptschCompId !== undefined && Number(body.rptschCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot schedule a report for a company you do not belong to." });
+        }
+    } else {
+        companyId = Number(body.rptschCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify rptschCompId." });
+        }
+    }
+
+    try {
+        const created = await ReportSchedule.create({
+            rptschCompId: companyId,
+            rptschReport: body.rptschReport,
+            rptschTo: body.rptschTo,
+            rptschCadence: body.rptschCadence,
+            rptschNextRun: body.rptschNextRun,
+            rptschActive: true,
+            rptschArch: false,
+        });
+        return res.status(201).json({ message: "Report scheduled.", reportSchedule: created });
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/reportschedule/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+    return res.status(200).json({ message: "Found.", reportSchedule: sched });
+};
+
+/** GET /v1/reportschedule/bycompany/:id — list a company's schedules. */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await ReportSchedule.findAndCountAll({
+            where: { rptschCompId: targetCompanyId },
+            limit,
+            offset,
+            order: [['rptschNextRun', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, reportSchedules: rows });
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/reportschedule/due — active schedules due on/before today. */
+exports.listDue = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify companyId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const Op = db.Sequelize && db.Sequelize.Op;
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await ReportSchedule.findAndCountAll({
+            where: { rptschCompId: companyId, rptschActive: true, rptschNextRun: { [Op.lte]: todayISO() } },
+            limit,
+            offset,
+            order: [['rptschNextRun', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Report schedules due.", companyId, count, limit, offset, reportSchedules: rows });
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule due query failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** Build the revenue report for a company (same shape as GET /v1/report/revenue). */
+async function buildRevenueReport(companyId) {
+    const invoices = await db.Invoice.findAll({
+        where: { invArch: false },
+        include: [
+            {
+                model: db.Customer, as: 'customer', required: true,
+                where: { custCompId: companyId },
+                attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'],
+            },
+            { model: db.CustomerPayment, as: 'payments', required: false },
+        ],
+        order: [['invDate', 'ASC']],
+    });
+    const items = invoices.map((inv) => {
+        const c = inv.customer;
+        return {
+            custId: inv.invCustId,
+            custName: c ? (c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null) : null,
+            invDate: inv.invDate,
+            total: inv.invTotal,
+            collected: money.sum((inv.payments || []).map((p) => p.cpayAmount)),
+        };
+    });
+    return buildRevenue(items);
+}
+
+/**
+ * POST /v1/reportschedule/:id/run — render the report, email it, and
+ * advance the schedule by its cadence. 409 if inactive.
+ */
+exports.run = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    if (!sched.rptschActive) {
+        return res.status(409).json({ message: "Schedule is not active." });
+    }
+
+    let report;
+    let company;
+    try {
+        report = await buildRevenueReport(sched.rptschCompId);
+        company = await db.Company.findByPk(sched.rptschCompId, { attributes: ['compName'] });
+    } catch (error) {
+        log.error({ err: error }, 'report schedule run: build failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const { subject, text } = formatReport(sched.rptschReport, report, {
+        company: company ? company.compName : null,
+        generatedAt: todayISO(),
+    });
+
+    try {
+        await sendMail({ to: sched.rptschTo, subject, text });
+    } catch (error) {
+        log.error({ err: error }, 'report schedule run: sendMail failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const previousRun = sched.rptschNextRun;
+    const nextRun = advanceDate(previousRun, sched.rptschCadence);
+    if (!nextRun) {
+        log.error({ rptschId: sched.rptschId, cadence: sched.rptschCadence }, 'advanceDate returned null');
+        return res.status(500).json({ message: "Error!" });
+    }
+    try {
+        await sched.update({ rptschLastRun: previousRun, rptschNextRun: nextRun });
+    } catch (error) {
+        log.error({ err: error }, 'report schedule run: advance failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    return res.status(200).json({ message: "Report delivered.", to: sched.rptschTo, previousRun, nextRun });
+};
+
+/** PATCH /v1/reportschedule/:id — partial update. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ALLOWED_FIELDS_UPDATE) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await sched.update(updates);
+        return res.status(200).json({ message: "Updated.", reportSchedule: sched });
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/reportschedule/:id — soft-delete (sets rptschArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const sched = await findScoped(req, res);
+    if (!sched) return undefined;
+
+    try {
+        await sched.update({ rptschArch: true });
+        return res.status(200).json({ message: "Archived.", id: sched.rptschId });
+    } catch (error) {
+        log.error({ err: error }, 'ReportSchedule archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260624000000-report-schedule.js
+++ b/app/migrations/20260624000000-report-schedule.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Scheduled report delivery (#57). A ReportSchedule emails a report
+// (rptschReport) to rptschTo on a cadence; running it advances
+// rptschNextRun and stamps rptschLastRun. Company-scoped via rptschCompId.
+// New table in the increment layer; no FK constraints. setup/*.sql
+// untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'ReportSchedule', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    rptschId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    rptschCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    rptschReport: { type: Sequelize.TEXT, allowNull: false },
+                    rptschTo: { type: Sequelize.TEXT, allowNull: false },
+                    rptschCadence: { type: Sequelize.TEXT, allowNull: false },
+                    rptschNextRun: { type: Sequelize.DATEONLY, allowNull: false },
+                    rptschLastRun: { type: Sequelize.DATEONLY, allowNull: true },
+                    rptschActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+                    rptschArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'ReportSchedule_compId_arch_idx', fields: ['rptschCompId', 'rptschArch'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'ReportSchedule_due_idx', fields: ['rptschNextRun', 'rptschActive'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/reportschedule.model.js
+++ b/app/models/reportschedule.model.js
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * ReportSchedule — "email <report> to <rptschTo> every <cadence>" (#57).
+ * Running it renders the report, emails it, then advances rptschNextRun
+ * by the cadence (reusing recurring-schedule.js) and stamps rptschLastRun.
+ * Company-scoped via rptschCompId. Soft-deletes via rptschArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const ReportSchedule = sequelize.define('ReportSchedule', {
+        rptschId: {
+            field: 'rptschId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        rptschCompId: {
+            field: 'rptschCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rptschReport: {
+            field: 'rptschReport',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rptschTo: {
+            field: 'rptschTo',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rptschCadence: {
+            field: 'rptschCadence',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        rptschNextRun: {
+            field: 'rptschNextRun',
+            type: Sequelize.DATEONLY,
+            allowNull: false,
+        },
+        rptschLastRun: {
+            field: 'rptschLastRun',
+            type: Sequelize.DATEONLY,
+        },
+        rptschActive: {
+            field: 'rptschActive',
+            type: Sequelize.BOOLEAN,
+            defaultValue: true,
+        },
+        rptschArch: {
+            field: 'rptschArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'ReportSchedule',
+        timestamps: true,
+        defaultScope: { where: { rptschArch: false } }
+    });
+
+    return ReportSchedule;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -42,6 +42,7 @@ const rateSchedule = require('../controllers/rateschedulecontroller.js');
 const user = require('../controllers/usercontroller.js');
 const authController = require('../controllers/authcontroller.js');
 const receipt = require('../controllers/receiptcontroller.js');
+const reportSchedule = require('../controllers/reportschedulecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -74,6 +75,7 @@ const rateScheduleSchemas = require('../schemas/rateschedule.schema.js');
 const userSchemas = require('../schemas/user.schema.js');
 const authSchemas = require('../schemas/auth.schema.js');
 const receiptSchemas = require('../schemas/receipt.schema.js');
+const reportScheduleSchemas = require('../schemas/reportschedule.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -802,6 +804,46 @@ router.post(
     '/v1/password-reset/confirm',
     v.body(authSchemas.confirmResetBody),
     authController.confirmReset,
+);
+
+// v1 report-schedule routes (scheduled report delivery, #57).
+// GET /due is declared before GET /:id so "due" isn't parsed as an id.
+router.post(
+    '/v1/reportschedule',
+    v.body(reportScheduleSchemas.createReportScheduleBody),
+    reportSchedule.create,
+);
+router.get(
+    '/v1/reportschedule/due',
+    v.query(reportScheduleSchemas.dueQuery),
+    reportSchedule.listDue,
+);
+router.get(
+    '/v1/reportschedule/bycompany/:id',
+    v.params(reportScheduleSchemas.intIdParam),
+    v.query(reportScheduleSchemas.listByCompanyQuery),
+    reportSchedule.listByCompany,
+);
+router.post(
+    '/v1/reportschedule/:id/run',
+    v.params(reportScheduleSchemas.intIdParam),
+    reportSchedule.run,
+);
+router.get(
+    '/v1/reportschedule/:id',
+    v.params(reportScheduleSchemas.intIdParam),
+    reportSchedule.getById,
+);
+router.patch(
+    '/v1/reportschedule/:id',
+    v.params(reportScheduleSchemas.intIdParam),
+    v.body(reportScheduleSchemas.updateReportScheduleBody),
+    reportSchedule.update,
+);
+router.delete(
+    '/v1/reportschedule/:id',
+    v.params(reportScheduleSchemas.intIdParam),
+    reportSchedule.remove,
 );
 
 // v1 receipt routes (#419). Files attached to expenses; bytes in Postgres.

--- a/app/schemas/reportschedule.schema.js
+++ b/app/schemas/reportschedule.schema.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+const { REPORTS } = require('../services/report-email.js');
+const { CADENCES } = require('../services/recurring-schedule.js');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+
+/** POST /v1/reportschedule body (#57). rptschCompId optional (non-master defaults to own; master required). */
+const createReportScheduleBody = z.object({
+    rptschReport: z.enum(REPORTS),
+    rptschTo: z.string().email().max(320),
+    rptschCadence: z.enum(CADENCES),
+    rptschNextRun: isoDate,
+    rptschCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: rptschReport, rptschTo, rptschCadence, rptschNextRun, rptschCompId.',
+});
+
+/** PATCH /v1/reportschedule/:id — rptschCompId is not patchable. */
+const updateReportScheduleBody = z.object({
+    rptschReport: z.enum(REPORTS).optional(),
+    rptschTo: z.string().email().max(320).optional(),
+    rptschCadence: z.enum(CADENCES).optional(),
+    rptschNextRun: isoDate.optional(),
+    rptschActive: z.boolean().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: rptschReport, rptschTo, rptschCadence, rptschNextRun, rptschActive.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+/** GET /v1/reportschedule/due query. companyId required for master keys. */
+const dueQuery = z.object({
+    companyId: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: companyId, limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createReportScheduleBody,
+    updateReportScheduleBody,
+    listByCompanyQuery,
+    dueQuery,
+};

--- a/app/services/report-email.js
+++ b/app/services/report-email.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * report-email.js — format a report as an email subject + body for
+ * scheduled delivery (#57). Currently the revenue summary. PURE: takes a
+ * built report object (from report-revenue.js) and returns { subject,
+ * text }. No DB, no transport; money via money.js.
+ */
+
+const money = require('./money.js');
+
+const REPORTS = ['revenue'];
+
+const fmt = (n) => money.toFixedString(n == null ? 0 : n);
+
+/** @param report the buildRevenue() output. @param opts { company?, generatedAt? } */
+function formatRevenueText(report, opts = {}) {
+    const r = report || {};
+    const lines = [];
+    lines.push(`Revenue summary${opts.company ? ' for ' + opts.company : ''}${opts.generatedAt ? ' (as of ' + opts.generatedAt + ')' : ''}:`);
+    lines.push('');
+    lines.push(`Invoices:            ${r.invoiceCount || 0}`);
+    lines.push(`Revenue (invoiced):  ${fmt(r.totalRevenue)}`);
+    lines.push(`Collected:           ${fmt(r.totalCollected)}`);
+    lines.push(`Outstanding:         ${fmt(r.totalOutstanding)}`);
+
+    const byCust = Array.isArray(r.byCustomer) ? r.byCustomer.slice(0, 10) : [];
+    if (byCust.length) {
+        lines.push('');
+        lines.push('By customer:');
+        for (const c of byCust) {
+            lines.push(`  - ${c.custName || 'Unknown'}: revenue ${fmt(c.revenue)}, outstanding ${fmt(c.outstanding)}`);
+        }
+    }
+
+    return {
+        subject: `Revenue report${opts.company ? ' — ' + opts.company : ''}`,
+        text: lines.join('\n'),
+    };
+}
+
+/** Dispatch a report name → { subject, text }. */
+function formatReport(reportName, report, opts) {
+    if (reportName === 'revenue') return formatRevenueText(report, opts);
+    return { subject: 'Report', text: 'Unsupported report.' };
+}
+
+module.exports = { REPORTS, formatRevenueText, formatReport };

--- a/tests/api/reportschedule.test.js
+++ b/tests/api/reportschedule.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/reportschedule (#57) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, User: {}, Receipt: {},
+    ReportSchedule: { findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { rptschReport: 'revenue', rptschTo: 'boss@co.com', rptschCadence: 'monthly', rptschNextRun: '2026-02-01' };
+
+describe('ReportSchedule auth + schema contract', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/reportschedule').send(good)).status).toBe(403);
+    });
+    test('POST 400 on missing rptschTo (schema)', async () => {
+        expect((await request(app).post('/v1/reportschedule').set('authKey', 'k').send({ rptschReport: 'revenue', rptschCadence: 'monthly', rptschNextRun: '2026-02-01' })).status).toBe(400);
+    });
+    test('POST 400 on an invalid report (schema enum)', async () => {
+        expect((await request(app).post('/v1/reportschedule').set('authKey', 'k').send({ ...good, rptschReport: 'made-up' })).status).toBe(400);
+    });
+    test('POST 400 on an invalid cadence (schema enum)', async () => {
+        expect((await request(app).post('/v1/reportschedule').set('authKey', 'k').send({ ...good, rptschCadence: 'hourly' })).status).toBe(400);
+    });
+    test('GET /due 403 without authKey', async () => {
+        expect((await request(app).get('/v1/reportschedule/due')).status).toBe(403);
+    });
+    test('POST /:id/run 403 without authKey', async () => {
+        expect((await request(app).post('/v1/reportschedule/1/run')).status).toBe(403);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/reportschedule/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('ReportSchedule table exists with a company include (#57)', async () => {
+        if (!connected) return;
+        const rows = await db.ReportSchedule.findAll({
+            attributes: ['rptschId', 'rptschCompId', 'rptschReport', 'rptschTo', 'rptschCadence', 'rptschNextRun'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.ReportSchedule.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('Receipt table exists with an expense include (#419)', async () => {
         if (!connected) return;
         const rows = await db.Receipt.findAll({

--- a/tests/unit/report-email.test.js
+++ b/tests/unit/report-email.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { formatRevenueText, formatReport, REPORTS } from '../../app/services/report-email.js';
+
+const REPORT = {
+    invoiceCount: 3,
+    totalRevenue: 12000,
+    totalCollected: 9000,
+    totalOutstanding: 3000,
+    byCustomer: [
+        { custName: 'Globex', revenue: 8000, collected: 6000, outstanding: 2000 },
+        { custName: 'Initech', revenue: 4000, collected: 3000, outstanding: 1000 },
+    ],
+};
+
+describe('report-email (#57)', () => {
+    test('formatRevenueText renders subject + totals + per-customer lines', () => {
+        const { subject, text } = formatRevenueText(REPORT, { company: 'Acme', generatedAt: '2026-04-01' });
+        expect(subject).toBe('Revenue report — Acme');
+        expect(text).toContain('Revenue summary for Acme (as of 2026-04-01)');
+        expect(text).toContain('Invoices:            3');
+        expect(text).toContain('Revenue (invoiced):  12000.00');
+        expect(text).toContain('Outstanding:         3000.00');
+        expect(text).toContain('- Globex: revenue 8000.00, outstanding 2000.00');
+    });
+
+    test('handles an empty report', () => {
+        const { text } = formatRevenueText({});
+        expect(text).toContain('Invoices:            0');
+        expect(text).toContain('Revenue (invoiced):  0.00');
+    });
+
+    test('formatReport dispatches known reports and REPORTS lists revenue', () => {
+        expect(REPORTS).toContain('revenue');
+        expect(formatReport('revenue', REPORT).subject).toBe('Revenue report');
+        expect(formatReport('unknown', REPORT).text).toBe('Unsupported report.');
+    });
+});


### PR DESCRIPTION
## Summary

Put a report on autopilot — "email the revenue summary to finance every month." The first v2.0 item, and a capstone that ties three existing subsystems together.

Closes #57.

## Changes

- **Migration `20260624000000`** — a company-scoped `ReportSchedule` table (`rptschReport`, `rptschTo`, `rptschCadence`, `rptschNextRun`, `rptschLastRun`, `rptschActive`, `rptschArch`) + a due-lookup index.
- **Full REST** on `/v1/reportschedule` — `POST`, `GET /bycompany/{id}`, `GET|PATCH|DELETE /{id}` — company-scoped with secure-404.
- **`GET /due`** — active schedules whose next run is **≤ today** (company-scoped; master keys pass `?companyId`).
- **`POST /{id}/run`** — the payoff: **renders** the report (revenue summary via `report-revenue.js`), **emails** it through the mailer (#68) as a formatted digest, then **advances** `rptschNextRun` by the cadence (the #425 engine) and stamps `rptschLastRun`. **409** if inactive.
- **`report-email.js`** — a pure report→`{subject, text}` formatter, unit-tested independently.

## How it composes

Reporting (#429) → email (#68) → cadence (#425): `run` is a thin orchestrator over three already-shipped, already-tested subsystems. Revenue is the first supported report; the `REPORTS` enum + `formatReport` dispatch make adding others (unbilled, profitability) a small step.

## Verification

`npm run lint` clean; `npm test` → **1381 passing** (formatter: totals + per-customer + empty + dispatch; route auth + report/cadence enum schema; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/