### PR TITLE
fix(security): scope teCustId to the effective company on create (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`pg` bumped 8.20.0 → 8.21.0** (#122). Patch-level dep refresh
   in the `minor-and-patch` Dependabot group.
 
+### Security
+- **Tenant-scope `teCustId` on time-entry create** (#373). Creating a time
+  entry (single or bulk) now verifies the customer belongs to the
+  effective company — a scoped key can no longer book time against another
+  tenant's customer (previously only a supplied `teJobId`'s customer was
+  cross-checked; a jobless entry with a foreign `teCustId` slipped through).
+  Returns 400 when the customer is missing or in another company.
+
 ### Added
 - **Bulk time-entry import** (#379). `POST /v1/timeentry/bulk`
   `{ entries: [...] }` creates up to 200 entries in one call. Each row is

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -181,6 +181,15 @@ async function createOneEntry(companyId, body) {
     payload.teArch = false;
     payload.teMinutes = computeMinutes(payload.teStartedAt, payload.teEndedAt);
 
+    // Multi-tenant scope (#373): the customer MUST belong to the effective
+    // company — otherwise a scoped key could book time against another
+    // tenant's customer. (Archived customers read as not-found via
+    // defaultScope → 400.)
+    const customer = await db.Customer.findByPk(Number(payload.teCustId), { attributes: ['custCompId'] });
+    if (!customer || customer.custCompId !== companyId) {
+        return { error: { status: 400, message: "teCustId must reference a customer in your company." } };
+    }
+
     const linkError = await checkEntryLinks(payload, companyId, payload.teCustId);
     if (linkError) {
         return { error: { status: linkError.status, message: linkError.message } };


### PR DESCRIPTION
## Summary

Close a multi-tenant hole in time-entry creation: a company-scoped key could book time against **another tenant's customer**.

Closes #373.

## The gap

`checkEntryLinks` verifies the worker / job / billing-type / task all belong to the caller's company — and if a `teJobId` is supplied, that the job's customer matches `teCustId`. But **`teCustId` itself was never tenant-verified**. A **jobless** entry (just `teCustId` + `teStartedAt`) with a `teCustId` pointing at a *different* company's customer would be created and scoped to the caller's company — leaking a foreign customer id into the caller's data and mis-attributing time.

## Fix

`createOneEntry` (the helper shared by single-create and the bulk importer from #379) now looks up the customer and rejects with **400** when it's missing or its `custCompId` doesn't match the effective company — before any row is written. One check, both create paths.

## Verification

`npm run lint` clean; `npm test` → **1560 passing**, including the **43 existing time-entry create tests unchanged** (no regression). A dedicated mock-based test for this branch is blocked by this repo's controller ↔ `db.config` mock interop (the same limitation documented on #445): the auth/customer lookups can't be injected into the controller's captured `db` from an ESM test. The guard itself is a direct `customer.custCompId !== companyId` comparison, and the debug run confirmed control reaches the customer lookup on the create path. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/