### PR TITLE
feat(timeentry): bulk import (#379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Added
+- **Bulk time-entry import** (#379). `POST /v1/timeentry/bulk`
+  `{ entries: [...] }` creates up to 200 entries in one call. Each row is
+  validated and created **independently** — a bad row fails on its own and
+  the rest still import — with a per-row `results[]` (`ok`/`teId` or
+  `status`/`message`) and counts. Status is **201** all-ok, **207**
+  partial, **400** all-failed. Single-create and bulk now share a
+  `createOneEntry` helper, so both apply identical validation, worker/job
+  link checks, and the locked-period guard.
 - **Billable-classification rules** (#415). A new company-scoped
   `BillableRule` entity, migration `20260630000000`, mapping a match on a
   time entry's **job / task / category** to a default billable /

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -880,6 +880,19 @@ const spec = {
                 },
             },
         },
+        '/v1/timeentry/bulk': {
+            post: {
+                summary: 'Bulk-import time entries — per-row results (#379)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { teCompId: { type: 'integer', description: 'Required for master keys.' }, entries: { type: 'array', items: { $ref: '#/components/schemas/TimeEntry' }, minItems: 1, maxItems: 200 } }, required: ['entries'] } } } },
+                responses: {
+                    201: { description: 'All rows created — { requested, created, failed, results[] }' },
+                    207: { description: 'Partial — some rows failed; see results[]' },
+                    400: { description: 'Validation error or all rows failed' },
+                    403: { description: 'Auth failure' },
+                },
+            },
+        },
         '/v1/timeentry': {
             post: {
                 summary: 'Create a time entry',

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -12,6 +12,7 @@ const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
 const { buildApprovalDigest } = require('../services/approval-reminders.js');
 const { sendMail } = require('../services/mailer.js');
+const { createTimeEntryBody } = require('../schemas/timeentry.schema.js');
 const TimeEntry = db.TimeEntry;
 
 // Auth helpers used to live inline here — they now share a single
@@ -158,6 +159,45 @@ async function checkEntryLinks({ teWorkerId, teJobId, teBillTypeId, teTaskId }, 
 }
 
 /**
+ * Create one time entry for a resolved company (#379). Returns
+ * { created } on success or { error: { status, message } } on a business
+ * validation failure; throws on a DB error (the caller maps to 500).
+ * Shared by the single-create handler and the bulk importer so both apply
+ * identical validation, link checks, and the locked-period guard.
+ */
+async function createOneEntry(companyId, body) {
+    const src = body || {};
+    const payload = {};
+    for (const f of ALLOWED_FIELDS_CREATE) {
+        if (src[f] !== undefined) payload[f] = src[f];
+    }
+    if (!payload.teCustId || !Number.isInteger(Number(payload.teCustId))) {
+        return { error: { status: 400, message: "teCustId is required and must be an integer." } };
+    }
+    if (!payload.teStartedAt) {
+        return { error: { status: 400, message: "teStartedAt is required (ISO 8601)." } };
+    }
+    payload.teCompId = companyId;
+    payload.teArch = false;
+    payload.teMinutes = computeMinutes(payload.teStartedAt, payload.teEndedAt);
+
+    const linkError = await checkEntryLinks(payload, companyId, payload.teCustId);
+    if (linkError) {
+        return { error: { status: linkError.status, message: linkError.message } };
+    }
+
+    // Locked-period guard (#441): can't create time in a closed period.
+    const lockDate = await companyLockDate(companyId);
+    const createLock = lockReason({ approvalStatus: 'open', startedAt: payload.teStartedAt, lockDate });
+    if (createLock) {
+        return { error: { status: 409, message: createLock } };
+    }
+
+    const created = await TimeEntry.create(payload);
+    return { created };
+}
+
+/**
  * POST /v1/timeentry
  *
  * Create a new time entry for a customer in the auth'd company.
@@ -190,52 +230,81 @@ exports.create = async (req, res) => {
         }
     }
 
-    const body = req.body || {};
-    const payload = {};
-    for (const f of ALLOWED_FIELDS_CREATE) {
-        if (body[f] !== undefined) payload[f] = body[f];
-    }
-    if (!payload.teCustId || !Number.isInteger(Number(payload.teCustId))) {
-        return res.status(400).json({ message: "teCustId is required and must be an integer." });
-    }
-    if (!payload.teStartedAt) {
-        return res.status(400).json({ message: "teStartedAt is required (ISO 8601)." });
-    }
-    payload.teCompId = companyId;
-    payload.teArch = false;
-    payload.teMinutes = computeMinutes(payload.teStartedAt, payload.teEndedAt);
-
-    let linkError;
+    let result;
     try {
-        linkError = await checkEntryLinks(payload, companyId, payload.teCustId);
-    } catch (error) {
-        log.error({ err: error }, 'TimeEntry worker/job link validation failed');
-        return res.status(500).json({ message: "Error!" });
-    }
-    if (linkError) {
-        return res.status(linkError.status).json({ message: linkError.message });
-    }
-
-    // Locked-period guard (#441): can't create time in a closed period.
-    let createLock;
-    try {
-        const lockDate = await companyLockDate(companyId);
-        createLock = lockReason({ approvalStatus: 'open', startedAt: payload.teStartedAt, lockDate });
-    } catch (error) {
-        log.error({ err: error }, 'create: lock check failed');
-        return res.status(500).json({ message: "Error!" });
-    }
-    if (createLock) {
-        return res.status(409).json({ message: createLock });
-    }
-
-    try {
-        const created = await TimeEntry.create(payload);
-        return res.status(201).json({ message: "Time entry created.", timeEntry: created });
+        result = await createOneEntry(companyId, req.body || {});
     } catch (error) {
         log.error({ err: error }, 'TimeEntry.create failed');
         return res.status(500).json({ message: "Error!" });
     }
+    if (result.error) {
+        return res.status(result.error.status).json({ message: result.error.message });
+    }
+    return res.status(201).json({ message: "Time entry created.", timeEntry: result.created });
+};
+
+/**
+ * POST /v1/timeentry/bulk — import many entries in one call (#379). Each
+ * row is validated + created independently, so a bad row fails on its own
+ * without aborting the rest. Returns a per-row result array and counts.
+ * Status: 201 all-ok, 207 partial, 400 all-failed.
+ */
+exports.bulk = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+
+    const isMaster = await IsMaster(authKey);
+    let companyId;
+    if (isMaster) {
+        companyId = Number(req.body && req.body.teCompId);
+        if (!Number.isInteger(companyId) || companyId <= 0) {
+            return res.status(400).json({ message: "Master-key requests must specify teCompId." });
+        }
+    } else {
+        companyId = await GetCompanyId(authKey);
+        if (companyId === -1) {
+            return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    }
+
+    const entries = (req.body && Array.isArray(req.body.entries)) ? req.body.entries : [];
+    const results = [];
+    let created = 0;
+    let failed = 0;
+
+    for (let i = 0; i < entries.length; i++) {
+        const parsed = createTimeEntryBody.safeParse(entries[i]);
+        if (!parsed.success) {
+            failed += 1;
+            results.push({ index: i, ok: false, status: 400, message: "Validation error." });
+            continue;
+        }
+        if (!isMaster && parsed.data.teCompId !== undefined && Number(parsed.data.teCompId) !== companyId) {
+            failed += 1;
+            results.push({ index: i, ok: false, status: 403, message: "Cannot create a time entry for a company you do not belong to." });
+            continue;
+        }
+
+        let r;
+        try {
+            r = await createOneEntry(companyId, parsed.data);
+        } catch (error) {
+            log.error({ err: error, index: i }, 'bulk: create failed');
+            r = { error: { status: 500, message: "Error!" } };
+        }
+        if (r.error) {
+            failed += 1;
+            results.push({ index: i, ok: false, status: r.error.status, message: r.error.message });
+        } else {
+            created += 1;
+            results.push({ index: i, ok: true, teId: r.created.teId });
+        }
+    }
+
+    const status = failed === 0 ? 201 : (created === 0 ? 400 : 207);
+    return res.status(status).json({ message: "Bulk import processed.", requested: entries.length, created, failed, results });
 };
 
 const START_FIELDS = [

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -197,6 +197,12 @@ router.post(
     v.body(timeEntrySchemas.createTimeEntryBody),
     timeEntry.create,
 );
+// Bulk import (#379): create many entries in one call, per-row results.
+router.post(
+    '/v1/timeentry/bulk',
+    v.body(timeEntrySchemas.bulkTimeEntryBody),
+    timeEntry.bulk,
+);
 // Timer capture (#396): start begins an in-flight entry, stop closes it.
 router.post(
     '/v1/timeentry/start',

--- a/app/schemas/timeentry.schema.js
+++ b/app/schemas/timeentry.schema.js
@@ -171,10 +171,23 @@ const startTimerBody = z.object({
     message: 'Unexpected field in body. Whitelist: teCustId, teCompId, teWorkerId, teJobId, teBillTypeId, teDescription, teBillable, teTags, teTaskId.',
 });
 
+/**
+ * POST /v1/timeentry/bulk body (#379). The outer shape only — each entry
+ * is validated per-row against createTimeEntryBody in the controller so a
+ * bad row reports its own error instead of failing the whole import.
+ */
+const bulkTimeEntryBody = z.object({
+    teCompId: z.coerce.number().int().positive().optional(),
+    entries: z.array(z.object({}).passthrough()).min(1).max(200),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: teCompId, entries.',
+});
+
 module.exports = {
     intIdParam,
     createTimeEntryBody,
     updateTimeEntryBody,
+    bulkTimeEntryBody,
     startTimerBody,
     approvalBody,
     copyTimeEntryBody,

--- a/tests/api/timeentry-bulk.test.js
+++ b/tests/api/timeentry-bulk.test.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// HTTP contract tests for POST /v1/timeentry/bulk (#379) — auth + schema.
+// The per-row create path is covered by the existing time-entry create
+// tests (create + bulk now share createOneEntry).
+
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../app/config/db.config.js', () => ({
+    sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
+    Sequelize: { Op: {} },
+    Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, ApprovalChain: {}, Invitation: {}, CustomFieldDef: {}, BillableRule: {}, User: {},
+    TimeEntry: { create: vi.fn(), findByPk: vi.fn().mockResolvedValue(null), findAndCountAll: vi.fn().mockResolvedValue({ count: 0, rows: [] }) },
+    ApiKey: {}, ApiMaster: {},
+}));
+
+let app;
+
+beforeAll(async () => {
+    const router = (await import('../../app/routers/router.js')).default
+        || require('../../app/routers/router.js');
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+});
+
+const entry = { teCustId: 1, teStartedAt: '2026-03-01T09:00:00Z', teEndedAt: '2026-03-01T10:00:00Z' };
+
+describe('Bulk time-entry import contract (#379)', () => {
+    test('403 without authKey (valid body reaches controller)', async () => {
+        expect((await request(app).post('/v1/timeentry/bulk').send({ entries: [entry] })).status).toBe(403);
+    });
+    test('400 on empty entries (schema min 1)', async () => {
+        expect((await request(app).post('/v1/timeentry/bulk').set('authKey', 'k').send({ entries: [] })).status).toBe(400);
+    });
+    test('400 on a non-array entries (schema)', async () => {
+        expect((await request(app).post('/v1/timeentry/bulk').set('authKey', 'k').send({ entries: 'nope' })).status).toBe(400);
+    });
+    test('400 on an unknown top-level field (strict)', async () => {
+        expect((await request(app).post('/v1/timeentry/bulk').set('authKey', 'k').send({ entries: [entry], bogus: 1 })).status).toBe(400);
+    });
+});


### PR DESCRIPTION
## Summary

Import a whole timesheet in one request — with per-row results, so one bad row doesn't sink the batch.

Closes #379.

## Changes

- **`POST /v1/timeentry/bulk`** `{ entries: [...] }` — creates up to **200** entries per call. Each row is **validated and created independently**: a bad row fails on its own and the rest still import. The response carries a per-row **`results[]`** (`{ index, ok, teId }` or `{ index, ok:false, status, message }`) plus `requested` / `created` / `failed` counts. Status is **201** all-ok, **207** partial, **400** all-failed.
- **Refactor:** extracted a shared **`createOneEntry`** helper; the single-create handler now calls it too, so `POST /v1/timeentry` and the bulk importer apply **identical** validation, worker/job link checks (belong-to-company), and the locked-period guard (#441) — no drift between the two paths.

## Design

Per-row isolation (vs. all-or-nothing) is the right default for an import — a spreadsheet with one malformed date shouldn't reject 199 good rows. Company scoping is resolved once (master passes `teCompId`); every row is stamped to that company.

## Verification

`npm run lint` clean; `npm test` → **1560 passing**. Crucially, the **35 existing time-entry create tests stay green** after the refactor (create + bulk share `createOneEntry`), and new bulk tests cover the auth + outer-schema gates (empty/non-array/unknown-field). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/