### PR TITLE
feat(auth): roles & permissions / RBAC (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Roles & permissions (RBAC)** (#448). Each user (#444) now carries a
+  `userRole` (owner/admin/manager/member/viewer; migration
+  `20260625000000`, defaults to `member`). A pure `rbac.js` defines the
+  cumulative permission matrix + `canAssignRole` (no privilege
+  escalation). `PATCH /v1/user/{id}/role` sets a role;
+  `GET /v1/user/{id}/permissions` returns a user's effective permissions;
+  `GET /v1/me` now includes the caller's role + permissions. The model is
+  surfaced for client/JWT enforcement; the API-key auth path is unchanged.
 - **Scheduled report delivery** (#57). A new company-scoped
   `ReportSchedule` entity (report, recipient, cadence, next-run),
   migration `20260624000000`. Full REST on `/v1/reportschedule` (create,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1650,6 +1650,23 @@ const spec = {
                 responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/user/{id}/role': {
+            patch: {
+                summary: "Set a user's RBAC role (#448)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { userRole: { type: 'string', enum: ['owner', 'admin', 'manager', 'member', 'viewer'] } }, required: ['userRole'] } } } },
+                responses: { 200: { description: 'Role updated' }, 400: { description: 'Invalid role' }, 404: { description: 'Not found' } },
+            },
+        },
+        '/v1/user/{id}/permissions': {
+            get: {
+                summary: "A user's role + effective permissions (#448)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found — {userId, userRole, permissions[]}' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/rateschedule': {
             post: {
                 summary: 'Create an effective-dated rate (#414)',

--- a/app/controllers/authcontroller.js
+++ b/app/controllers/authcontroller.js
@@ -14,6 +14,7 @@ const jwt = require('../services/jwt.js');
 const { verifyPassword, hashPassword } = require('../services/password.js');
 const { sendMail } = require('../services/mailer.js');
 const { generateToken, isValid } = require('../services/password-reset.js');
+const rbac = require('../services/rbac.js');
 
 const TOKEN_TTL_SEC = 12 * 60 * 60; // 12 hours
 
@@ -77,7 +78,7 @@ exports.me = async (req, res) => {
 
     let user;
     try {
-        user = await db.User.findByPk(payload.sub, { attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userArch'] });
+        user = await db.User.findByPk(payload.sub, { attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userRole', 'userArch'] });
     } catch (error) {
         log.error({ err: error }, 'me: User.findByPk failed');
         return res.status(500).json({ message: "Error!" });
@@ -85,7 +86,12 @@ exports.me = async (req, res) => {
     if (!user || user.userArch) {
         return res.status(401).json({ message: "Invalid or expired token." });
     }
-    return res.status(200).json({ message: "OK.", user: safeUser(user) });
+    return res.status(200).json({
+        message: "OK.",
+        user: safeUser(user),
+        userRole: user.userRole,
+        permissions: rbac.permissionsFor(user.userRole),
+    });
 };
 
 /**

--- a/app/controllers/usercontroller.js
+++ b/app/controllers/usercontroller.js
@@ -7,13 +7,14 @@ const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const { hashPassword } = require('../services/password.js');
+const rbac = require('../services/rbac.js');
 const User = db.User;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 
 // userPasswordHash is deliberately excluded — it is write-only.
-const SAFE_ATTRS = ['userId', 'userCompId', 'userEmail', 'userName', 'userArch', 'createdAt', 'updatedAt'];
+const SAFE_ATTRS = ['userId', 'userCompId', 'userEmail', 'userName', 'userRole', 'userArch', 'createdAt', 'updatedAt'];
 
 /** A response-safe view of a user row (never includes the password hash). */
 function safeView(u) {
@@ -22,6 +23,7 @@ function safeView(u) {
         userCompId: u.userCompId,
         userEmail: u.userEmail,
         userName: u.userName,
+        userRole: u.userRole,
         userArch: u.userArch,
     };
 }
@@ -103,6 +105,7 @@ exports.create = async (req, res) => {
         userCompId: companyId,
         userEmail: body.userEmail,
         userName: body.userName,
+        userRole: rbac.isRole(body.userRole) ? body.userRole : rbac.DEFAULT_ROLE,
         userPasswordHash: hashPassword(body.password),
         userArch: false,
     };
@@ -225,4 +228,41 @@ exports.remove = async (req, res) => {
         log.error({ err: error }, 'User archive failed');
         return res.status(500).json({ message: "Error!" });
     }
+};
+
+/** PATCH /v1/user/:id/role — set a user's RBAC role (#448). Company-scoped. */
+exports.setRole = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const body = req.body || {};
+    if (!rbac.isRole(body.userRole)) {
+        return res.status(400).json({ message: "Invalid role." });
+    }
+    const user = await findScoped(req, res);
+    if (!user) return undefined;
+
+    try {
+        await user.update({ userRole: body.userRole });
+        return res.status(200).json({ message: "Role updated.", user: safeView(user) });
+    } catch (error) {
+        log.error({ err: error }, 'User.setRole failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/user/:id/permissions — a user's role + effective permissions (#448). */
+exports.permissions = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const user = await findScoped(req, res);
+    if (!user) return undefined;
+
+    return res.status(200).json({
+        message: "Found.",
+        userId: user.userId,
+        userRole: user.userRole,
+        permissions: rbac.permissionsFor(user.userRole),
+    });
 };

--- a/app/migrations/20260625000000-user-role.js
+++ b/app/migrations/20260625000000-user-role.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Roles & permissions / RBAC (#448). userRole assigns each user (#444) an
+// RBAC role (owner/admin/manager/member/viewer); the permission matrix
+// lives in app/services/rbac.js. Existing rows default to 'member'.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const USER = { tableName: 'User', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(USER, 'userRole', {
+            type: Sequelize.TEXT,
+            allowNull: false,
+            defaultValue: 'member',
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(USER, 'userRole');
+    },
+};

--- a/app/models/user.model.js
+++ b/app/models/user.model.js
@@ -31,6 +31,13 @@ module.exports = (sequelize, Sequelize) => {
             field: 'userName',
             type: Sequelize.TEXT,
         },
+        userRole: {
+            field: 'userRole',
+            // RBAC role (#448): owner|admin|manager|member|viewer. The
+            // permission matrix lives in app/services/rbac.js.
+            type: Sequelize.TEXT,
+            defaultValue: 'member',
+        },
         userPasswordHash: {
             field: 'userPasswordHash',
             type: Sequelize.TEXT,

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -903,6 +903,18 @@ router.delete(
     v.params(userSchemas.intIdParam),
     user.remove,
 );
+// RBAC (#448): a user's role + effective permissions; set a user's role.
+router.get(
+    '/v1/user/:id/permissions',
+    v.params(userSchemas.intIdParam),
+    user.permissions,
+);
+router.patch(
+    '/v1/user/:id/role',
+    v.params(userSchemas.intIdParam),
+    v.body(userSchemas.setRoleBody),
+    user.setRole,
+);
 
 // v1 rate-schedule routes (effective-dated rates, #414).
 // GET /resolve is declared before GET /:id so "resolve" isn't parsed as an id.

--- a/app/schemas/user.schema.js
+++ b/app/schemas/user.schema.js
@@ -3,6 +3,7 @@
 "use strict";
 
 const { z } = require('zod');
+const { ROLES } = require('../services/rbac.js');
 
 const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
@@ -18,9 +19,17 @@ const createUserBody = z.object({
     userEmail: z.string().email().max(320),
     password: password,
     userName: z.string().min(1).max(255).optional(),
+    userRole: z.enum(ROLES).optional(),
     userCompId: z.coerce.number().int().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: userEmail, password, userName, userCompId.',
+    message: 'Unexpected field in body. Whitelist: userEmail, password, userName, userRole, userCompId.',
+});
+
+/** PATCH /v1/user/:id/role body (#448). */
+const setRoleBody = z.object({
+    userRole: z.enum(ROLES),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: userRole.',
 });
 
 /** PATCH /v1/user/:id — userCompId is not patchable; password optional (re-hash). */
@@ -43,5 +52,6 @@ module.exports = {
     intIdParam,
     createUserBody,
     updateUserBody,
+    setRoleBody,
     listByCompanyQuery,
 };

--- a/app/services/rbac.js
+++ b/app/services/rbac.js
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * rbac.js — the role/permission model for user accounts (#448). PURE: no
+ * DB, no I/O. Roles are ordered most→least privileged; each maps to a set
+ * of permission strings. The API-key auth path is unchanged; this model
+ * is assigned per-user (User.userRole) and surfaced via /v1/me and
+ * /v1/user/:id/permissions so a client (and, later, JWT-guarded routes)
+ * can enforce it.
+ */
+
+// Ordered highest privilege (index 0) → lowest.
+const ROLES = ['owner', 'admin', 'manager', 'member', 'viewer'];
+const DEFAULT_ROLE = 'member';
+
+// Cumulative capability tiers.
+const VIEWER = ['invoice:read', 'billing:read', 'time:read', 'report:read', 'user:read'];
+const MEMBER = VIEWER.concat(['time:write']);
+const MANAGER = MEMBER.concat(['invoice:write', 'invoice:send', 'billing:write']);
+const ADMIN = MANAGER.concat(['user:write', 'user:manage-roles']);
+const OWNER = ADMIN.concat(['company:manage']);
+
+const PERMISSIONS = {
+    owner: OWNER,
+    admin: ADMIN,
+    manager: MANAGER,
+    member: MEMBER,
+    viewer: VIEWER,
+};
+
+/** Is `role` a known role? */
+function isRole(role) {
+    return ROLES.includes(role);
+}
+
+/** Privilege rank (0 = highest). -1 for unknown roles. */
+function roleRank(role) {
+    return ROLES.indexOf(role);
+}
+
+/** The permission strings granted to `role` (empty for unknown roles). */
+function permissionsFor(role) {
+    return (PERMISSIONS[role] || []).slice();
+}
+
+/** Does `role` grant `permission`? */
+function hasPermission(role, permission) {
+    return permissionsFor(role).includes(permission);
+}
+
+/**
+ * May an actor with `actorRole` assign `targetRole` to someone? Requires
+ * the manage-roles permission AND that the target role is not more
+ * privileged than the actor's own (no privilege escalation).
+ */
+function canAssignRole(actorRole, targetRole) {
+    if (!isRole(targetRole) || !hasPermission(actorRole, 'user:manage-roles')) return false;
+    return roleRank(actorRole) <= roleRank(targetRole);
+}
+
+module.exports = {
+    ROLES,
+    DEFAULT_ROLE,
+    PERMISSIONS,
+    isRole,
+    roleRank,
+    permissionsFor,
+    hasPermission,
+    canAssignRole,
+};

--- a/tests/api/user-rbac.test.js
+++ b/tests/api/user-rbac.test.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for RBAC on users (#448) — role set + permissions.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, User: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('User RBAC contract (#448)', () => {
+    test('PATCH /:id/role 403 without authKey (valid role reaches controller)', async () => {
+        expect((await request(app).patch('/v1/user/1/role').send({ userRole: 'admin' })).status).toBe(403);
+    });
+    test('PATCH /:id/role 400 on an invalid role (schema enum)', async () => {
+        expect((await request(app).patch('/v1/user/1/role').set('authKey', 'k').send({ userRole: 'wizard' })).status).toBe(400);
+    });
+    test('PATCH /:id/role 400 on an unknown field (strict)', async () => {
+        expect((await request(app).patch('/v1/user/1/role').set('authKey', 'k').send({ userRole: 'admin', bogus: 1 })).status).toBe(400);
+    });
+    test('GET /:id/permissions 403 without authKey', async () => {
+        expect((await request(app).get('/v1/user/1/permissions')).status).toBe(403);
+    });
+    test('POST /v1/user 400 on an invalid userRole (schema enum)', async () => {
+        expect((await request(app).post('/v1/user').set('authKey', 'k').send({ userEmail: 'a@b.com', password: 'longenough1', userRole: 'root' })).status).toBe(400);
+    });
+    test('POST /v1/user 403 without authKey (valid body incl. userRole)', async () => {
+        expect((await request(app).post('/v1/user').send({ userEmail: 'a@b.com', password: 'longenough1', userRole: 'manager' })).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -247,7 +247,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
     test('User table exists with a company include (#444)', async () => {
         if (!connected) return;
         const rows = await db.User.findAll({
-            attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userArch', 'userResetTokenHash', 'userResetExpires'],
+            attributes: ['userId', 'userCompId', 'userEmail', 'userName', 'userRole', 'userArch', 'userResetTokenHash', 'userResetExpires'],
             limit: 1,
         });
         expect(Array.isArray(rows)).toBe(true);

--- a/tests/unit/rbac.test.js
+++ b/tests/unit/rbac.test.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { ROLES, DEFAULT_ROLE, isRole, roleRank, permissionsFor, hasPermission, canAssignRole } from '../../app/services/rbac.js';
+
+describe('rbac (#448)', () => {
+    test('ROLES ordered highest→lowest; default is member', () => {
+        expect(ROLES).toEqual(['owner', 'admin', 'manager', 'member', 'viewer']);
+        expect(DEFAULT_ROLE).toBe('member');
+        expect(roleRank('owner')).toBeLessThan(roleRank('viewer'));
+        expect(roleRank('nope')).toBe(-1);
+    });
+
+    test('isRole validates membership', () => {
+        expect(isRole('admin')).toBe(true);
+        expect(isRole('superuser')).toBe(false);
+    });
+
+    test('permissions are cumulative down the hierarchy', () => {
+        // Everything a viewer can do, a member (and up) can too.
+        for (const p of permissionsFor('viewer')) {
+            expect(hasPermission('member', p)).toBe(true);
+            expect(hasPermission('owner', p)).toBe(true);
+        }
+        expect(hasPermission('viewer', 'time:write')).toBe(false);
+        expect(hasPermission('member', 'time:write')).toBe(true);
+        expect(hasPermission('member', 'invoice:write')).toBe(false);
+        expect(hasPermission('manager', 'invoice:write')).toBe(true);
+        expect(hasPermission('manager', 'user:manage-roles')).toBe(false);
+        expect(hasPermission('admin', 'user:manage-roles')).toBe(true);
+        expect(hasPermission('admin', 'company:manage')).toBe(false);
+        expect(hasPermission('owner', 'company:manage')).toBe(true);
+    });
+
+    test('unknown role grants nothing', () => {
+        expect(permissionsFor('ghost')).toEqual([]);
+        expect(hasPermission('ghost', 'time:read')).toBe(false);
+    });
+
+    test('canAssignRole: needs manage-roles and no privilege escalation', () => {
+        // Admin can assign member/viewer/manager/admin, but NOT owner.
+        expect(canAssignRole('admin', 'member')).toBe(true);
+        expect(canAssignRole('admin', 'admin')).toBe(true);
+        expect(canAssignRole('admin', 'owner')).toBe(false);
+        // Owner can assign anything.
+        expect(canAssignRole('owner', 'owner')).toBe(true);
+        // Manager lacks manage-roles entirely.
+        expect(canAssignRole('manager', 'viewer')).toBe(false);
+        // Unknown target rejected.
+        expect(canAssignRole('owner', 'wizard')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Give users roles, and roles permissions — a real RBAC model layered onto the user accounts from the auth epic.

Closes #448.

## Changes

- **Migration `20260625000000`** — adds `User.userRole` (defaults existing rows to `member`).
- **`rbac.js`** — a **pure** permission model: five roles ordered by privilege (`owner > admin > manager > member > viewer`), a **cumulative** permission matrix (a manager can do everything a member can, and more), and `canAssignRole(actor, target)` which blocks **privilege escalation** (you can't grant a role above your own). Unit-tested independently.
- **`PATCH /v1/user/{id}/role`** `{ userRole }` — set a user's role (company-scoped, secure-404, role-validated).
- **`GET /v1/user/{id}/permissions`** — returns `{ userId, userRole, permissions[] }`.
- **`GET /v1/me`** now returns the signed-in user's **role + effective permissions**, and `POST /v1/user` accepts an optional `userRole`.

## Scope

The RBAC model is **assigned per-user and surfaced** (via `/me` and `/permissions`) so a client — and, in a follow-up, JWT-guarded routes — can enforce it. The existing **API-key auth path is unchanged**; this doesn't gate the key-authed endpoints, it establishes the role/permission foundation the auth epic (users → login → reset → **roles**) was building toward.

## Verification

`npm run lint` clean; `npm test` → **1396 passing** (rbac: cumulative hierarchy, unknown-role empties, `canAssignRole` escalation guard; route auth + role-enum schema + strict-whitelist; integration column). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/