### PR TITLE
feat(integrations): payroll export (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Payroll export** (#456). `GET /v1/payroll/export` produces a
+  payroll-ready **CSV** of completed worker hours over a pay period
+  (`from`/`to`) — per worker: total / billable / non-billable hours and a
+  labor-cost total (hours × `workerCostRate`, exact money) — reusing the
+  OWASP formula-injection-safe cell escaper. `GET /v1/payroll/summary`
+  returns the same aggregation as JSON. Pure `payroll.js` aggregator;
+  company-scoped; no new tables.
 - **GDPR data export & erasure** (#461). `GET /v1/gdpr/customer/{id}/export`
   returns a portable JSON bundle of everything held about a customer
   (record + invoices, jobs, expenses, time entries, payments, retainers,

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1689,6 +1689,34 @@ const spec = {
                 },
             },
         },
+        '/v1/payroll/summary': {
+            get: {
+                summary: 'Per-worker payroll totals for a pay period, as JSON (#456)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                ],
+                responses: { 200: { description: 'Payroll summary — rows (hours + labor cost per worker) + totals' }, 400: { description: 'Missing from/to; master keys must specify companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/payroll/export': {
+            get: {
+                summary: 'Per-worker payroll totals for a pay period, as a payroll-ready CSV (#456)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                ],
+                responses: {
+                    200: { description: 'CSV (Content-Disposition attachment); OWASP formula-injection safe', content: { 'text/csv': { schema: { type: 'string' } } } },
+                    400: { description: 'Missing from/to; master keys must specify companyId' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/rateschedule': {
             post: {
                 summary: 'Create an effective-dated rate (#414)',

--- a/app/controllers/payrollcontroller.js
+++ b/app/controllers/payrollcontroller.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { escapeCsvCell } = require('./_csv-escape.js');
+const { buildPayroll } = require('../services/payroll.js');
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/** Resolve the target company (or null after responding). Master keys pass ?companyId. */
+async function resolveCompany(req, res) {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        res.status(403).json({ message: "Authorization key not sent." });
+        return null;
+    }
+    const isMaster = await IsMaster(authKey);
+    if (isMaster) {
+        const companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            res.status(400).json({ message: "Master-key requests must specify companyId." });
+            return null;
+        }
+        return companyId;
+    }
+    const companyId = await GetCompanyId(authKey);
+    if (companyId === -1) {
+        res.status(403).json({ message: "Invalid Authorization Key." });
+        return null;
+    }
+    return companyId;
+}
+
+/** Aggregate completed time entries + workers for a company over [from, to]. */
+async function aggregate(companyId, from, to) {
+    const Op = db.Sequelize.Op;
+    const [entries, workers] = await Promise.all([
+        db.TimeEntry.findAll({
+            where: {
+                teCompId: companyId,
+                teArch: false,
+                teEndedAt: { [Op.ne]: null },
+                teStartedAt: { [Op.gte]: `${from}T00:00:00.000Z`, [Op.lte]: `${to}T23:59:59.999Z` },
+            },
+            attributes: ['teWorkerId', 'teMinutes', 'teBillable'],
+        }),
+        db.Worker.findAll({
+            where: { workerCompId: companyId },
+            attributes: ['workerId', 'workerFName', 'workerLName', 'workerCostRate'],
+        }),
+    ]);
+    return buildPayroll(entries, workers, { from, to });
+}
+
+/** GET /v1/payroll/summary — per-worker payroll totals as JSON. */
+exports.summary = async (req, res) => {
+    const companyId = await resolveCompany(req, res);
+    if (companyId === null) return undefined;
+    const { from, to } = req.query;
+    try {
+        const payroll = await aggregate(companyId, from, to);
+        return res.status(200).json({ message: "Payroll summary.", companyId, ...payroll });
+    } catch (error) {
+        log.error({ err: error }, 'payroll summary failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+const CSV_FIELDS = [
+    ['workerId', 'Worker ID'],
+    ['workerName', 'Worker Name'],
+    ['periodStart', 'Period Start'],
+    ['periodEnd', 'Period End'],
+    ['totalHours', 'Total Hours'],
+    ['billableHours', 'Billable Hours'],
+    ['nonBillableHours', 'Non-Billable Hours'],
+    ['costRate', 'Cost Rate'],
+    ['costTotal', 'Labor Cost'],
+];
+
+/** GET /v1/payroll/export — per-worker payroll totals as a payroll-ready CSV. */
+exports.exportCsv = async (req, res) => {
+    const companyId = await resolveCompany(req, res);
+    if (companyId === null) return undefined;
+    const { from, to } = req.query;
+
+    let payroll;
+    try {
+        payroll = await aggregate(companyId, from, to);
+    } catch (error) {
+        log.error({ err: error }, 'payroll export failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const lines = [];
+    lines.push(CSV_FIELDS.map(([, header]) => escapeCsvCell(header)).join(','));
+    for (const r of payroll.rows) {
+        const row = { ...r, periodStart: payroll.periodStart, periodEnd: payroll.periodEnd };
+        lines.push(CSV_FIELDS.map(([key]) => escapeCsvCell(row[key])).join(','));
+    }
+    const body = `${lines.join('\r\n')}\r\n`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="payroll-company-${companyId}-${from}_${to}.csv"`);
+    return res.status(200).send(body);
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -44,6 +44,7 @@ const authController = require('../controllers/authcontroller.js');
 const receipt = require('../controllers/receiptcontroller.js');
 const reportSchedule = require('../controllers/reportschedulecontroller.js');
 const gdpr = require('../controllers/gdprcontroller.js');
+const payroll = require('../controllers/payrollcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -78,6 +79,7 @@ const authSchemas = require('../schemas/auth.schema.js');
 const receiptSchemas = require('../schemas/receipt.schema.js');
 const reportScheduleSchemas = require('../schemas/reportschedule.schema.js');
 const gdprSchemas = require('../schemas/gdpr.schema.js');
+const payrollSchemas = require('../schemas/payroll.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -929,6 +931,19 @@ router.post(
     '/v1/gdpr/customer/:id/erase',
     v.params(gdprSchemas.intIdParam),
     gdpr.eraseCustomer,
+);
+
+// v1 payroll routes (#456): aggregate completed worker hours over a pay
+// period as JSON (summary) or a payroll-ready CSV (export).
+router.get(
+    '/v1/payroll/summary',
+    v.query(payrollSchemas.payrollQuery),
+    payroll.summary,
+);
+router.get(
+    '/v1/payroll/export',
+    v.query(payrollSchemas.payrollQuery),
+    payroll.exportCsv,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/payroll.schema.js
+++ b/app/schemas/payroll.schema.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+
+/** GET /v1/payroll/export|summary query. from/to required; companyId for master keys. */
+const payrollQuery = z.object({
+    from: isoDate,
+    to: isoDate,
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: from, to, companyId.',
+});
+
+module.exports = { payrollQuery };

--- a/app/services/payroll.js
+++ b/app/services/payroll.js
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * payroll.js — aggregate completed time entries into per-worker hours for
+ * a pay period (#456). PURE: no DB, no I/O. Given entries (teWorkerId,
+ * teMinutes, teBillable) and workers (name + workerCostRate), produce one
+ * row per worker who logged time: total/billable/non-billable hours and a
+ * labor-cost total (hours × cost rate, exact money). Consumed by the CSV
+ * and JSON payroll endpoints.
+ */
+
+const money = require('./money.js');
+
+/** Minutes → hours, rounded to 2 decimals. */
+function hoursFromMinutes(min) {
+    return Math.round((Number(min || 0) / 60) * 100) / 100;
+}
+
+/**
+ * @param entries array of { teWorkerId, teMinutes, teBillable }.
+ * @param workers array of { workerId, workerFName, workerLName, workerCostRate }.
+ * @param opts { from, to } — echoed into the result as the period bounds.
+ */
+function buildPayroll(entries, workers, opts = {}) {
+    const wmap = new Map();
+    for (const w of workers || []) wmap.set(w.workerId, w);
+
+    const byId = new Map();
+    for (const e of entries || []) {
+        const wid = e.teWorkerId;
+        if (wid == null) continue;
+        if (!byId.has(wid)) byId.set(wid, { workerId: wid, totalMinutes: 0, billableMinutes: 0, nonBillableMinutes: 0 });
+        const agg = byId.get(wid);
+        const m = Number(e.teMinutes) || 0;
+        agg.totalMinutes += m;
+        if (e.teBillable) agg.billableMinutes += m;
+        else agg.nonBillableMinutes += m;
+    }
+
+    const rows = [];
+    let totalMinutes = 0;
+    let costTotal = 0;
+    for (const agg of byId.values()) {
+        const w = wmap.get(agg.workerId);
+        const name = w ? [w.workerFName, w.workerLName].filter(Boolean).join(' ') || null : null;
+        const costRate = (w && w.workerCostRate != null) ? Number(w.workerCostRate) : null;
+        const totalHours = hoursFromMinutes(agg.totalMinutes);
+        const rowCost = costRate != null ? money.multiply(totalHours, costRate) : null;
+        rows.push({
+            workerId: agg.workerId,
+            workerName: name,
+            totalMinutes: agg.totalMinutes,
+            totalHours,
+            billableHours: hoursFromMinutes(agg.billableMinutes),
+            nonBillableHours: hoursFromMinutes(agg.nonBillableMinutes),
+            costRate,
+            costTotal: rowCost,
+        });
+        totalMinutes += agg.totalMinutes;
+        if (rowCost != null) costTotal = money.add(costTotal, rowCost);
+    }
+    rows.sort((a, b) => a.workerId - b.workerId);
+
+    return {
+        periodStart: opts.from || null,
+        periodEnd: opts.to || null,
+        rows,
+        totals: {
+            workers: rows.length,
+            totalMinutes,
+            totalHours: hoursFromMinutes(totalMinutes),
+            costTotal,
+        },
+    };
+}
+
+module.exports = { buildPayroll, hoursFromMinutes };

--- a/tests/api/payroll.test.js
+++ b/tests/api/payroll.test.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/payroll (#456) — auth + query validation.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, User: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Payroll export contract (#456)', () => {
+    test('GET /summary 403 without authKey (valid query reaches controller)', async () => {
+        expect((await request(app).get('/v1/payroll/summary?from=2026-01-01&to=2026-01-15')).status).toBe(403);
+    });
+    test('GET /export 403 without authKey', async () => {
+        expect((await request(app).get('/v1/payroll/export?from=2026-01-01&to=2026-01-15')).status).toBe(403);
+    });
+    test('GET /summary 400 on a missing from (schema)', async () => {
+        expect((await request(app).get('/v1/payroll/summary?to=2026-01-15').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /export 400 on a malformed date (schema)', async () => {
+        expect((await request(app).get('/v1/payroll/export?from=01-01-2026&to=2026-01-15').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /summary 400 on an unknown query param (strict)', async () => {
+        expect((await request(app).get('/v1/payroll/summary?from=2026-01-01&to=2026-01-15&bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
+});

--- a/tests/unit/payroll.test.js
+++ b/tests/unit/payroll.test.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildPayroll, hoursFromMinutes } from '../../app/services/payroll.js';
+
+const WORKERS = [
+    { workerId: 1, workerFName: 'Jane', workerLName: 'Doe', workerCostRate: 100 },
+    { workerId: 2, workerFName: 'Bob', workerLName: 'Roe', workerCostRate: 80 },
+    { workerId: 3, workerFName: 'No', workerLName: 'Rate', workerCostRate: null },
+];
+const ENTRIES = [
+    { teWorkerId: 1, teMinutes: 60, teBillable: true },
+    { teWorkerId: 1, teMinutes: 30, teBillable: false },
+    { teWorkerId: 2, teMinutes: 120, teBillable: true },
+    { teWorkerId: 3, teMinutes: 45, teBillable: true },
+    { teWorkerId: null, teMinutes: 999, teBillable: true }, // ignored (no worker)
+];
+
+describe('payroll (#456)', () => {
+    test('hoursFromMinutes rounds to 2 decimals', () => {
+        expect(hoursFromMinutes(90)).toBe(1.5);
+        expect(hoursFromMinutes(45)).toBe(0.75);
+        expect(hoursFromMinutes(0)).toBe(0);
+    });
+
+    test('aggregates per worker with billable split and labor cost', () => {
+        const { rows, periodStart, periodEnd } = buildPayroll(ENTRIES, WORKERS, { from: '2026-01-01', to: '2026-01-15' });
+        expect(periodStart).toBe('2026-01-01');
+        expect(periodEnd).toBe('2026-01-15');
+        expect(rows).toHaveLength(3);
+
+        const jane = rows.find((r) => r.workerId === 1);
+        expect(jane.workerName).toBe('Jane Doe');
+        expect(jane.totalMinutes).toBe(90);
+        expect(jane.totalHours).toBe(1.5);
+        expect(jane.billableHours).toBe(1);
+        expect(jane.nonBillableHours).toBe(0.5);
+        expect(jane.costTotal).toBe(150);
+
+        const bob = rows.find((r) => r.workerId === 2);
+        expect(bob.totalHours).toBe(2);
+        expect(bob.costTotal).toBe(160);
+
+        // Worker with no cost rate → null cost, still counted for hours.
+        const norate = rows.find((r) => r.workerId === 3);
+        expect(norate.costRate).toBeNull();
+        expect(norate.costTotal).toBeNull();
+        expect(norate.totalHours).toBe(0.75);
+    });
+
+    test('totals sum hours and known costs; rows sorted by workerId', () => {
+        const { rows, totals } = buildPayroll(ENTRIES, WORKERS);
+        expect(rows.map((r) => r.workerId)).toEqual([1, 2, 3]);
+        expect(totals.workers).toBe(3);
+        expect(totals.totalMinutes).toBe(255);
+        expect(totals.totalHours).toBe(4.25);
+        expect(totals.costTotal).toBe(310); // 150 + 160 (+ null ignored)
+    });
+
+    test('empty input yields an empty payroll', () => {
+        const { rows, totals } = buildPayroll([], []);
+        expect(rows).toEqual([]);
+        expect(totals.costTotal).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Hand payroll a clean CSV: each worker's hours for a pay period, plus labor cost — ready to import into a payroll system.

Closes #456.

## Changes

- **`GET /v1/payroll/export`** `?from=&to=` — a **payroll-ready CSV**: one row per worker who logged time, with **total / billable / non-billable hours** and a **labor-cost total** (hours × `workerCostRate`, exact money). Built with the existing **OWASP formula-injection-safe** cell escaper.
- **`GET /v1/payroll/summary`** — the same aggregation as **JSON** (rows + period + totals) for programmatic consumers.
- **`payroll.js`** — a **pure** aggregator: groups completed entries by worker, splits billable/non-billable, computes cost, sorts by worker id, and rolls up totals. Unit-tested.

Only **completed** entries (`teEndedAt` set) within `[from, to]` count; both endpoints are **company-scoped** (master keys pass `?companyId`). **No new tables** — a service + controller over `TimeEntry` + `Worker`.

## Verification

`npm run lint` clean; `npm test` → **1423 passing** (aggregator: billable split, labor cost, null-cost-rate worker, totals, empty; route auth + `from`/`to` date + strict-query validation). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/