### PR TITLE
feat(reporting): shareable client-facing invoice links (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Shareable client-facing invoice links** (#438). `POST /v1/share/invoice/{id}`
+  mints a **signed, expiring** link (HS256 JWT via `jwt.js`, keyed by the
+  `SHARE_SECRET` env var; default 7-day, max 90-day lifetime) for one of
+  the tenant's invoices. `GET /v1/share/invoice?token=…` is **public — no
+  API key** — and returns a read-only, client-safe projection (totals,
+  collected, balance, customer name; internal fields withheld) authorized
+  by the signed token alone. Both 503 when `SHARE_SECRET` is unset. Pure
+  `share-link.js` (TTL policy + projection); no new tables.
 - **Payroll export** (#456). `GET /v1/payroll/export` produces a
   payroll-ready **CSV** of completed worker hours over a pay period
   (`from`/`to`) — per worker: total / billable / non-billable hours and a

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1717,6 +1717,32 @@ const spec = {
                 },
             },
         },
+        '/v1/share/invoice/{id}': {
+            post: {
+                summary: 'Mint a signed, expiring shareable link for an invoice (#438)',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { expiresInSec: { type: 'integer', description: 'Link lifetime (default 7 days, max 90 days).' } } } } } },
+                responses: {
+                    201: { description: 'Link created — {token, path, expiresIn}' },
+                    403: { description: 'Auth failure' },
+                    404: { description: 'Not found / cross-tenant' },
+                    503: { description: 'SHARE_SECRET not configured' },
+                },
+            },
+        },
+        '/v1/share/invoice': {
+            get: {
+                summary: 'View an invoice via a signed link — PUBLIC, no API key (#438)',
+                parameters: [{ name: 'token', in: 'query', required: true, schema: { type: 'string' } }],
+                responses: {
+                    200: { description: 'Read-only invoice projection (totals, balance, customer name)' },
+                    401: { description: 'Invalid or expired link' },
+                    404: { description: 'Invoice not found' },
+                    503: { description: 'SHARE_SECRET not configured' },
+                },
+            },
+        },
         '/v1/rateschedule': {
             post: {
                 summary: 'Create an effective-dated rate (#414)',

--- a/app/controllers/sharecontroller.js
+++ b/app/controllers/sharecontroller.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+// Shareable client-facing invoice links (#438). A tenant mints a signed,
+// expiring token for one of their invoices; anyone holding the link can
+// view a read-only projection of that invoice WITHOUT an API key. Tokens
+// are HS256 JWTs (jwt.js) keyed by SHARE_SECRET — when it's unset, both
+// endpoints return 503.
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const jwt = require('../services/jwt.js');
+const { resolveTtl, publicInvoiceView } = require('../services/share-link.js');
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
+
+function secret() {
+    return process.env.SHARE_SECRET || '';
+}
+
+/** POST /v1/share/invoice/:id — mint a signed, expiring share link (tenant-scoped). */
+exports.createInvoiceShare = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const s = secret();
+    if (!s) {
+        return res.status(503).json({ message: "Link sharing is not configured." });
+    }
+
+    let invoice;
+    try {
+        invoice = await db.Invoice.findByPk(req.params.id, { attributes: ['invId', 'invCustId', 'invArch'] });
+    } catch (error) {
+        log.error({ err: error }, 'share: Invoice.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!invoice || invoice.invArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const invCompanyId = await GetCompanyIdByCustomerId(invoice.invCustId);
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || invCompanyId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    const ttl = resolveTtl((req.body || {}).expiresInSec);
+    const token = jwt.sign({ kind: 'invoice', id: invoice.invId }, s, ttl);
+    return res.status(201).json({
+        message: "Share link created.",
+        token,
+        path: `/v1/share/invoice?token=${encodeURIComponent(token)}`,
+        expiresIn: ttl,
+    });
+};
+
+/** GET /v1/share/invoice?token=... — PUBLIC read-only invoice view. */
+exports.viewInvoice = async (req, res) => {
+    const s = secret();
+    if (!s) {
+        return res.status(503).json({ message: "Link sharing is not configured." });
+    }
+
+    const payload = jwt.verify(String(req.query.token || ''), s);
+    if (!payload || payload.kind !== 'invoice' || !payload.id) {
+        return res.status(401).json({ message: "Invalid or expired link." });
+    }
+
+    let invoice;
+    try {
+        invoice = await db.Invoice.findByPk(payload.id, {
+            include: [
+                { model: db.Customer, as: 'customer', attributes: ['custId', 'custCompanyName', 'custFName', 'custLName'] },
+                { model: db.CustomerPayment, as: 'payments', required: false },
+            ],
+        });
+    } catch (error) {
+        log.error({ err: error }, 'share: Invoice view load failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!invoice || invoice.invArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    return res.status(200).json({ message: "OK.", invoice: publicInvoiceView(invoice, invoice.payments) });
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -45,6 +45,7 @@ const receipt = require('../controllers/receiptcontroller.js');
 const reportSchedule = require('../controllers/reportschedulecontroller.js');
 const gdpr = require('../controllers/gdprcontroller.js');
 const payroll = require('../controllers/payrollcontroller.js');
+const share = require('../controllers/sharecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -80,6 +81,7 @@ const receiptSchemas = require('../schemas/receipt.schema.js');
 const reportScheduleSchemas = require('../schemas/reportschedule.schema.js');
 const gdprSchemas = require('../schemas/gdpr.schema.js');
 const payrollSchemas = require('../schemas/payroll.schema.js');
+const shareSchemas = require('../schemas/share.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -944,6 +946,21 @@ router.get(
     '/v1/payroll/export',
     v.query(payrollSchemas.payrollQuery),
     payroll.exportCsv,
+);
+
+// v1 shareable-link routes (#438): mint a signed invoice link (tenant-
+// scoped); the view is PUBLIC (no authKey) and authorized by the signed
+// token alone.
+router.post(
+    '/v1/share/invoice/:id',
+    v.params(shareSchemas.intIdParam),
+    v.body(shareSchemas.shareCreateBody),
+    share.createInvoiceShare,
+);
+router.get(
+    '/v1/share/invoice',
+    v.query(shareSchemas.shareViewQuery),
+    share.viewInvoice,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/share.schema.js
+++ b/app/schemas/share.schema.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/share/invoice/:id body (#438) — optional link lifetime. */
+const shareCreateBody = z.object({
+    expiresInSec: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: expiresInSec.',
+});
+
+/** GET /v1/share/invoice query (#438) — the signed token. */
+const shareViewQuery = z.object({
+    token: z.string().min(1).max(4096),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: token.',
+});
+
+module.exports = { intIdParam, shareCreateBody, shareViewQuery };

--- a/app/services/share-link.js
+++ b/app/services/share-link.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * share-link.js — shareable client-facing invoice links (#438). The token
+ * itself is a signed HS256 JWT (jwt.js) keyed by SHARE_SECRET; this module
+ * holds the TTL policy and the PURE read-only public projection of an
+ * invoice (no internal-only fields, no cross-tenant data). money via
+ * money.js.
+ */
+
+const money = require('./money.js');
+
+const SHARE_TTL_DEFAULT_SEC = 7 * 24 * 60 * 60; // 7 days
+const SHARE_TTL_MAX_SEC = 90 * 24 * 60 * 60;    // 90 days
+const SHARE_TTL_MIN_SEC = 60;
+
+/** Clamp a requested TTL into [MIN, MAX], defaulting when absent/invalid. */
+function resolveTtl(requested) {
+    const n = Number(requested);
+    if (!Number.isFinite(n) || n <= 0) return SHARE_TTL_DEFAULT_SEC;
+    return Math.min(Math.max(Math.floor(n), SHARE_TTL_MIN_SEC), SHARE_TTL_MAX_SEC);
+}
+
+/** The read-only, client-safe view of an invoice (+ its payments). */
+function publicInvoiceView(invoice, payments) {
+    const inv = invoice || {};
+    const collected = money.sum((payments || []).map((p) => p.cpayAmount));
+    const total = inv.invTotal == null ? 0 : Number(inv.invTotal);
+    const balance = money.subtract(total, collected);
+    const c = inv.customer;
+    return {
+        invId: inv.invId,
+        invNumber: inv.invNumber,
+        invDate: inv.invDate,
+        invDueDate: inv.invDueDate,
+        invCurrency: inv.invCurrency,
+        invSubtotal: inv.invSubtotal,
+        invTax: inv.invTax,
+        invDiscount: inv.invDiscount,
+        invWriteOff: inv.invWriteOff,
+        invTotal: inv.invTotal,
+        invPaid: inv.invPaid,
+        collected,
+        balance,
+        customer: c ? { name: c.custCompanyName || [c.custFName, c.custLName].filter(Boolean).join(' ') || null } : null,
+    };
+}
+
+module.exports = {
+    SHARE_TTL_DEFAULT_SEC,
+    SHARE_TTL_MAX_SEC,
+    SHARE_TTL_MIN_SEC,
+    resolveTtl,
+    publicInvoiceView,
+};

--- a/tests/api/share.test.js
+++ b/tests/api/share.test.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for shareable invoice links (#438) — auth, schema,
+// and the SHARE_SECRET gate.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, User: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    delete process.env.SHARE_SECRET;
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Shareable invoice links (#438)', () => {
+    test('POST /:id 403 without authKey', async () => {
+        expect((await request(app).post('/v1/share/invoice/1').send({})).status).toBe(403);
+    });
+    test('POST /:id 503 when SHARE_SECRET unset (authKey present)', async () => {
+        expect((await request(app).post('/v1/share/invoice/1').set('authKey', 'k').send({})).status).toBe(503);
+    });
+    test('POST /:id 400 on a non-numeric id (schema)', async () => {
+        expect((await request(app).post('/v1/share/invoice/abc').set('authKey', 'k').send({})).status).toBe(400);
+    });
+    test('GET view 400 without a token (schema)', async () => {
+        expect((await request(app).get('/v1/share/invoice')).status).toBe(400);
+    });
+    test('GET view 503 when SHARE_SECRET unset', async () => {
+        expect((await request(app).get('/v1/share/invoice?token=x.y.z')).status).toBe(503);
+    });
+    test('GET view 401 on a garbage token (SHARE_SECRET set)', async () => {
+        process.env.SHARE_SECRET = 'unit-test-share-secret';
+        try {
+            expect((await request(app).get('/v1/share/invoice?token=not.a.valid.jwt')).status).toBe(401);
+        } finally {
+            delete process.env.SHARE_SECRET;
+        }
+    });
+});

--- a/tests/unit/share-link.test.js
+++ b/tests/unit/share-link.test.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { resolveTtl, publicInvoiceView, SHARE_TTL_DEFAULT_SEC, SHARE_TTL_MAX_SEC, SHARE_TTL_MIN_SEC } from '../../app/services/share-link.js';
+
+describe('share-link (#438)', () => {
+    test('resolveTtl clamps and defaults', () => {
+        expect(resolveTtl(undefined)).toBe(SHARE_TTL_DEFAULT_SEC);
+        expect(resolveTtl(0)).toBe(SHARE_TTL_DEFAULT_SEC);
+        expect(resolveTtl(-5)).toBe(SHARE_TTL_DEFAULT_SEC);
+        expect(resolveTtl('nope')).toBe(SHARE_TTL_DEFAULT_SEC);
+        expect(resolveTtl(10)).toBe(SHARE_TTL_MIN_SEC); // below min → min
+        expect(resolveTtl(3600)).toBe(3600);
+        expect(resolveTtl(999 * SHARE_TTL_MAX_SEC)).toBe(SHARE_TTL_MAX_SEC); // above max → max
+    });
+
+    test('publicInvoiceView computes balance and a client-safe projection', () => {
+        const invoice = {
+            invId: 7, invNumber: 'INV-007', invDate: '2026-03-01', invDueDate: '2026-03-31',
+            invCurrency: 'USD', invSubtotal: 1000, invTax: 80, invDiscount: 0, invWriteOff: 0,
+            invTotal: 1080, invPaid: false,
+            invCustId: 3, invArch: false, invNotes: 'internal note',
+            customer: { custCompanyName: 'Globex', custFName: 'A', custLName: 'B' },
+        };
+        const payments = [{ cpayAmount: 300 }, { cpayAmount: 200 }];
+        const view = publicInvoiceView(invoice, payments);
+
+        expect(view.invTotal).toBe(1080);
+        expect(view.collected).toBe(500);
+        expect(view.balance).toBe(580);
+        expect(view.customer).toEqual({ name: 'Globex' });
+        // Internal-only fields are NOT projected.
+        expect('invNotes' in view).toBe(false);
+        expect('invCustId' in view).toBe(false);
+        expect('invArch' in view).toBe(false);
+    });
+
+    test('publicInvoiceView tolerates no payments / no customer', () => {
+        const view = publicInvoiceView({ invTotal: 100 }, null);
+        expect(view.collected).toBe(0);
+        expect(view.balance).toBe(100);
+        expect(view.customer).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Send a client a link to their invoice — no login, no API key — that expires on its own.

Closes #438.

## Changes

- **`POST /v1/share/invoice/{id}`** — a tenant mints a **signed, expiring** link for one of their invoices. The token is an **HS256 JWT** (`jwt.js`, keyed by `SHARE_SECRET`), lifetime **7 days by default, 90 max**. Returns `{ token, path, expiresIn }`. Scoped + secure-404.
- **`GET /v1/share/invoice?token=…`** — **PUBLIC, no API key**. The signed token *is* the authorization. Returns a **read-only, client-safe** projection: number, dates, currency, subtotal/tax/discount/total, amount collected, **balance**, and the customer name — **internal-only fields are withheld** (no notes, no cross-tenant data).
- Both endpoints return **503** when `SHARE_SECRET` is unset (fails safe — no sharing without a configured secret).
- **`share-link.js`** — pure TTL-clamp + invoice projection, unit-tested.

## Design

Reuses the dependency-free `jwt.js` from the auth epic — the link's validity and expiry are cryptographic, so **no share records to store or revoke-scan**; the token expiring is the revocation. **No new tables.**

## Verification

`npm run lint` clean; `npm test` → **1438 passing** (share-link: TTL clamp/default, balance + safe projection, no-payments/no-customer; route auth, id/token schema, and the `SHARE_SECRET` 503 gate on both endpoints). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/