### PR TITLE
feat(billing-rates): billable-classification rules (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Billable-classification rules** (#415). A new company-scoped
+  `BillableRule` entity, migration `20260630000000`, mapping a match on a
+  time entry's **job / task / category** to a default billable /
+  non-billable classification. Rules evaluate **first-match by priority**
+  (like the rate resolver); non-null criteria are required, null criteria
+  are wildcards (an all-null rule is a catch-all). Full REST on
+  `/v1/billablerule` (create, `bycompany` list, get/patch/delete) plus
+  `POST /v1/billablerule/evaluate` → `{ billable, matchedRuleId }`. Pure
+  `billable-rules.js` engine.
 - **Custom fields** (#409). A new company-scoped `CustomFieldDef` entity,
   migration `20260629000000`, declaring **typed** custom fields
   (text/number/date/boolean) for a target entity (`customer` / `job` /

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -81,6 +81,7 @@ db.ReportSchedule = require('../models/reportschedule.model.js')(sequelize, Sequ
 db.ApprovalChain = require('../models/approvalchain.model.js')(sequelize, Sequelize);
 db.Invitation = require('../models/invitation.model.js')(sequelize, Sequelize);
 db.CustomFieldDef = require('../models/customfielddef.model.js')(sequelize, Sequelize);
+db.BillableRule = require('../models/billablerule.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible
@@ -258,5 +259,9 @@ db.Invitation.belongsTo(db.Company, { foreignKey: 'invtCompId', as: 'company' })
 // CustomFieldDef → Company (cfdCompId): custom-field definitions (#409).
 db.Company.hasMany(db.CustomFieldDef,   { foreignKey: 'cfdCompId', as: 'customFieldDefs' });
 db.CustomFieldDef.belongsTo(db.Company, { foreignKey: 'cfdCompId', as: 'company' });
+
+// BillableRule → Company (bruCompId): billable-classification rules (#415).
+db.Company.hasMany(db.BillableRule,   { foreignKey: 'bruCompId', as: 'billableRules' });
+db.BillableRule.belongsTo(db.Company, { foreignKey: 'bruCompId', as: 'company' });
 
 module.exports = db;

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1694,6 +1694,50 @@ const spec = {
                 },
             },
         },
+        '/v1/billablerule': {
+            post: {
+                summary: 'Define a billable-classification rule (#415)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { bruName: { type: 'string' }, bruPriority: { type: 'integer' }, bruMatchJobId: { type: 'integer', nullable: true }, bruMatchTaskId: { type: 'integer', nullable: true }, bruMatchCategory: { type: 'string', nullable: true }, bruBillable: { type: 'boolean' }, bruCompId: { type: 'integer' } }, required: ['bruName', 'bruBillable'] } } } },
+                responses: { 201: { description: 'Created' }, 400: { description: 'Validation error; master keys must specify bruCompId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/billablerule/evaluate': {
+            post: {
+                summary: 'Classify a { jobId, taskId, category } context (#415)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { jobId: { type: 'integer' }, taskId: { type: 'integer' }, category: { type: 'string' }, companyId: { type: 'integer' } } } } } },
+                responses: { 200: { description: '{ billable, matchedRuleId } — billable null if no rule matches' }, 400: { description: 'Master keys must specify companyId' }, 403: { description: 'Auth failure' } },
+            },
+        },
+        '/v1/billablerule/bycompany/{id}': {
+            get: {
+                summary: "List a company's billable rules (priority order)",
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found (paginated)' }, 403: { description: 'Cross-tenant' } },
+            },
+        },
+        '/v1/billablerule/{id}': {
+            get: {
+                summary: 'Fetch a billable rule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Found' }, 404: { description: 'Not found' } },
+            },
+            patch: {
+                summary: 'Update a billable rule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Updated' }, 400: { description: 'Validation error' }, 404: { description: 'Not found' } },
+            },
+            delete: {
+                summary: 'Archive a billable rule',
+                security: [{ authKey: [] }],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'Archived' }, 404: { description: 'Not found' } },
+            },
+        },
         '/v1/customfield': {
             post: {
                 summary: 'Declare a typed custom field for an entity (#409)',

--- a/app/controllers/billablerulecontroller.js
+++ b/app/controllers/billablerulecontroller.js
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const db = require('../config/db.config.js');
+const log = require('../config/logger.js');
+const auth = require('../middleware/auth.js');
+const { buildLinkHeader } = require('../middleware/pagination.js');
+const { evaluate } = require('../services/billable-rules.js');
+const BillableRule = db.BillableRule;
+
+const IsMaster = auth.isMaster;
+const GetCompanyId = auth.getCompanyId;
+
+const MATCH_FIELDS = ['bruName', 'bruPriority', 'bruMatchJobId', 'bruMatchTaskId', 'bruMatchCategory', 'bruBillable', 'bruActive'];
+
+/** Load a rule and enforce the secure-404 company scope. */
+async function findScoped(req, res) {
+    let rule;
+    try {
+        rule = await BillableRule.findByPk(req.params.id);
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule.findByPk failed');
+        res.status(500).json({ message: "Error!" });
+        return null;
+    }
+    if (!rule || rule.bruArch) {
+        res.status(404).json({ message: "Not found." });
+        return null;
+    }
+    const isMaster = await IsMaster(req.get('authKey'));
+    if (!isMaster) {
+        const companyId = await GetCompanyId(req.get('authKey'));
+        if (companyId === -1 || rule.bruCompId !== companyId) {
+            res.status(404).json({ message: "Not found." });
+            return null;
+        }
+    }
+    return rule;
+}
+
+/** Resolve the target company (or null after responding). Master keys pass companyId (body). */
+async function resolveCompany(req, res) {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        res.status(403).json({ message: "Authorization key not sent." });
+        return null;
+    }
+    const isMaster = await IsMaster(authKey);
+    if (isMaster) {
+        const companyId = Number((req.body || {}).companyId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            res.status(400).json({ message: "Master-key requests must specify companyId." });
+            return null;
+        }
+        return companyId;
+    }
+    const companyId = await GetCompanyId(authKey);
+    if (companyId === -1) {
+        res.status(403).json({ message: "Invalid Authorization Key." });
+        return null;
+    }
+    return companyId;
+}
+
+/** POST /v1/billablerule — define a billable-classification rule. */
+exports.create = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    let isMaster;
+    try {
+        isMaster = await IsMaster(authKey);
+    } catch (error) {
+        log.error({ err: error }, 'IsMaster failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const body = req.body || {};
+    let companyId;
+    if (!isMaster) {
+        try {
+            companyId = await GetCompanyId(authKey);
+        } catch (error) {
+            log.error({ err: error }, 'GetCompanyId failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+        if (body.bruCompId !== undefined && Number(body.bruCompId) !== companyId) {
+            return res.status(403).json({ message: "Cannot define a rule for a company you do not belong to." });
+        }
+    } else {
+        companyId = Number(body.bruCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify bruCompId." });
+        }
+    }
+
+    try {
+        const created = await BillableRule.create({
+            bruCompId: companyId,
+            bruName: body.bruName,
+            bruPriority: body.bruPriority == null ? 100 : body.bruPriority,
+            bruMatchJobId: body.bruMatchJobId == null ? null : body.bruMatchJobId,
+            bruMatchTaskId: body.bruMatchTaskId == null ? null : body.bruMatchTaskId,
+            bruMatchCategory: body.bruMatchCategory == null ? null : body.bruMatchCategory,
+            bruBillable: body.bruBillable === true,
+            bruActive: true,
+            bruArch: false,
+        });
+        return res.status(201).json({ message: "Billable rule created.", billableRule: created });
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule.create failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** GET /v1/billablerule/:id — fetch one. Secure-404 scoped. */
+exports.getById = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rule = await findScoped(req, res);
+    if (!rule) return undefined;
+    return res.status(200).json({ message: "Found.", billableRule: rule });
+};
+
+/** GET /v1/billablerule/bycompany/:id — list a company's rules (priority order). */
+exports.listByCompany = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const targetCompanyId = Number(req.params.id);
+    if (!Number.isInteger(targetCompanyId) || targetCompanyId <= 0) {
+        return res.status(400).json({ message: "Invalid company id." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    if (!isMaster) {
+        const companyId = await GetCompanyId(authKey);
+        if (companyId === -1 || companyId !== targetCompanyId) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const requestedLimit = parseInt(req.query.limit, 10);
+    const limit = Number.isInteger(requestedLimit) && requestedLimit > 0 ? Math.min(requestedLimit, 500) : 100;
+    const requestedOffset = parseInt(req.query.offset, 10);
+    const offset = Number.isInteger(requestedOffset) && requestedOffset >= 0 ? requestedOffset : 0;
+
+    try {
+        const { count, rows } = await BillableRule.findAndCountAll({
+            where: { bruCompId: targetCompanyId },
+            limit,
+            offset,
+            order: [['bruPriority', 'ASC'], ['bruId', 'ASC']],
+        });
+        const link = buildLinkHeader({ req, limit, offset, count });
+        if (link) res.setHeader('Link', link);
+        return res.status(200).json({ message: "Found.", count, limit, offset, billableRules: rows });
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule.findAndCountAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/**
+ * POST /v1/billablerule/evaluate — classify a { jobId, taskId, category }
+ * context against the company's rules. Returns { billable, matchedRuleId }
+ * (billable null when no rule matches).
+ */
+exports.evaluate = async (req, res) => {
+    const companyId = await resolveCompany(req, res);
+    if (companyId === null) return undefined;
+    const body = req.body || {};
+
+    let rules;
+    try {
+        rules = await BillableRule.findAll({ where: { bruCompId: companyId, bruActive: true } });
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule.findAll failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const result = evaluate(rules, { jobId: body.jobId, taskId: body.taskId, category: body.category });
+    return res.status(200).json({ message: "Evaluated.", companyId, ...result });
+};
+
+/** PATCH /v1/billablerule/:id — partial update. */
+exports.update = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rule = await findScoped(req, res);
+    if (!rule) return undefined;
+
+    const body = req.body || {};
+    const updates = {};
+    for (const f of MATCH_FIELDS) {
+        if (body[f] !== undefined) updates[f] = body[f];
+    }
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ message: "No updatable fields supplied." });
+    }
+
+    try {
+        await rule.update(updates);
+        return res.status(200).json({ message: "Updated.", billableRule: rule });
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule.update failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};
+
+/** DELETE /v1/billablerule/:id — soft-delete (sets bruArch = true). */
+exports.remove = async (req, res) => {
+    if (!req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const rule = await findScoped(req, res);
+    if (!rule) return undefined;
+
+    try {
+        await rule.update({ bruArch: true });
+        return res.status(200).json({ message: "Archived.", id: rule.bruId });
+    } catch (error) {
+        log.error({ err: error }, 'BillableRule archive failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+};

--- a/app/migrations/20260630000000-billable-rule.js
+++ b/app/migrations/20260630000000-billable-rule.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Billable-classification rules (#415). A BillableRule maps a match on a
+// time entry's job / task / category to a default billable/non-billable
+// classification. Rules evaluate first-match by priority (like the rate
+// resolver). Company-scoped via bruCompId. New table in the increment
+// layer; no FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'BillableRule', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    bruId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    bruCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    bruName: { type: Sequelize.TEXT, allowNull: false },
+                    bruPriority: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 100 },
+                    bruMatchJobId: { type: Sequelize.INTEGER, allowNull: true },
+                    bruMatchTaskId: { type: Sequelize.INTEGER, allowNull: true },
+                    bruMatchCategory: { type: Sequelize.TEXT, allowNull: true },
+                    bruBillable: { type: Sequelize.BOOLEAN, allowNull: false },
+                    bruActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+                    bruArch: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'BillableRule_scope_idx', fields: ['bruCompId', 'bruArch', 'bruPriority'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/billablerule.model.js
+++ b/app/models/billablerule.model.js
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * BillableRule — a company-scoped rule (#415) that classifies a time
+ * entry as billable or not based on its job / task / category. Any
+ * non-null match column is a required condition; null columns are
+ * wildcards, so an all-null rule is a catch-all default. Rules evaluate
+ * first-match by bruPriority (ascending) — see app/services/billable-rules.js.
+ * Soft-deletes via bruArch.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const BillableRule = sequelize.define('BillableRule', {
+        bruId: {
+            field: 'bruId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        bruCompId: {
+            field: 'bruCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        bruName: {
+            field: 'bruName',
+            type: Sequelize.TEXT,
+            allowNull: false,
+        },
+        bruPriority: {
+            field: 'bruPriority',
+            type: Sequelize.INTEGER,
+            defaultValue: 100,
+        },
+        bruMatchJobId: {
+            field: 'bruMatchJobId',
+            type: Sequelize.INTEGER,
+        },
+        bruMatchTaskId: {
+            field: 'bruMatchTaskId',
+            type: Sequelize.INTEGER,
+        },
+        bruMatchCategory: {
+            field: 'bruMatchCategory',
+            type: Sequelize.TEXT,
+        },
+        bruBillable: {
+            field: 'bruBillable',
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+        },
+        bruActive: {
+            field: 'bruActive',
+            type: Sequelize.BOOLEAN,
+            defaultValue: true,
+        },
+        bruArch: {
+            field: 'bruArch',
+            type: Sequelize.BOOLEAN,
+            defaultValue: false,
+        },
+    }, {
+        tableName: 'BillableRule',
+        timestamps: true,
+        defaultScope: { where: { bruArch: false } }
+    });
+
+    return BillableRule;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -50,6 +50,7 @@ const approvalChain = require('../controllers/approvalchaincontroller.js');
 const invitation = require('../controllers/invitationcontroller.js');
 const capacity = require('../controllers/capacitycontroller.js');
 const customField = require('../controllers/customfielddefcontroller.js');
+const billableRule = require('../controllers/billablerulecontroller.js');
 const openapiSpec = require('../config/openapi.js');
 const v = require('../middleware/validate.js');
 const customerSchemas = require('../schemas/customer.schema.js');
@@ -90,6 +91,7 @@ const approvalChainSchemas = require('../schemas/approvalchain.schema.js');
 const invitationSchemas = require('../schemas/invitation.schema.js');
 const capacitySchemas = require('../schemas/capacity.schema.js');
 const customFieldSchemas = require('../schemas/customfielddef.schema.js');
+const billableRuleSchemas = require('../schemas/billablerule.schema.js');
 const inventoryTransactionSchemas = require('../schemas/inventorytransaction.schema.js');
 
 // Health / readiness probe. No auth required — only exposes liveness
@@ -1070,6 +1072,40 @@ router.delete(
     '/v1/customfield/:id',
     v.params(customFieldSchemas.intIdParam),
     customField.remove,
+);
+
+// v1 billable-rule routes (#415): classification rules + an evaluator.
+router.post(
+    '/v1/billablerule',
+    v.body(billableRuleSchemas.createBillableRuleBody),
+    billableRule.create,
+);
+router.post(
+    '/v1/billablerule/evaluate',
+    v.body(billableRuleSchemas.evaluateBody),
+    billableRule.evaluate,
+);
+router.get(
+    '/v1/billablerule/bycompany/:id',
+    v.params(billableRuleSchemas.intIdParam),
+    v.query(billableRuleSchemas.listByCompanyQuery),
+    billableRule.listByCompany,
+);
+router.get(
+    '/v1/billablerule/:id',
+    v.params(billableRuleSchemas.intIdParam),
+    billableRule.getById,
+);
+router.patch(
+    '/v1/billablerule/:id',
+    v.params(billableRuleSchemas.intIdParam),
+    v.body(billableRuleSchemas.updateBillableRuleBody),
+    billableRule.update,
+);
+router.delete(
+    '/v1/billablerule/:id',
+    v.params(billableRuleSchemas.intIdParam),
+    billableRule.remove,
 );
 
 // v1 rate-schedule routes (effective-dated rates, #414).

--- a/app/schemas/billablerule.schema.js
+++ b/app/schemas/billablerule.schema.js
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+const { z } = require('zod');
+
+const intIdParam = z.object({
+    id: z.coerce.number().int().positive(),
+});
+
+/** POST /v1/billablerule body (#415). bruCompId optional (non-master → own; master required). */
+const createBillableRuleBody = z.object({
+    bruName: z.string().min(1).max(255),
+    bruPriority: z.coerce.number().int().min(0).max(100000).optional(),
+    bruMatchJobId: z.coerce.number().int().positive().nullable().optional(),
+    bruMatchTaskId: z.coerce.number().int().positive().nullable().optional(),
+    bruMatchCategory: z.string().min(1).max(255).nullable().optional(),
+    bruBillable: z.boolean(),
+    bruCompId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: bruName, bruPriority, bruMatchJobId, bruMatchTaskId, bruMatchCategory, bruBillable, bruCompId.',
+});
+
+/** PATCH /v1/billablerule/:id — bruCompId is not patchable. */
+const updateBillableRuleBody = z.object({
+    bruName: z.string().min(1).max(255).optional(),
+    bruPriority: z.coerce.number().int().min(0).max(100000).optional(),
+    bruMatchJobId: z.coerce.number().int().positive().nullable().optional(),
+    bruMatchTaskId: z.coerce.number().int().positive().nullable().optional(),
+    bruMatchCategory: z.string().min(1).max(255).nullable().optional(),
+    bruBillable: z.boolean().optional(),
+    bruActive: z.boolean().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: bruName, bruPriority, bruMatchJobId, bruMatchTaskId, bruMatchCategory, bruBillable, bruActive.',
+});
+
+const listByCompanyQuery = z.object({
+    limit: z.coerce.number().int().positive().max(500).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+}).strict({
+    message: 'Unexpected query parameter. Allowed: limit, offset.',
+});
+
+/** POST /v1/billablerule/evaluate body — classify a time-entry context. */
+const evaluateBody = z.object({
+    jobId: z.coerce.number().int().positive().optional(),
+    taskId: z.coerce.number().int().positive().optional(),
+    category: z.string().min(1).max(255).optional(),
+    companyId: z.coerce.number().int().positive().optional(),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: jobId, taskId, category, companyId.',
+});
+
+module.exports = {
+    intIdParam,
+    createBillableRuleBody,
+    updateBillableRuleBody,
+    listByCompanyQuery,
+    evaluateBody,
+};

--- a/app/services/billable-rules.js
+++ b/app/services/billable-rules.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * billable-rules.js — first-match billable classification (#415). PURE: no
+ * DB, no I/O. Given a company's rules and a time-entry context
+ * ({ jobId, taskId, category }), return the billable classification from
+ * the highest-priority (lowest bruPriority) active rule whose non-null
+ * match criteria ALL equal the context. Null criteria are wildcards, so an
+ * all-null rule is a catch-all. No rule matches → { billable: null }.
+ */
+
+/** Does a rule's (non-null) criteria all match the context? */
+function ruleMatches(rule, ctx) {
+    const c = ctx || {};
+    if (rule.bruMatchJobId != null && Number(rule.bruMatchJobId) !== Number(c.jobId)) return false;
+    if (rule.bruMatchTaskId != null && Number(rule.bruMatchTaskId) !== Number(c.taskId)) return false;
+    if (rule.bruMatchCategory != null && String(rule.bruMatchCategory) !== String(c.category)) return false;
+    return true;
+}
+
+/** Evaluate a rule set against a context. @returns { billable, matchedRuleId }. */
+function evaluate(rules, ctx) {
+    const active = (rules || []).filter((r) => r && r.bruActive !== false && r.bruArch !== true);
+    active.sort((a, b) => (
+        (Number(a.bruPriority) || 0) - (Number(b.bruPriority) || 0)
+        || (Number(a.bruId) || 0) - (Number(b.bruId) || 0)
+    ));
+    for (const r of active) {
+        if (ruleMatches(r, ctx)) {
+            return { billable: r.bruBillable === true, matchedRuleId: r.bruId != null ? r.bruId : null };
+        }
+    }
+    return { billable: null, matchedRuleId: null };
+}
+
+module.exports = { evaluate, ruleMatches };

--- a/tests/api/billablerule.test.js
+++ b/tests/api/billablerule.test.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for /v1/billablerule (#415) — auth + schema.
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, ApprovalChain: {}, Invitation: {}, CustomFieldDef: {}, User: {},
+    BillableRule: { findByPk: vi.fn().mockResolvedValue(null), findAll: vi.fn().mockResolvedValue([]), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }), create: vi.fn() },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const good = { bruName: 'Travel is non-billable', bruMatchCategory: 'travel', bruBillable: false };
+
+describe('BillableRule auth + schema contract (#415)', () => {
+    test('POST 403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/billablerule').send(good)).status).toBe(403);
+    });
+    test('POST 400 on a missing bruBillable (schema)', async () => {
+        expect((await request(app).post('/v1/billablerule').set('authKey', 'k').send({ bruName: 'X', bruMatchCategory: 'travel' })).status).toBe(400);
+    });
+    test('POST 400 on a non-boolean bruBillable (schema)', async () => {
+        expect((await request(app).post('/v1/billablerule').set('authKey', 'k').send({ bruName: 'X', bruBillable: 'yes' })).status).toBe(400);
+    });
+    test('POST /evaluate 403 without authKey', async () => {
+        expect((await request(app).post('/v1/billablerule/evaluate').send({ jobId: 7 })).status).toBe(403);
+    });
+    test('POST /evaluate 400 on an unknown field (strict)', async () => {
+        expect((await request(app).post('/v1/billablerule/evaluate').set('authKey', 'k').send({ jobId: 7, bogus: 1 })).status).toBe(400);
+    });
+    test('GET /:id 403 without authKey', async () => {
+        expect((await request(app).get('/v1/billablerule/1')).status).toBe(403);
+    });
+});

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -215,6 +215,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(rows)).toBe(true);
     });
 
+    test('BillableRule table exists with a company include (#415)', async () => {
+        if (!connected) return;
+        const rows = await db.BillableRule.findAll({
+            attributes: ['bruId', 'bruCompId', 'bruName', 'bruPriority', 'bruMatchCategory', 'bruBillable'],
+            limit: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+        const withCompany = await db.BillableRule.findAll({
+            limit: 1,
+            include: [{ model: db.Company, as: 'company', required: false }],
+        });
+        expect(Array.isArray(withCompany)).toBe(true);
+    });
+
     test('CustomFieldDef table exists with a company include (#409)', async () => {
         if (!connected) return;
         const rows = await db.CustomFieldDef.findAll({

--- a/tests/unit/billable-rules.test.js
+++ b/tests/unit/billable-rules.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+
+import { describe, test, expect } from 'vitest';
+import { evaluate, ruleMatches } from '../../app/services/billable-rules.js';
+
+const RULES = [
+    { bruId: 1, bruPriority: 10, bruMatchCategory: 'travel', bruMatchJobId: null, bruMatchTaskId: null, bruBillable: false },
+    { bruId: 2, bruPriority: 20, bruMatchJobId: 7, bruMatchCategory: null, bruMatchTaskId: null, bruBillable: true },
+    { bruId: 3, bruPriority: 100, bruMatchJobId: null, bruMatchTaskId: null, bruMatchCategory: null, bruBillable: true }, // catch-all
+];
+
+describe('billable-rules (#415)', () => {
+    test('ruleMatches respects non-null criteria as required, null as wildcard', () => {
+        expect(ruleMatches({ bruMatchJobId: 7 }, { jobId: 7 })).toBe(true);
+        expect(ruleMatches({ bruMatchJobId: 7 }, { jobId: 8 })).toBe(false);
+        expect(ruleMatches({ bruMatchJobId: 7 }, {})).toBe(false);
+        expect(ruleMatches({ bruMatchJobId: null }, { jobId: 8 })).toBe(true); // wildcard
+    });
+
+    test('first match by priority wins', () => {
+        expect(evaluate(RULES, { category: 'travel' })).toEqual({ billable: false, matchedRuleId: 1 });
+        expect(evaluate(RULES, { jobId: 7 })).toEqual({ billable: true, matchedRuleId: 2 });
+    });
+
+    test('falls through to the catch-all', () => {
+        expect(evaluate(RULES, { jobId: 99, category: 'dev' })).toEqual({ billable: true, matchedRuleId: 3 });
+    });
+
+    test('priority ordering is by number, not array order', () => {
+        const shuffled = [RULES[2], RULES[1], RULES[0]];
+        expect(evaluate(shuffled, { category: 'travel' }).matchedRuleId).toBe(1);
+    });
+
+    test('inactive/archived rules are skipped; empty set → null', () => {
+        const inactive = [{ bruId: 5, bruPriority: 1, bruMatchCategory: 'travel', bruBillable: false, bruActive: false }];
+        expect(evaluate(inactive, { category: 'travel' })).toEqual({ billable: null, matchedRuleId: null });
+        expect(evaluate([], { jobId: 1 })).toEqual({ billable: null, matchedRuleId: null });
+    });
+});


### PR DESCRIPTION
## Summary

Encode "travel is never billable, internal jobs aren't billable, everything else is" as rules — then ask the API to classify any entry.

Closes #415.

## Changes

- **Migration `20260630000000`** — a company-scoped `BillableRule` (`bruName`, `bruPriority`, `bruMatchJobId`/`bruMatchTaskId`/`bruMatchCategory`, `bruBillable`, `bruActive`, `bruArch`).
- **Full REST** on `/v1/billablerule` — `POST`, `GET /bycompany/{id}` (priority order), `GET|PATCH|DELETE /{id}` — company-scoped with secure-404.
- **`POST /v1/billablerule/evaluate`** `{ jobId?, taskId?, category? }` → **`{ billable, matchedRuleId }`** (`billable: null` when nothing matches).
- **`billable-rules.js`** — pure, **first-match by priority** (same shape as the six-tier rate resolver): a rule's non-null criteria are all required; null criteria are wildcards, so an all-null rule is a catch-all default. Unit-tested.

## Design

Reuses the codebase's established **first-match-by-priority** resolution pattern, so classification is deterministic and auditable. Wiring this into time-entry creation (auto-set `teBillable` from the matched rule) is the natural additive follow-up — this PR lands the rule store + evaluator.

## Verification

`npm run lint` clean; `npm test` → **1555 passing** (`ruleMatches` required-vs-wildcard, first-match priority, catch-all fall-through, numeric ordering, inactive/empty → null; route auth + `bruBillable` boolean schema + strict-whitelist; integration table/association). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/