### PR TITLE
docs(readme): document the cross-tenant 404-vs-403 policy (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`pg` bumped 8.20.0 → 8.21.0** (#122). Patch-level dep refresh
   in the `minor-and-patch` Dependabot group.
 
+### Documentation
+- **Cross-tenant response-code policy** (#375). The README's "Secure-404 on
+  cross-tenant access" section now spells out, in a table, exactly when the
+  API returns **404** (a specific row you don't own — anti-enumeration)
+  versus **403** (a rejected credential or a `bycompany` scope you named
+  explicitly) versus **400** (validation / a bad cross-tenant foreign key),
+  so the distinction reads as deliberate rather than incidental.
+
 ### Security
 - **Tenant-scope `teCustId` on time-entry create** (#373). Creating a time
   entry (single or bulk) now verifies the customer belongs to the

--- a/README.md
+++ b/README.md
@@ -86,10 +86,26 @@ not `403 Forbidden` — when a non-master key references a row in a
 different company's scope. The two outcomes look identical from the
 client's side so a scoped caller can't probe sequential IDs to
 enumerate the size of another tenant's table by status code. Master
-keys still see all rows. The same pattern applies across all 16
-single-row entity endpoints; the auth-scope check that produces it
-is the same `getCompanyId(...) !== row.<entity>CompId` comparison
-the controllers use for the 403 paths on other surfaces.
+keys still see all rows.
+
+**When each status is used.** The 404-vs-403 choice is deliberate and
+consistent across the API:
+
+| Situation | Status | Why |
+|---|---|---|
+| Missing / malformed `authKey` | **403** | No identity to scope by; nothing about any tenant is revealed. |
+| Key doesn't resolve to a company | **403** | The credential itself is rejected. |
+| Single-row `:id` belongs to another tenant | **404** | Anti-enumeration — indistinguishable from "no such id". |
+| `…/bycompany/:id` list for a company that isn't yours | **403** | The company id is the *named* resource, not a hidden row; a 404 would be misleading and no per-row existence leaks. |
+| Request body / params fail validation | **400** | A shape error, decided before the scope check. |
+| Create body references another tenant's row (e.g. a foreign `teCustId`, #373) | **400** | Treated as a bad foreign key, not a scope probe. |
+
+In short: **a 404 hides the existence of a specific row you don't own; a
+403 rejects a credential or a company-scope you named explicitly.** The
+check behind both is the same `getCompanyId(...) !== row.<entity>CompId`
+comparison — only the response code differs by whether you asked for a
+specific hidden id (404) or a named scope / credential (403). This applies
+across all single-row entity endpoints.
 
 ![example image](https://github.com/CryptoJones/TimeTrackerAPI/blob/master/setup/postman_example.PNG?raw=true)
 


### PR DESCRIPTION
## Summary

The API deliberately returns **404** in some cross-tenant cases and **403** in others. This makes that choice explicit so it reads as a policy, not an inconsistency.

Closes #375.

## Changes

Extends the README's **"Secure-404 on cross-tenant access"** section with a table covering every case:

| Situation | Status |
|---|---|
| Missing / malformed `authKey` | **403** |
| Key doesn't resolve to a company | **403** |
| Single-row `:id` belongs to another tenant | **404** |
| `…/bycompany/:id` for a company that isn't yours | **403** |
| Body / params fail validation | **400** |
| Create body references another tenant's row (e.g. foreign `teCustId`, #373) | **400** |

The framing: **a 404 hides the existence of a specific row you don't own (anti-enumeration); a 403 rejects a credential or a company-scope you *named* explicitly.** Same underlying `getCompanyId(...) !== row.<entity>CompId` check — only the response code differs by whether the resource was a hidden id or a named scope.

## Verification

Docs only — no code touched. `npm run lint` clean; `npm test` → **1560 passing** (unchanged; lone failure is the pre-existing `Sequelize authenticates` connectivity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/