### PR TITLE
feat(team): teammate invitations (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Teammate invitations** (#458). A new company-scoped `Invitation`
+  entity, migration `20260627000000`. `POST /v1/invitation` invites an
+  email to join a workspace with a chosen RBAC role — storing only the
+  token's SHA-256 and emailing the token via the mailer (#68).
+  `POST /v1/invitation/accept` is **public**: it validates the token
+  (pure `invitation.js`), provisions a `User` (#444) with the invited role
+  and the caller's password, and consumes the invite.
+  `GET /v1/invitation/bycompany/{id}` lists invitations (token hash
+  withheld); `DELETE` revokes. Duplicate-email guarded (409).
 - **Multi-level approval chains** (#443). A new company-scoped
   `ApprovalChain` entity (ordered approver levels, each requiring an RBAC
   role), migration `20260626000000`. Full REST on `/v1/approvalchain`

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -79,6 +79,7 @@ db.User = require('../models/user.model.js')(sequelize, Sequelize);
 db.Receipt = require('../models/receipt.model.js')(sequelize, Sequelize);
 db.ReportSchedule = require('../models/reportschedule.model.js')(sequelize, Sequelize);
 db.ApprovalChain = require('../models/approvalchain.model.js')(sequelize, Sequelize);
+db.Invitation = require('../models/invitation.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -248,5 +249,9 @@ db.ReportSchedule.belongsTo(db.Company, { foreignKey: 'rptschCompId', as: 'compa
 // ApprovalChain → Company (apchCompId): multi-level approval routing (#443).
 db.Company.hasMany(db.ApprovalChain,   { foreignKey: 'apchCompId', as: 'approvalChains' });
 db.ApprovalChain.belongsTo(db.Company, { foreignKey: 'apchCompId', as: 'company' });
+
+// Invitation → Company (invtCompId): teammate invitations (#458).
+db.Company.hasMany(db.Invitation,   { foreignKey: 'invtCompId', as: 'invitations' });
+db.Invitation.belongsTo(db.Company, { foreignKey: 'invtCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1743,6 +1743,37 @@ const spec = {
                 },
             },
         },
+        '/v1/invitation': {
+            post: {
+                summary: 'Invite a teammate to a company workspace (#458)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { invtEmail: { type: 'string', format: 'email' }, invtRole: { type: 'string', enum: ['owner', 'admin', 'manager', 'member', 'viewer'] }, invtCompId: { type: 'integer' } }, required: ['invtEmail', 'invtRole'] } } } },
+                responses: { 201: { description: 'Invitation sent (token emailed)' }, 400: { description: 'Validation error; master keys must specify invtCompId' }, 403: { description: 'Auth failure' }, 409: { description: 'A user with that email already exists' } },
+            },
+        },
+        '/v1/invitation/accept': {
+            post: {
+                summary: 'Accept an invitation — PUBLIC; provisions a user (#458)',
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { token: { type: 'string' }, userName: { type: 'string' }, password: { type: 'string' } }, required: ['token', 'password'] } } } },
+                responses: { 201: { description: 'User provisioned with the invited role' }, 400: { description: 'Invalid or expired invitation / validation error' }, 409: { description: 'A user with that email already exists' } },
+            },
+        },
+        '/v1/invitation/bycompany/{id}': {
+            get: {
+                summary: "List a company's invitations (no token hash)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/invitation/{id}': {
+            delete: {
+                summary: 'Revoke an invitation',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Revoked' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/approvalchain': {
             post: {
                 summary: 'Define a multi-level approval chain (#443)',

--- a/app/controllers/invitationcontroller.js
+++ b/app/controllers/invitationcontroller.js
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { hashPassword } = require('../services/password.js');
+const { generateToken } = require('../services/password-reset.js');
+const { sendMail } = require('../services/mailer.js');
+const { isInviteValid, INVITE_TTL_SEC } = require('../services/invitation.js');
+const Invitation = db.Invitation;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+// invtTokenHash is write-only.
+const SAFE_ATTRS = ['invtId', 'invtCompId', 'invtEmail', 'invtRole', 'invtExpires', 'invtAcceptedAt', 'invtArch', 'createdAt', 'updatedAt'];
+
+function safeView(i) {
+    return {
+        invtId: i.invtId, invtCompId: i.invtCompId, invtEmail: i.invtEmail,
+        invtRole: i.invtRole, invtExpires: i.invtExpires, invtAcceptedAt: i.invtAcceptedAt, invtArch: i.invtArch,
+    };
+}
+
+/** POST /v1/invitation — invite an email to join a company with a role. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    let companyId;
+    if (!isMaster) {
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (body.invtCompId !== undefined && Number(body.invtCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot invite to a company you do not belong to." });
+        }
+    } else {
+        companyId = Number(body.invtCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify invtCompId." });
+        }
+    }
+
+    // Reject if an active user already holds that email in the company.
+    try {
+        const existing = await db.User.findOne({ where: { userCompId: companyId, userEmail: body.invtEmail } });
+        if (existing) {
+            return res.status(409).json({ message: "A user with that email already exists." });
+        }
+    } catch (error) {
+        log.error({ err: error }, 'invitation: user uniqueness check failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const token = generateToken();
+    const expires = new Date(Date.now() + INVITE_TTL_SEC * 1000);
+    let created;
+    try {
+        created = await Invitation.create({
+            invtCompId: companyId,
+            invtEmail: body.invtEmail,
+            invtRole: body.invtRole,
+            invtTokenHash: auth.hashKey(token),
+            invtExpires: expires,
+            invtAcceptedAt: null,
+            invtArch: false,
+        });
+    } catch (error) {
+        log.error({ err: error }, 'Invitation.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    try {
+        await sendMail({
+            to: body.invtEmail,
+            subject: 'You have been invited',
+            text: `You've been invited to join a workspace as "${body.invtRole}". Accept with this token (valid 7 days):\n\n${token}`,
+        });
+    } catch (error) {
+        // The invite exists; a mail failure shouldn't 500 the caller.
+        log.error({ err: error }, 'invitation: sendMail failed');
+    }
+
+    return res.status(201).json({ message: "Invitation sent.", invitation: safeView(created) });
+};
+
+/**
+ * POST /v1/invitation/accept — PUBLIC. Provision a user from a valid,
+ * unexpired, unaccepted invitation token.
+ */
+exports.accept = async (req, res) => {
+    const body = req.body || {};
+    const tokenHash = auth.hashKey(body.token || '');
+
+    let invite;
+    try {
+        invite = await Invitation.findOne({ where: { invtTokenHash: tokenHash } });
+    } catch (error) {
+        log.error({ err: error }, 'invitation accept: findOne failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!isInviteValid(invite, tokenHash, Date.now())) {
+        return res.status(400).json({ message: "Invalid or expired invitation." });
+    }
+
+    // Guard against a user having been created for that email meanwhile.
+    try {
+        const existing = await db.User.findOne({ where: { userCompId: invite.invtCompId, userEmail: invite.invtEmail } });
+        if (existing) {
+            return res.status(409).json({ message: "A user with that email already exists." });
+        }
+    } catch (error) {
+        log.error({ err: error }, 'invitation accept: user uniqueness check failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    let user;
+    try {
+        user = await db.User.create({
+            userCompId: invite.invtCompId,
+            userEmail: invite.invtEmail,
+            userName: body.userName,
+            userRole: invite.invtRole,
+            userPasswordHash: hashPassword(body.password),
+            userArch: false,
+        });
+        await invite.update({ invtAcceptedAt: new Date() });
+    } catch (error) {
+        log.error({ err: error }, 'invitation accept: provisioning failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    return res.status(201).json({
+        message: "Invitation accepted.",
+        user: { userId: user.userId, userCompId: user.userCompId, userEmail: user.userEmail, userName: user.userName, userRole: user.userRole },
+    });
+};
+
+/** GET /v1/invitation/bycompany/:id — list a company's invitations (no token hash). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await Invitation.findAndCountAll({
+            where: { invtCompId: targetCompanyId },
+            attributes: SAFE_ATTRS,
+            limit,
+            offset,
+            order: [['invtId', 'DESC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, invitations: rows });
+    } catch (error) {
+        log.error({ err: error }, 'Invitation.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/invitation/:id — revoke (soft-delete). Company-scoped, secure-404. */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let invite;
+    try {
+        invite = await Invitation.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'Invitation.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!invite || invite.invtArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || invite.invtCompId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    try {
+        await invite.update({ invtArch: true });
+        return res.status(200).json({ message: "Revoked.", id: invite.invtId });
+    } catch (error) {
+        log.error({ err: error }, 'Invitation revoke failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260627000000-invitation.js
+++ b/app/migrations/20260627000000-invitation.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Teammate invitations (#458). An Invitation records a pending invite to
+// join a company workspace with a chosen RBAC role (#448); accepting it
+// (with the emailed token) provisions a User (#444). Only the token's
+// SHA-256 is stored. New table in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Invitation', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    invtId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    invtCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    invtEmail: { type: Sequelize.TEXT, allowNull: false },
+                    invtRole: { type: Sequelize.TEXT, allowNull: false },
+                    invtTokenHash: { type: Sequelize.TEXT, allowNull: false },
+                    invtExpires: { type: Sequelize.DATE, allowNull: false },
+                    invtAcceptedAt: { type: Sequelize.DATE, allowNull: true },
+                    invtArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'Invitation_compId_arch_idx', fields: ['invtCompId', 'invtArch'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'Invitation_tokenHash_idx', fields: ['invtTokenHash'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/invitation.model.js
+++ b/app/models/invitation.model.js
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * Invitation — a pending invite to join a company workspace (#458).
+ * invtTokenHash is the SHA-256 of a one-time token emailed to invtEmail;
+ * accepting provisions a User with invtRole. invtAcceptedAt marks it
+ * consumed. Company-scoped via invtCompId. Soft-deletes via invtArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const Invitation = sequelize.define('Invitation', {
+        invtId: {
+            field: 'invtId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        invtCompId: {
+            field: 'invtCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        invtEmail: {
+            field: 'invtEmail',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        invtRole: {
+            field: 'invtRole',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        invtTokenHash: {
+            field: 'invtTokenHash',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        invtExpires: {
+            field: 'invtExpires',
+            type: Sequelize.DATE,
+            allowNull: false,
+        },
+        invtAcceptedAt: {
+            field: 'invtAcceptedAt',
+            type: Sequelize.DATE,
+        },
+        invtArch: {
+            field: 'invtArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'Invitation',
+        timestamps: true,
+        defaultScope: { where: { invtArch: false } }
+    });
+
+    return Invitation;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -47,6 +47,7 @@ const gdpr = require('../controllers/gdprcontroller.js');
 const payroll = require('../controllers/payrollcontroller.js');
 const share = require('../controllers/sharecontroller.js');
 const approvalChain = require('../controllers/approvalchaincontroller.js');
+const invitation = require('../controllers/invitationcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -84,6 +85,7 @@ const gdprSchemas = require('../schemas/gdpr.schema.js');
 const payrollSchemas = require('../schemas/payroll.schema.js');
 const shareSchemas = require('../schemas/share.schema.js');
 const approvalChainSchemas = require('../schemas/approvalchain.schema.js');
+const invitationSchemas = require('../schemas/invitation.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -999,6 +1001,30 @@ router.delete(
     '/v1/approvalchain/:id',
     v.params(approvalChainSchemas.intIdParam),
     approvalChain.remove,
+);
+
+// v1 invitation routes (#458): invite a teammate (scoped); accept is
+// PUBLIC and provisions a user from the emailed token.
+router.post(
+    '/v1/invitation',
+    v.body(invitationSchemas.createInvitationBody),
+    invitation.create,
+);
+router.post(
+    '/v1/invitation/accept',
+    v.body(invitationSchemas.acceptInvitationBody),
+    invitation.accept,
+);
+router.get(
+    '/v1/invitation/bycompany/:id',
+    v.params(invitationSchemas.intIdParam),
+    v.query(invitationSchemas.listByCompanyQuery),
+    invitation.listByCompany,
+);
+router.delete(
+    '/v1/invitation/:id',
+    v.params(invitationSchemas.intIdParam),
+    invitation.remove,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/invitation.schema.js
+++ b/app/schemas/invitation.schema.js
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+const { ROLES } = require('../services/rbac.js');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/invitation body (#458). invtCompId optional (non-master → own; master required). */
+const createInvitationBody = z.object({
+    invtEmail: z.string().email().max(320),
+    invtRole: z.enum(ROLES),
+    invtCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: invtEmail, invtRole, invtCompId.',
+});
+
+/** POST /v1/invitation/accept body (#458) — public; provisions a user. */
+const acceptInvitationBody = z.object({
+    token: z.string().min(1).max(200),
+    userName: z.string().min(1).max(255).optional(),
+    password: z.string().min(8).max(200),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: token, userName, password.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+module.exports = {
+    intIdParam,
+    createInvitationBody,
+    acceptInvitationBody,
+    listByCompanyQuery,
+};

--- a/app/services/invitation.js
+++ b/app/services/invitation.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * invitation.js — teammate-invitation validity (#458). PURE: no DB, no
+ * clock (nowMs injected). An invite is acceptable only if it is not
+ * archived, not already accepted, its stored token hash matches the
+ * presented one, and it has not expired. Token generation reuses
+ * password-reset.js's generateToken.
+ */
+
+const INVITE_TTL_SEC = 7 * 24 * 60 * 60; // 7 days
+
+/**
+ * @param invite a { invtArch, invtAcceptedAt, invtTokenHash, invtExpires }.
+ * @param candidateHash SHA-256 of the presented token.
+ * @param nowMs current time in ms.
+ */
+function isInviteValid(invite, candidateHash, nowMs) {
+    if (!invite || invite.invtArch) return false;
+    if (invite.invtAcceptedAt) return false;
+    if (!invite.invtTokenHash || !candidateHash || invite.invtTokenHash !== candidateHash) return false;
+    if (!invite.invtExpires) return false;
+    const exp = new Date(invite.invtExpires).getTime();
+    return Number.isFinite(exp) && Number(nowMs) <= exp;
+}
+
+module.exports = { INVITE_TTL_SEC, isInviteValid };

--- a/tests/api/invitation.test.js
+++ b/tests/api/invitation.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/invitation (#458) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, ApprovalChain: {}, User: {},
+    Invitation: { findByPk: vi.fn().mockResolvedValue(null), findOne: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { invtEmail: 'new@co.com', invtRole: 'member' };
+
+describe('Invitation auth + schema contract (#458)', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/invitation').send(good)).status).toBe(403);
+    });
+    test('POST 400 on an invalid role (schema enum)', async () => {
+        expect((await request(app).post('/v1/invitation').set('authKey', 'k').send({ invtEmail: 'new@co.com', invtRole: 'wizard' })).status).toBe(400);
+    });
+    test('POST 400 on a bad email (schema)', async () => {
+        expect((await request(app).post('/v1/invitation').set('authKey', 'k').send({ invtEmail: 'nope', invtRole: 'member' })).status).toBe(400);
+    });
+    test('POST /accept 400 on a missing password (schema)', async () => {
+        expect((await request(app).post('/v1/invitation/accept').send({ token: 'abc' })).status).toBe(400);
+    });
+    test('POST /accept 400 on a too-short password (schema)', async () => {
+        expect((await request(app).post('/v1/invitation/accept').send({ token: 'abc', password: 'short' })).status).toBe(400);
+    });
+    test('GET /bycompany/:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/invitation/bycompany/1')).status).toBe(403);
+    });
+    test('DELETE /:id 403 without authKey', async () => {
+        expect((await request(app).delete('/v1/invitation/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('Invitation table exists with a company include (#458)', async () => {
+        if (!connected) return;
+        const rows = await db.Invitation.findAll({
+            attributes: ['invtId', 'invtCompId', 'invtEmail', 'invtRole', 'invtExpires', 'invtAcceptedAt'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.Invitation.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('ApprovalChain table exists with a company include (#443)', async () => {
         if (!connected) return;
         const rows = await db.ApprovalChain.findAll({

--- a/tests/unit/invitation.test.js
+++ b/tests/unit/invitation.test.js
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { isInviteValid, INVITE_TTL_SEC } from '../../app/services/invitation.js';
+
+const NOW = new Date('2026-05-01T00:00:00Z').getTime();
+const future = '2026-05-05T00:00:00Z';
+const past = '2026-04-01T00:00:00Z';
+
+describe('invitation (#458)', () => {
+    test('INVITE_TTL_SEC is 7 days', () => {
+        expect(INVITE_TTL_SEC).toBe(7 * 24 * 60 * 60);
+    });
+
+    test('valid for a matching, unexpired, unaccepted invite', () => {
+        const inv = { invtArch: false, invtAcceptedAt: null, invtTokenHash: 'abc', invtExpires: future };
+        expect(isInviteValid(inv, 'abc', NOW)).toBe(true);
+    });
+
+    test('invalid when hash mismatches', () => {
+        const inv = { invtArch: false, invtAcceptedAt: null, invtTokenHash: 'abc', invtExpires: future };
+        expect(isInviteValid(inv, 'WRONG', NOW)).toBe(false);
+    });
+
+    test('invalid when expired', () => {
+        const inv = { invtArch: false, invtAcceptedAt: null, invtTokenHash: 'abc', invtExpires: past };
+        expect(isInviteValid(inv, 'abc', NOW)).toBe(false);
+    });
+
+    test('invalid when already accepted or archived or missing', () => {
+        expect(isInviteValid({ invtArch: false, invtAcceptedAt: '2026-04-15T00:00:00Z', invtTokenHash: 'abc', invtExpires: future }, 'abc', NOW)).toBe(false);
+        expect(isInviteValid({ invtArch: true, invtAcceptedAt: null, invtTokenHash: 'abc', invtExpires: future }, 'abc', NOW)).toBe(false);
+        expect(isInviteValid(null, 'abc', NOW)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Invite someone to your workspace by email; they accept with a link and get an account — no admin provisioning by hand.

Closes #458.

## Changes

- **Migration `20260627000000`** — a company-scoped `Invitation` (`invtEmail`, `invtRole`, `invtTokenHash`, `invtExpires`, `invtAcceptedAt`, `invtArch`).
- **`POST /v1/invitation`** `{ invtEmail, invtRole }` — invite an email to join with an **RBAC role** (#448). Stores **only the token's SHA-256** and emails the token via the mailer (#68). 409 if a user with that email already exists.
- **`POST /v1/invitation/accept`** `{ token, userName?, password }` — **PUBLIC**. Validates the token (pure `invitation.js`: match + unexpired + unaccepted + not revoked), **provisions a `User`** (#444) with the invited role and the chosen password, and consumes the invite.
- **`GET /v1/invitation/bycompany/{id}`** lists invitations (**token hash withheld**); **`DELETE`** revokes.

## Design

Mirrors the password-reset token pattern (#446) — one-time, hashed-at-rest, expiring — and reuses the mailer, password, and RBAC subsystems. The accept flow is the second public, self-service auth path (alongside login), so onboarding needs no API key. **7-day** invite lifetime.

## Verification

`npm run lint` clean; `npm test` → **1478 passing** (invite validity: match / expired / already-accepted / archived / missing; route auth, role/email/password schema; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/