### PR TITLE
feat(team): capacity & resource planning report (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Capacity & resource planning** (#459). `GET /v1/capacity/summary`
+  reports, per worker over a `from`/`to` period, **target hours** (each
+  worker's `workerTargetMinsPerWeek` × weeks in the period) vs. **logged
+  hours**, with **utilization %** and **remaining capacity** — plus
+  company totals. Every worker is listed (a zero-logged worker shows full
+  remaining capacity). Pure `capacity.js` aggregator; company-scoped; no
+  new tables.
 - **Teammate invitations** (#458). A new company-scoped `Invitation`
   entity, migration `20260627000000`. `POST /v1/invitation` invites an
   email to join a workspace with a chosen RBAC role — storing only the

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1689,6 +1689,18 @@ const spec = {
                 },
             },
         },
+        '/v1/capacity/summary': {
+            get: {
+                summary: 'Per-worker capacity / utilization for a period (#459)',
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date' } },
+                    { name: 'companyId', in: 'query', schema: { type: 'integer' }, description: 'Required for master keys.' },
+                ],
+                responses: { 200: { description: 'Rows (target/logged/remaining hours + utilization %) + weeks + totals' }, 400: { description: 'Missing from/to; master keys must specify companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
         '/v1/payroll/summary': {
             get: {
                 summary: 'Per-worker payroll totals for a pay period, as JSON (#456)',

--- a/app/controllers/capacitycontroller.js
+++ b/app/controllers/capacitycontroller.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildCapacity, weeksBetween } = require('../services/capacity.js');
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/** Resolve the target company (or null after responding). Master keys pass ?companyId. */
+async function resolveCompany(req, res) {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        res.status(403).json({ message: "Authorization key not sent." });
+        return null;
+    }
+    const isMaster = await IsMaster(authKey);
+    if (isMaster) {
+        const companyId = Number(req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            res.status(400).json({ message: "Master-key requests must specify companyId." });
+            return null;
+        }
+        return companyId;
+    }
+    const companyId = await GetCompanyId(authKey);
+    if (companyId === -1) {
+        res.status(403).json({ message: "Invalid Authorization Key." });
+        return null;
+    }
+    return companyId;
+}
+
+/** GET /v1/capacity/summary — per-worker capacity/utilization over a period. */
+exports.summary = async (req, res) => {
+    const companyId = await resolveCompany(req, res);
+    if (companyId === null) return undefined;
+    const { from, to } = req.query;
+    const Op = db.Sequelize.Op;
+
+    try {
+        const [entries, workers] = await Promise.all([
+            db.TimeEntry.findAll({
+                where: {
+                    teCompId: companyId,
+                    teArch: false,
+                    teEndedAt: { [Op.ne]: null },
+                    teStartedAt: { [Op.gte]: `${from}T00:00:00.000Z`, [Op.lte]: `${to}T23:59:59.999Z` },
+                },
+                attributes: ['teWorkerId', 'teMinutes'],
+            }),
+            db.Worker.findAll({
+                where: { workerCompId: companyId },
+                attributes: ['workerId', 'workerFName', 'workerLName', 'workerTargetMinsPerWeek'],
+            }),
+        ]);
+        const weeks = weeksBetween(from, to);
+        const capacity = buildCapacity(entries, workers, { from, to, weeks });
+        return res.status(200).json({ message: "Capacity summary.", companyId, ...capacity });
+    } catch (error) {
+        log.error({ err: error }, 'capacity summary failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -48,6 +48,7 @@ const payroll = require('../controllers/payrollcontroller.js');
 const share = require('../controllers/sharecontroller.js');
 const approvalChain = require('../controllers/approvalchaincontroller.js');
 const invitation = require('../controllers/invitationcontroller.js');
+const capacity = require('../controllers/capacitycontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -86,6 +87,7 @@ const payrollSchemas = require('../schemas/payroll.schema.js');
 const shareSchemas = require('../schemas/share.schema.js');
 const approvalChainSchemas = require('../schemas/approvalchain.schema.js');
 const invitationSchemas = require('../schemas/invitation.schema.js');
+const capacitySchemas = require('../schemas/capacity.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -1025,6 +1027,13 @@ router.delete(
     '/v1/invitation/:id',
     v.params(invitationSchemas.intIdParam),
     invitation.remove,
+);
+
+// v1 capacity route (#459): per-worker target vs logged hours + utilization.
+router.get(
+    '/v1/capacity/summary',
+    v.query(capacitySchemas.capacityQuery),
+    capacity.summary,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/capacity.schema.js
+++ b/app/schemas/capacity.schema.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date.');
+
+/** GET /v1/capacity/summary query. from/to required; companyId for master keys. */
+const capacityQuery = z.object({
+    from: isoDate,
+    to: isoDate,
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: from, to, companyId.',
+});
+
+module.exports = { capacityQuery };

--- a/app/services/capacity.js
+++ b/app/services/capacity.js
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * capacity.js — worker capacity / utilization for resource planning (#459).
+ * PURE: no DB, no I/O. Given completed time entries and workers (with a
+ * `workerTargetMinsPerWeek` target), compute per-worker target vs. logged
+ * hours, utilization %, and remaining capacity over a period. Unlike
+ * payroll, EVERY worker is listed (a zero-logged worker has full remaining
+ * capacity — the point of planning).
+ */
+
+/** Minutes → hours, rounded to 2 decimals. */
+function hoursFromMinutes(min) {
+    return Math.round((Number(min || 0) / 60) * 100) / 100;
+}
+
+/** Whole+fractional weeks spanned by an inclusive [from, to] date range. */
+function weeksBetween(from, to) {
+    const a = new Date(`${from}T00:00:00Z`).getTime();
+    const b = new Date(`${to}T00:00:00Z`).getTime();
+    if (!Number.isFinite(a) || !Number.isFinite(b) || b < a) return 0;
+    const days = Math.floor((b - a) / (24 * 60 * 60 * 1000)) + 1; // inclusive
+    return Math.round((days / 7) * 100) / 100;
+}
+
+function pct(part, whole) {
+    if (!whole || whole <= 0) return null;
+    return Math.round((part / whole) * 1000) / 10; // 1 decimal
+}
+
+/**
+ * @param entries [{ teWorkerId, teMinutes }].
+ * @param workers [{ workerId, workerFName, workerLName, workerTargetMinsPerWeek }].
+ * @param opts { from, to, weeks }.
+ */
+function buildCapacity(entries, workers, opts = {}) {
+    const weeks = Number(opts.weeks) || 0;
+
+    const logged = new Map();
+    for (const e of entries || []) {
+        const wid = e.teWorkerId;
+        if (wid == null) continue;
+        logged.set(wid, (logged.get(wid) || 0) + (Number(e.teMinutes) || 0));
+    }
+
+    const rows = [];
+    let totalTarget = 0;
+    let totalLogged = 0;
+    for (const w of workers || []) {
+        const perWeek = w.workerTargetMinsPerWeek == null ? null : Number(w.workerTargetMinsPerWeek);
+        const targetMinutes = perWeek != null ? Math.round(perWeek * weeks) : null;
+        const loggedMinutes = logged.get(w.workerId) || 0;
+        const remainingMinutes = targetMinutes != null ? targetMinutes - loggedMinutes : null;
+        rows.push({
+            workerId: w.workerId,
+            workerName: [w.workerFName, w.workerLName].filter(Boolean).join(' ') || null,
+            targetHours: targetMinutes != null ? hoursFromMinutes(targetMinutes) : null,
+            loggedHours: hoursFromMinutes(loggedMinutes),
+            remainingHours: remainingMinutes != null ? hoursFromMinutes(remainingMinutes) : null,
+            utilizationPct: pct(loggedMinutes, targetMinutes),
+        });
+        if (targetMinutes != null) totalTarget += targetMinutes;
+        totalLogged += loggedMinutes;
+    }
+    rows.sort((a, b) => a.workerId - b.workerId);
+
+    return {
+        periodStart: opts.from || null,
+        periodEnd: opts.to || null,
+        weeks,
+        rows,
+        totals: {
+            workers: rows.length,
+            targetHours: hoursFromMinutes(totalTarget),
+            loggedHours: hoursFromMinutes(totalLogged),
+            utilizationPct: pct(totalLogged, totalTarget),
+        },
+    };
+}
+
+module.exports = { buildCapacity, weeksBetween, hoursFromMinutes };

--- a/tests/api/capacity.test.js
+++ b/tests/api/capacity.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/capacity (#459) — auth + query validation.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, ApprovalChain: {}, Invitation: {}, User: {},
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+describe('Capacity report contract (#459)', () => {
+    test('GET /summary 403 without authKey (valid query reaches controller)', async () => {
+        expect((await request(app).get('/v1/capacity/summary?from=2026-01-01&to=2026-01-14')).status).toBe(403);
+    });
+    test('GET /summary 400 on a missing from (schema)', async () => {
+        expect((await request(app).get('/v1/capacity/summary?to=2026-01-14').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /summary 400 on a malformed date (schema)', async () => {
+        expect((await request(app).get('/v1/capacity/summary?from=Jan-1&to=2026-01-14').set('authKey', 'k')).status).toBe(400);
+    });
+    test('GET /summary 400 on an unknown query param (strict)', async () => {
+        expect((await request(app).get('/v1/capacity/summary?from=2026-01-01&to=2026-01-14&bogus=1').set('authKey', 'k')).status).toBe(400);
+    });
+});

--- a/tests/unit/capacity.test.js
+++ b/tests/unit/capacity.test.js
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { buildCapacity, weeksBetween, hoursFromMinutes } from '../../app/services/capacity.js';
+
+const WORKERS = [
+    { workerId: 1, workerFName: 'Jane', workerLName: 'Doe', workerTargetMinsPerWeek: 2400 }, // 40h/wk
+    { workerId: 2, workerFName: 'Bob', workerLName: 'Roe', workerTargetMinsPerWeek: null },  // no target
+    { workerId: 3, workerFName: 'Zoe', workerLName: 'Poe', workerTargetMinsPerWeek: 1200 },  // 20h/wk
+];
+const ENTRIES = [
+    { teWorkerId: 1, teMinutes: 3000 }, // 50h
+    { teWorkerId: 3, teMinutes: 600 },  // 10h
+    { teWorkerId: 2, teMinutes: 300 },  // 5h (no target)
+    { teWorkerId: null, teMinutes: 99 }, // ignored
+];
+
+describe('capacity (#459)', () => {
+    test('weeksBetween counts inclusive days / 7', () => {
+        expect(weeksBetween('2026-01-01', '2026-01-14')).toBe(2); // 14 days
+        expect(weeksBetween('2026-01-01', '2026-01-07')).toBe(1); // 7 days
+        expect(weeksBetween('2026-01-10', '2026-01-01')).toBe(0); // reversed
+    });
+
+    test('hoursFromMinutes rounds to 2 decimals', () => {
+        expect(hoursFromMinutes(90)).toBe(1.5);
+    });
+
+    test('per-worker target vs logged, utilization, remaining (all workers listed)', () => {
+        const { rows, weeks, totals } = buildCapacity(ENTRIES, WORKERS, { from: '2026-01-01', to: '2026-01-14', weeks: 2 });
+        expect(weeks).toBe(2);
+        expect(rows).toHaveLength(3);
+
+        const jane = rows.find((r) => r.workerId === 1);
+        expect(jane.targetHours).toBe(80);   // 2400*2 min = 4800 → 80h
+        expect(jane.loggedHours).toBe(50);
+        expect(jane.remainingHours).toBe(30);
+        expect(jane.utilizationPct).toBe(62.5);
+
+        const bob = rows.find((r) => r.workerId === 2); // no target
+        expect(bob.targetHours).toBeNull();
+        expect(bob.remainingHours).toBeNull();
+        expect(bob.utilizationPct).toBeNull();
+        expect(bob.loggedHours).toBe(5);
+
+        const zoe = rows.find((r) => r.workerId === 3);
+        expect(zoe.targetHours).toBe(40);
+        expect(zoe.utilizationPct).toBe(25);
+
+        // Totals: targets 80+40=120h; logged 50+5+10=65h; util 65/120.
+        expect(totals.targetHours).toBe(120);
+        expect(totals.loggedHours).toBe(65);
+        expect(totals.utilizationPct).toBe(54.2);
+    });
+
+    test('a worker with no logged time shows full remaining capacity', () => {
+        const { rows } = buildCapacity([], [WORKERS[0]], { weeks: 1 });
+        expect(rows[0].loggedHours).toBe(0);
+        expect(rows[0].targetHours).toBe(40);
+        expect(rows[0].remainingHours).toBe(40);
+        expect(rows[0].utilizationPct).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Who has room for more work? A per-worker capacity report: target vs. logged hours, utilization, and remaining availability over a period.

Closes #459.

## Changes

- **`GET /v1/capacity/summary`** `?from=&to=` — for each worker: **target hours** (their `workerTargetMinsPerWeek` × the weeks the period spans), **logged hours** (completed entries), **utilization %**, and **remaining capacity** — plus company totals (`weeks`, aggregate target/logged, overall utilization).
- **`capacity.js`** — pure aggregator + `weeksBetween` (inclusive days ÷ 7). Workers with **no target** report `null` for target/utilization but still show logged hours; workers with **no logged time** show **full remaining capacity** — which is exactly what planning needs. Unit-tested.

Only **completed** entries count; the report is **company-scoped** (master keys pass `?companyId`) and adds **no new tables** — a service + controller over `TimeEntry` + `Worker`.

## Verification

`npm run lint` clean; `npm test` → **1492 passing** (aggregator: `weeksBetween`, per-worker utilization + remaining, no-target worker, zero-logged full-capacity; route auth + `from`/`to` date + strict-query validation). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/