### PR TITLE
feat(structure): custom fields (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Custom fields** (#409). A new company-scoped `CustomFieldDef` entity,
+  migration `20260629000000`, declaring **typed** custom fields
+  (text/number/date/boolean) for a target entity (`customer` / `job` /
+  `timeentry`). Full REST on `/v1/customfield` (create — name-unique per
+  entity, `bycompany` list with `?entity`, get/patch/delete) plus
+  `POST /v1/customfield/validate` which coerces + checks a values object
+  against the company's defs (**422** with per-field errors on failure).
+  Pure `custom-field.js` (`coerceValue`, `validateAgainstDefs`); attaching
+  values to records is a follow-up.
 - **SOC 2 & security-posture roadmap** (#463). New
   [`docs/SECURITY-POSTURE.md`](docs/SECURITY-POSTURE.md) inventories the
   implemented technical controls (auth tiers, secure-404 tenant isolation,

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -80,6 +80,7 @@ db.Receipt = require('../models/receipt.model.js')(sequelize, Sequelize);
 db.ReportSchedule = require('../models/reportschedule.model.js')(sequelize, Sequelize);
 db.ApprovalChain = require('../models/approvalchain.model.js')(sequelize, Sequelize);
 db.Invitation = require('../models/invitation.model.js')(sequelize, Sequelize);
+db.CustomFieldDef = require('../models/customfielddef.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -253,5 +254,9 @@ db.ApprovalChain.belongsTo(db.Company, { foreignKey: 'apchCompId', as: 'company'
 // Invitation → Company (invtCompId): teammate invitations (#458).
 db.Company.hasMany(db.Invitation,   { foreignKey: 'invtCompId', as: 'invitations' });
 db.Invitation.belongsTo(db.Company, { foreignKey: 'invtCompId', as: 'company' });
+
+// CustomFieldDef → Company (cfdCompId): custom-field definitions (#409).
+db.Company.hasMany(db.CustomFieldDef,   { foreignKey: 'cfdCompId', as: 'customFieldDefs' });
+db.CustomFieldDef.belongsTo(db.Company, { foreignKey: 'cfdCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1694,6 +1694,53 @@ const spec = {
                 },
             },
         },
+        '/v1/customfield': {
+            post: {
+                summary: 'Declare a typed custom field for an entity (#409)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { cfdEntity: { type: 'string', enum: ['customer', 'job', 'timeentry'] }, cfdName: { type: 'string' }, cfdLabel: { type: 'string' }, cfdType: { type: 'string', enum: ['text', 'number', 'date', 'boolean'] }, cfdRequired: { type: 'boolean' }, cfdCompId: { type: 'integer' } }, required: ['cfdEntity', 'cfdName', 'cfdType'] } } } },
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error; master keys must specify cfdCompId' }, 403: { description: 'Auth failure' }, 409: { description: 'Duplicate field name for the entity' } },
+            },
+        },
+        '/v1/customfield/validate': {
+            post: {
+                summary: "Validate a values object against a company entity's custom fields (#409)",
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { entity: { type: 'string', enum: ['customer', 'job', 'timeentry'] }, values: { type: 'object' }, companyId: { type: 'integer' } }, required: ['entity', 'values'] } } } },
+                responses: { 200: { description: 'Valid — coerced { values }' }, 422: { description: 'Invalid — { errors } per field' }, 400: { description: 'Validation error' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/customfield/bycompany/{id}': {
+            get: {
+                summary: "List a company's custom fields (optional ?entity)",
+                security: [{ authKey: [] }],
+                parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    { name: 'entity', in: 'query', schema: { type: 'string', enum: ['customer', 'job', 'timeentry'] } },
+                ],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/customfield/{id}': {
+            get: {
+                summary: 'Fetch a custom field',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a custom field',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a custom field',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/capacity/summary': {
             get: {
                 summary: 'Per-worker capacity / utilization for a period (#459)',

--- a/app/controllers/customfielddefcontroller.js
+++ b/app/controllers/customfielddefcontroller.js
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { validateAgainstDefs } = require('../services/custom-field.js');
+const CustomFieldDef = db.CustomFieldDef;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+/** Load a def and enforce the secure-404 company scope. */
+async function findScoped(req, res) {
+    let def;
+    try {
+        def = await CustomFieldDef.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!def || def.cfdArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || def.cfdCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return def;
+}
+
+/** Resolve the target company (or null after responding). Master keys pass companyId. */
+async function resolveCompany(req, res, fromBody) {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        res.status(403).json({ message: "Authorization key not sent." });
+        return null;
+    }
+    const isMaster = await IsMaster(authKey);
+    if (isMaster) {
+        const companyId = Number(fromBody ? (req.body || {}).companyId : req.query.companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            res.status(400).json({ message: "Master-key requests must specify companyId." });
+            return null;
+        }
+        return companyId;
+    }
+    const companyId = await GetCompanyId(authKey);
+    if (companyId === -1) {
+        res.status(403).json({ message: "Invalid Authorization Key." });
+        return null;
+    }
+    return companyId;
+}
+
+/** POST /v1/customfield — declare a custom field. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    let companyId;
+    if (!isMaster) {
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (body.cfdCompId !== undefined && Number(body.cfdCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot define a field for a company you do not belong to." });
+        }
+    } else {
+        companyId = Number(body.cfdCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify cfdCompId." });
+        }
+    }
+
+    // Enforce name uniqueness per (company, entity).
+    try {
+        const existing = await CustomFieldDef.findOne({ where: { cfdCompId: companyId, cfdEntity: body.cfdEntity, cfdName: body.cfdName } });
+        if (existing) {
+            return res.status(409).json({ message: "A field with that name already exists for this entity." });
+        }
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef uniqueness check failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    try {
+        const created = await CustomFieldDef.create({
+            cfdCompId: companyId,
+            cfdEntity: body.cfdEntity,
+            cfdName: body.cfdName,
+            cfdLabel: body.cfdLabel,
+            cfdType: body.cfdType,
+            cfdRequired: body.cfdRequired === true,
+            cfdArch: false,
+        });
+        return res.status(201).json({ message: "Custom field created.", customField: created });
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/customfield/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const def = await findScoped(req, res);
+    if (!def) return undefined;
+    return res.status(200).json({ message: "Found.", customField: def });
+};
+
+/** GET /v1/customfield/bycompany/:id — list a company's fields (optional ?entity). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const where = { cfdCompId: targetCompanyId };
+    if (typeof req.query.entity === 'string' && req.query.entity) where.cfdEntity = req.query.entity;
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await CustomFieldDef.findAndCountAll({
+            where,
+            limit,
+            offset,
+            order: [['cfdId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, customFields: rows });
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/customfield/validate — validate a values object against the
+ * company's defs for an entity. 200 { valid:true, values } or 422
+ * { valid:false, errors }.
+ */
+exports.validate = async (req, res) => {
+    const companyId = await resolveCompany(req, res, true);
+    if (companyId === null) return undefined;
+    const body = req.body || {};
+
+    let defs;
+    try {
+        defs = await CustomFieldDef.findAll({ where: { cfdCompId: companyId, cfdEntity: body.entity } });
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const result = validateAgainstDefs(defs, body.values);
+    if (result.errors) {
+        return res.status(422).json({ message: "Custom field validation failed.", valid: false, errors: result.errors });
+    }
+    return res.status(200).json({ message: "Valid.", valid: true, values: result.values });
+};
+
+/** PATCH /v1/customfield/:id — partial update. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const def = await findScoped(req, res);
+    if (!def) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of ['cfdName', 'cfdLabel', 'cfdType', 'cfdRequired']) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await def.update(updates);
+        return res.status(200).json({ message: "Updated.", customField: def });
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/customfield/:id — soft-delete (sets cfdArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const def = await findScoped(req, res);
+    if (!def) return undefined;
+
+    try {
+        await def.update({ cfdArch: true });
+        return res.status(200).json({ message: "Archived.", id: def.cfdId });
+    } catch (error) {
+        log.error({ err: error }, 'CustomFieldDef archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260629000000-custom-field-def.js
+++ b/app/migrations/20260629000000-custom-field-def.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Custom fields (#409). A CustomFieldDef declares a typed custom field
+// (text/number/date/boolean) for a target entity type (customer / job /
+// timeentry) within a company. Values are validated against these defs
+// (app/services/custom-field.js); storing values on the target rows is a
+// follow-up. New table in the increment layer; no FK constraints.
+// setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'CustomFieldDef', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    cfdId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    cfdCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    cfdEntity: { type: Sequelize.TEXT, allowNull: false },
+                    cfdName: { type: Sequelize.TEXT, allowNull: false },
+                    cfdLabel: { type: Sequelize.TEXT, allowNull: true },
+                    cfdType: { type: Sequelize.TEXT, allowNull: false },
+                    cfdRequired: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    cfdArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'CustomFieldDef_scope_idx', fields: ['cfdCompId', 'cfdEntity', 'cfdArch'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/customfielddef.model.js
+++ b/app/models/customfielddef.model.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * CustomFieldDef — a typed custom-field declaration (#409): cfdName/cfdType
+ * for a target cfdEntity ('customer' | 'job' | 'timeentry') within a
+ * company. The pure validator in app/services/custom-field.js coerces and
+ * checks values against these defs. Company-scoped via cfdCompId.
+ * Soft-deletes via cfdArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const CustomFieldDef = sequelize.define('CustomFieldDef', {
+        cfdId: {
+            field: 'cfdId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        cfdCompId: {
+            field: 'cfdCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        cfdEntity: {
+            field: 'cfdEntity',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        cfdName: {
+            field: 'cfdName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        cfdLabel: {
+            field: 'cfdLabel',
+            type: Sequelize.TEXT,
+        },
+        cfdType: {
+            field: 'cfdType',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        cfdRequired: {
+            field: 'cfdRequired',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+        cfdArch: {
+            field: 'cfdArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'CustomFieldDef',
+        timestamps: true,
+        defaultScope: { where: { cfdArch: false } }
+    });
+
+    return CustomFieldDef;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -49,6 +49,7 @@ const share = require('../controllers/sharecontroller.js');
 const approvalChain = require('../controllers/approvalchaincontroller.js');
 const invitation = require('../controllers/invitationcontroller.js');
 const capacity = require('../controllers/capacitycontroller.js');
+const customField = require('../controllers/customfielddefcontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -88,6 +89,7 @@ const shareSchemas = require('../schemas/share.schema.js');
 const approvalChainSchemas = require('../schemas/approvalchain.schema.js');
 const invitationSchemas = require('../schemas/invitation.schema.js');
 const capacitySchemas = require('../schemas/capacity.schema.js');
+const customFieldSchemas = require('../schemas/customfielddef.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -1034,6 +1036,40 @@ router.get(
     '/v1/capacity/summary',
     v.query(capacitySchemas.capacityQuery),
     capacity.summary,
+);
+
+// v1 custom-field routes (#409): typed field definitions + a validator.
+router.post(
+    '/v1/customfield',
+    v.body(customFieldSchemas.createCustomFieldDefBody),
+    customField.create,
+);
+router.post(
+    '/v1/customfield/validate',
+    v.body(customFieldSchemas.validateBody),
+    customField.validate,
+);
+router.get(
+    '/v1/customfield/bycompany/:id',
+    v.params(customFieldSchemas.intIdParam),
+    v.query(customFieldSchemas.listByCompanyQuery),
+    customField.listByCompany,
+);
+router.get(
+    '/v1/customfield/:id',
+    v.params(customFieldSchemas.intIdParam),
+    customField.getById,
+);
+router.patch(
+    '/v1/customfield/:id',
+    v.params(customFieldSchemas.intIdParam),
+    v.body(customFieldSchemas.updateCustomFieldDefBody),
+    customField.update,
+);
+router.delete(
+    '/v1/customfield/:id',
+    v.params(customFieldSchemas.intIdParam),
+    customField.remove,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/customfielddef.schema.js
+++ b/app/schemas/customfielddef.schema.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+const { TYPES, ENTITIES } = require('../services/custom-field.js');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/customfield body (#409). cfdCompId optional (non-master → own; master required). */
+const createCustomFieldDefBody = z.object({
+    cfdEntity: z.enum(ENTITIES),
+    cfdName: z.string().min(1).max(64).regex(/^[A-Za-z][A-Za-z0-9_]*$/, 'Must start with a letter; letters/digits/underscore only.'),
+    cfdLabel: z.string().min(1).max(255).optional(),
+    cfdType: z.enum(TYPES),
+    cfdRequired: z.boolean().optional(),
+    cfdCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: cfdEntity, cfdName, cfdLabel, cfdType, cfdRequired, cfdCompId.',
+});
+
+/** PATCH /v1/customfield/:id — cfdEntity + cfdCompId are not patchable. */
+const updateCustomFieldDefBody = z.object({
+    cfdName: z.string().min(1).max(64).regex(/^[A-Za-z][A-Za-z0-9_]*$/).optional(),
+    cfdLabel: z.string().min(1).max(255).nullable().optional(),
+    cfdType: z.enum(TYPES).optional(),
+    cfdRequired: z.boolean().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: cfdName, cfdLabel, cfdType, cfdRequired.',
+});
+
+const listByCompanyQuery = z.object({
+    entity: z.enum(ENTITIES).optional(),
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: entity, limit, offset.',
+});
+
+/** POST /v1/customfield/validate body — check a values object against the defs. */
+const validateBody = z.object({
+    entity: z.enum(ENTITIES),
+    values: z.record(z.any()),
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: entity, values, companyId.',
+});
+
+module.exports = {
+    intIdParam,
+    createCustomFieldDefBody,
+    updateCustomFieldDefBody,
+    listByCompanyQuery,
+    validateBody,
+};

--- a/app/services/custom-field.js
+++ b/app/services/custom-field.js
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * custom-field.js — typed custom-field validation (#409). PURE: no DB, no
+ * I/O. `coerceValue` turns a raw input into the canonical value for a
+ * field type (or an error); `validateAgainstDefs` checks a whole values
+ * object against a set of CustomFieldDefs — coercing knowns, rejecting
+ * unknown keys, and enforcing required. Returns `{ values }` on success or
+ * `{ errors }` (a field→message map).
+ */
+
+const TYPES = ['text', 'number', 'date', 'boolean'];
+const ENTITIES = ['customer', 'job', 'timeentry'];
+
+/** Coerce a raw value to its typed form. @returns { value } or { error }. */
+function coerceValue(type, raw) {
+    switch (type) {
+        case 'text':
+            return { value: String(raw) };
+        case 'number': {
+            const n = Number(raw);
+            return Number.isFinite(n) ? { value: n } : { error: 'must be a number' };
+        }
+        case 'boolean': {
+            if (typeof raw === 'boolean') return { value: raw };
+            if (raw === 'true' || raw === 1 || raw === '1') return { value: true };
+            if (raw === 'false' || raw === 0 || raw === '0') return { value: false };
+            return { error: 'must be a boolean' };
+        }
+        case 'date': {
+            const s = String(raw);
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(s) || Number.isNaN(new Date(`${s}T00:00:00Z`).getTime())) {
+                return { error: 'must be a YYYY-MM-DD date' };
+            }
+            return { value: s };
+        }
+        default:
+            return { error: 'unknown field type' };
+    }
+}
+
+const isEmpty = (v) => v == null || v === '';
+
+/**
+ * Validate a values object against the company's defs for an entity.
+ * @param defs array of CustomFieldDef ({ cfdName, cfdType, cfdRequired }).
+ * @param values a { fieldName: raw } object.
+ */
+function validateAgainstDefs(defs, values) {
+    const list = Array.isArray(defs) ? defs : [];
+    const vals = (values && typeof values === 'object') ? values : {};
+    const byName = new Map(list.map((d) => [d.cfdName, d]));
+    const out = {};
+    const errors = {};
+
+    // Reject values for fields that aren't defined.
+    for (const key of Object.keys(vals)) {
+        if (!byName.has(key)) errors[key] = 'unknown custom field';
+    }
+
+    for (const d of list) {
+        const raw = vals[d.cfdName];
+        if (isEmpty(raw)) {
+            if (d.cfdRequired) errors[d.cfdName] = 'is required';
+            continue;
+        }
+        const r = coerceValue(d.cfdType, raw);
+        if (r.error) errors[d.cfdName] = r.error;
+        else out[d.cfdName] = r.value;
+    }
+
+    if (Object.keys(errors).length) return { errors };
+    return { values: out };
+}
+
+module.exports = { TYPES, ENTITIES, coerceValue, validateAgainstDefs };

--- a/tests/api/customfield.test.js
+++ b/tests/api/customfield.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/customfield (#409) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, ApprovalChain: {}, Invitation: {}, User: {},
+    CustomFieldDef: { findByPk: vi.fn().mockResolvedValue(null), findOne: vi.fn().mockResolvedValue(null), findAll: vi.fn().mockResolvedValue([]), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { cfdEntity: 'customer', cfdName: 'region', cfdType: 'text' };
+
+describe('CustomFieldDef auth + schema contract (#409)', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/customfield').send(good)).status).toBe(403);
+    });
+    test('POST 400 on an invalid entity (schema enum)', async () => {
+        expect((await request(app).post('/v1/customfield').set('authKey', 'k').send({ ...good, cfdEntity: 'invoice' })).status).toBe(400);
+    });
+    test('POST 400 on an invalid type (schema enum)', async () => {
+        expect((await request(app).post('/v1/customfield').set('authKey', 'k').send({ ...good, cfdType: 'json' })).status).toBe(400);
+    });
+    test('POST 400 on a bad field name (schema regex)', async () => {
+        expect((await request(app).post('/v1/customfield').set('authKey', 'k').send({ ...good, cfdName: '1bad name' })).status).toBe(400);
+    });
+    test('POST /validate 403 without authKey', async () => {
+        expect((await request(app).post('/v1/customfield/validate').send({ entity: 'customer', values: {} })).status).toBe(403);
+    });
+    test('POST /validate 400 on a missing values object (schema)', async () => {
+        expect((await request(app).post('/v1/customfield/validate').set('authKey', 'k').send({ entity: 'customer' })).status).toBe(400);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/customfield/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('CustomFieldDef table exists with a company include (#409)', async () => {
+        if (!connected) return;
+        const rows = await db.CustomFieldDef.findAll({
+            attributes: ['cfdId', 'cfdCompId', 'cfdEntity', 'cfdName', 'cfdType', 'cfdRequired'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.CustomFieldDef.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('Invitation table exists with a company include (#458)', async () => {
         if (!connected) return;
         const rows = await db.Invitation.findAll({

--- a/tests/unit/custom-field.test.js
+++ b/tests/unit/custom-field.test.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { TYPES, ENTITIES, coerceValue, validateAgainstDefs } from '../../app/services/custom-field.js';
+
+describe('custom-field (#409)', () => {
+    test('type + entity vocab', () => {
+        expect(TYPES).toEqual(['text', 'number', 'date', 'boolean']);
+        expect(ENTITIES).toEqual(['customer', 'job', 'timeentry']);
+    });
+
+    test('coerceValue by type', () => {
+        expect(coerceValue('text', 42)).toEqual({ value: '42' });
+        expect(coerceValue('number', '3.5')).toEqual({ value: 3.5 });
+        expect(coerceValue('number', 'x')).toEqual({ error: 'must be a number' });
+        expect(coerceValue('boolean', 'true')).toEqual({ value: true });
+        expect(coerceValue('boolean', 0)).toEqual({ value: false });
+        expect(coerceValue('boolean', 'maybe')).toEqual({ error: 'must be a boolean' });
+        expect(coerceValue('date', '2026-03-01')).toEqual({ value: '2026-03-01' });
+        expect(coerceValue('date', '03/01/2026').error).toBeTruthy();
+        expect(coerceValue('bogus', 'x').error).toBeTruthy();
+    });
+
+    const DEFS = [
+        { cfdName: 'region', cfdType: 'text', cfdRequired: true },
+        { cfdName: 'seats', cfdType: 'number', cfdRequired: false },
+        { cfdName: 'vip', cfdType: 'boolean', cfdRequired: false },
+    ];
+
+    test('validateAgainstDefs coerces knowns and returns values', () => {
+        const res = validateAgainstDefs(DEFS, { region: 'EMEA', seats: '10', vip: 'true' });
+        expect(res).toEqual({ values: { region: 'EMEA', seats: 10, vip: true } });
+    });
+
+    test('validateAgainstDefs enforces required + rejects unknown + bad type', () => {
+        expect(validateAgainstDefs(DEFS, { seats: '10' }).errors).toMatchObject({ region: 'is required' });
+        expect(validateAgainstDefs(DEFS, { region: 'X', mystery: 1 }).errors).toMatchObject({ mystery: 'unknown custom field' });
+        expect(validateAgainstDefs(DEFS, { region: 'X', seats: 'nope' }).errors).toMatchObject({ seats: 'must be a number' });
+    });
+
+    test('optional empty fields are skipped', () => {
+        expect(validateAgainstDefs(DEFS, { region: 'X' })).toEqual({ values: { region: 'X' } });
+    });
+});


### PR DESCRIPTION
## Summary

Let each company define its own typed fields on customers, jobs, and time entries — and validate values against them.

Closes #409.

## Changes

- **Migration `20260629000000`** — a company-scoped `CustomFieldDef` (`cfdEntity`, `cfdName`, `cfdLabel`, `cfdType`, `cfdRequired`, `cfdArch`).
- **Full REST** on `/v1/customfield` — `POST` (name-unique per entity → **409** on dupe), `GET /bycompany/{id}` (optional `?entity`), `GET|PATCH|DELETE /{id}` — company-scoped with secure-404. Field names are identifier-validated (`^[A-Za-z][A-Za-z0-9_]*$`).
- **`POST /v1/customfield/validate`** `{ entity, values }` — coerces and checks a values object against the company's defs for that entity: **200** with the coerced `{ values }`, or **422** with a per-field `{ errors }` map (required-missing, unknown-field, wrong-type).
- **`custom-field.js`** — pure: `coerceValue` (text/number/date/boolean) and `validateAgainstDefs`. Unit-tested.

## Scope

This lands the **definitions + a validator** — the schema and the typed-validation primitive. **Attaching values to customer/job/timeentry rows** (a JSONB column validated through this service on write) is the natural, additive follow-up.

## Verification

`npm run lint` clean; `npm test` → **1535 passing** (coerce per type incl. bad inputs; validate required / unknown-field / wrong-type / optional-empty; route auth + entity/type/name schema; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/