### PR TITLE
feat(compliance): GDPR data export & erasure (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **GDPR data export & erasure** (#461). `GET /v1/gdpr/customer/{id}/export`
+  returns a portable JSON bundle of everything held about a customer
+  (record + invoices, jobs, expenses, time entries, payments, retainers,
+  recurring invoices, with counts) for data-portability requests.
+  `POST /v1/gdpr/customer/{id}/erase` performs right-to-erasure —
+  scrubbing the customer's PII (pure `gdpr.js` redaction map; NOT-NULL
+  columns get a placeholder, nullable ones null out) while **retaining
+  financial records** for accounting/tax, then archives the row. Both
+  company-scoped with secure-404; no new tables.
 - **Roles & permissions (RBAC)** (#448). Each user (#444) now carries a
   `userRole` (owner/admin/manager/member/viewer; migration
   `20260625000000`, defaults to `member`). A pure `rbac.js` defines the

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1667,6 +1667,28 @@ const spec = {
                 responses: { 200: { description: 'Found — {userId, userRole, permissions[]}' }, 404: { description: 'Not found' } },
             },
         },
+        '/v1/gdpr/customer/{id}/export': {
+            get: {
+                summary: "Export all data held about a customer — GDPR portability (#461)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: { description: 'Portable JSON: customer + invoices, jobs, expenses, time entries, payments, retainers, recurring invoices + counts' },
+                    404: { description: 'Not found / cross-tenant' },
+                },
+            },
+        },
+        '/v1/gdpr/customer/{id}/erase': {
+            post: {
+                summary: "Erase a customer's personal data — GDPR right-to-erasure (#461)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: {
+                    200: { description: 'Personal data scrubbed (financial records retained); row archived' },
+                    404: { description: 'Not found / cross-tenant' },
+                },
+            },
+        },
         '/v1/rateschedule': {
             post: {
                 summary: 'Create an effective-dated rate (#414)',

--- a/app/controllers/gdprcontroller.js
+++ b/app/controllers/gdprcontroller.js
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { anonymizedValues } = require('../services/gdpr.js');
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/** Load a customer and enforce the secure-404 company scope. */
+async function findScopedCustomer(req, res) {
+    let customer;
+    try {
+        customer = await db.Customer.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'gdpr: Customer.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!customer || customer.custArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || customer.custCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return customer;
+}
+
+/**
+ * GET /v1/gdpr/customer/:id/export — a portable JSON export of everything
+ * held about a customer (data-portability). Company-scoped, secure-404.
+ */
+exports.exportCustomer = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const customer = await findScopedCustomer(req, res);
+    if (!customer) return undefined;
+
+    const custId = customer.custId;
+    let bundle;
+    try {
+        const [invoices, jobs, expenses, timeEntries, payments, retainers, recurringInvoices] = await Promise.all([
+            db.Invoice.findAll({ where: { invCustId: custId } }),
+            db.Job.findAll({ where: { jobCustId: custId } }),
+            db.Expense.findAll({ where: { expCustId: custId } }),
+            db.TimeEntry.findAll({ where: { teCustId: custId } }),
+            db.CustomerPayment.findAll({ where: { cpayCustId: custId } }),
+            db.Retainer.findAll({ where: { retCustId: custId } }),
+            db.RecurringInvoice.findAll({ where: { recinvCustId: custId } }),
+        ]);
+        bundle = { invoices, jobs, expenses, timeEntries, payments, retainers, recurringInvoices };
+    } catch (error) {
+        log.error({ err: error }, 'gdpr export: aggregation failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const counts = {};
+    for (const [k, v] of Object.entries(bundle)) counts[k] = v.length;
+
+    return res.status(200).json({
+        message: "GDPR data export.",
+        exportedAt: new Date().toISOString(),
+        customer,
+        ...bundle,
+        counts,
+    });
+};
+
+/**
+ * POST /v1/gdpr/customer/:id/erase — right-to-erasure: scrub the
+ * customer's personal data (financial records are retained) and archive
+ * the row. Company-scoped, secure-404.
+ */
+exports.eraseCustomer = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const customer = await findScopedCustomer(req, res);
+    if (!customer) return undefined;
+
+    try {
+        await customer.update({ ...anonymizedValues(), custArch: true });
+        return res.status(200).json({ message: "Customer personal data erased.", custId: customer.custId });
+    } catch (error) {
+        log.error({ err: error }, 'gdpr erase: Customer.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -43,6 +43,7 @@ const user = require('../controllers/usercontroller.js');
 const authController = require('../controllers/authcontroller.js');
 const receipt = require('../controllers/receiptcontroller.js');
 const reportSchedule = require('../controllers/reportschedulecontroller.js');
+const gdpr = require('../controllers/gdprcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -76,6 +77,7 @@ const userSchemas = require('../schemas/user.schema.js');
 const authSchemas = require('../schemas/auth.schema.js');
 const receiptSchemas = require('../schemas/receipt.schema.js');
 const reportScheduleSchemas = require('../schemas/reportschedule.schema.js');
+const gdprSchemas = require('../schemas/gdpr.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -914,6 +916,19 @@ router.patch(
     v.params(userSchemas.intIdParam),
     v.body(userSchemas.setRoleBody),
     user.setRole,
+);
+
+// v1 GDPR routes (#461): export a customer's data (portability); erase
+// scrubs personal data (financial records retained) and archives the row.
+router.get(
+    '/v1/gdpr/customer/:id/export',
+    v.params(gdprSchemas.intIdParam),
+    gdpr.exportCustomer,
+);
+router.post(
+    '/v1/gdpr/customer/:id/erase',
+    v.params(gdprSchemas.intIdParam),
+    gdpr.eraseCustomer,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/gdpr.schema.js
+++ b/app/schemas/gdpr.schema.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+module.exports = { intIdParam };

--- a/app/services/gdpr.js
+++ b/app/services/gdpr.js
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * gdpr.js — data-subject helpers for GDPR export/erase (#461). PURE: no
+ * DB, no I/O. `anonymizedValues()` returns the column→value map used to
+ * scrub a Customer's personal data on a right-to-erasure request, while
+ * financial records (invoices, payments) are retained for accounting/tax
+ * obligations. NOT-NULL columns get a placeholder; nullable ones null out.
+ */
+
+// Personal data on a Customer row.
+const PII_FIELDS = [
+    'custCompanyName', 'custFName', 'custLName',
+    'custAddress1', 'custAddress2', 'custCity', 'custState', 'custZip',
+    'custPhone', 'custEmail',
+];
+
+// These are text NOT NULL in the DB — they must get a placeholder, not null.
+const NON_NULL_PII = ['custCompanyName', 'custFName', 'custLName'];
+
+const PLACEHOLDER = '[erased]';
+
+/** The column→value map that scrubs a customer's PII. */
+function anonymizedValues() {
+    const out = {};
+    for (const field of PII_FIELDS) {
+        out[field] = NON_NULL_PII.includes(field) ? PLACEHOLDER : null;
+    }
+    return out;
+}
+
+module.exports = { PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues };

--- a/tests/api/gdpr.test.js
+++ b/tests/api/gdpr.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/gdpr (#461) — auth + param validation.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, User: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('GDPR export/erase contract (#461)', () => {
+    test('GET export 403 without authKey', async () => {
+        expect((await request(app).get('/v1/gdpr/customer/1/export')).status).toBe(403);
+    });
+    test('POST erase 403 without authKey', async () => {
+        expect((await request(app).post('/v1/gdpr/customer/1/erase')).status).toBe(403);
+    });
+    test('GET export 400 on a non-numeric id (schema)', async () => {
+        expect((await request(app).get('/v1/gdpr/customer/abc/export').set('authKey', 'k')).status).toBe(400);
+    });
+    test('POST erase 400 on a non-numeric id (schema)', async () => {
+        expect((await request(app).post('/v1/gdpr/customer/abc/erase').set('authKey', 'k')).status).toBe(400);
+    });
+});

--- a/tests/unit/gdpr.test.js
+++ b/tests/unit/gdpr.test.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues } from '../../app/services/gdpr.js';
+
+describe('gdpr (#461)', () => {
+    test('anonymizedValues covers every PII field and nothing else', () => {
+        const v = anonymizedValues();
+        expect(Object.keys(v).sort()).toEqual([...PII_FIELDS].sort());
+        // Financial / identity columns are untouched.
+        expect('custDefaultRate' in v).toBe(false);
+        expect('custCompId' in v).toBe(false);
+        expect('custId' in v).toBe(false);
+    });
+
+    test('NOT-NULL columns get the placeholder; nullable ones null out', () => {
+        const v = anonymizedValues();
+        for (const f of NON_NULL_PII) expect(v[f]).toBe(PLACEHOLDER);
+        expect(v.custEmail).toBeNull();
+        expect(v.custPhone).toBeNull();
+        expect(v.custAddress1).toBeNull();
+        expect(v.custZip).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

The two GDPR data-subject rights, as endpoints: **export everything** you hold about a customer, and **erase** their personal data on request.

Closes #461.

## Changes

- **`GET /v1/gdpr/customer/{id}/export`** — data portability. Returns a portable JSON bundle: the customer record plus their **invoices, jobs, expenses, time entries, payments, retainers, and recurring invoices** (aggregated in parallel), with per-collection counts.
- **`POST /v1/gdpr/customer/{id}/erase`** — right to erasure. Scrubs the customer's **PII** (company name, names, address, phone, email) and archives the row — while **retaining financial records** (invoices, payments) as accounting/tax law requires.
- **`gdpr.js`** — a **pure** redaction map: NOT-NULL text columns get a `[erased]` placeholder, nullable ones null out; non-personal columns (rate, company id) are untouched. Unit-tested.

Both endpoints are **company-scoped with secure-404**, and this ships with **no new tables** — it's a service + controller over the existing entities.

## Design

Erasure **anonymizes rather than hard-deletes** so referential integrity and the financial audit trail survive — the standard reconciliation of GDPR erasure with retention obligations. A company-wide account export is a natural follow-up.

## Verification

`npm run lint` clean; `npm test` → **1408 passing** (redaction map: full PII coverage, placeholder-vs-null, financial columns untouched; route auth + id-param validation). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/