### PR TITLE
fix(auth): surface a DB outage as 503, not 403 (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly) versus **400** (validation / a bad cross-tenant foreign key),
   so the distinction reads as deliberate rather than incidental.
 
+### Fixed
+- **Surface a database outage as 503, not 403** (#377). When Postgres is
+  unreachable, the auth lookups previously swallowed the connection error
+  into the same "unknown key" sentinel, so the API answered **403** —
+  indistinguishable from a bad credential and misleading during an outage.
+  `isMaster`/`getCompanyId` now re-throw genuine connection errors (a new
+  `isDbUnavailable` classifier; logical misses still collapse to the
+  sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
+
 ### Security
 - **Tenant-scope `teCustId` on time-entry create** (#373). Creating a time
   entry (single or bulk) now verifies the customer belongs to the

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -94,6 +94,38 @@ function hashKey(rawKey) {
  * an archive column, so the soft-delete filter is implicit.
  */
 
+// Classifying "the database is UNREACHABLE" (an outage → 503) vs anything
+// else (a logical miss, or a config error like wrong credentials, which
+// keep the existing sentinel behaviour). The base `SequelizeConnectionError`
+// name is intentionally NOT trusted on its own — Sequelize also wraps a
+// bad-password failure (pg SQLSTATE 28P01) in it, which is a
+// misconfiguration, not a transient outage. So we match the SPECIFIC
+// connectivity subclasses by name, plus socket / pg-connection codes. The
+// auth lookups re-throw these so attachAuth answers 503 instead of letting
+// an outage masquerade as a bad key (403) — see attachAuth / #377.
+const DB_UNAVAILABLE_NAMES = new Set([
+    'SequelizeConnectionRefusedError',
+    'SequelizeHostNotFoundError',
+    'SequelizeHostNotReachableError',
+    'SequelizeInvalidConnectionError',
+    'SequelizeConnectionTimedOutError',
+    'SequelizeConnectionAcquireTimeoutError',
+]);
+const DB_UNAVAILABLE_CODES = new Set([
+    // socket-level
+    'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH', 'ECONNRESET', 'EPIPE',
+    // pg connection-class SQLSTATEs (08xxx) + admin shutdown / overload
+    '08000', '08001', '08003', '08004', '08006', '57P01', '57P03', '53300',
+]);
+
+/** True when `err` indicates the database is unreachable (not a logical/config error). */
+function isDbUnavailable(err) {
+    if (!err) return false;
+    if (typeof err.name === 'string' && DB_UNAVAILABLE_NAMES.has(err.name)) return true;
+    const code = (err.original && err.original.code) || (err.parent && err.parent.code) || err.code;
+    return typeof code === 'string' && DB_UNAVAILABLE_CODES.has(code);
+}
+
 async function isMaster(authKey) {
     if (!authKey || authKey.length === 0) return false;
     try {
@@ -103,6 +135,9 @@ async function isMaster(authKey) {
         });
         return !!(row && typeof row.amId === 'number' && row.amId > 0);
     } catch (error) {
+        // A DB outage is not "not a master" — re-throw so attachAuth can
+        // surface 503 (#377). Logical failures still collapse to false.
+        if (isDbUnavailable(error)) throw error;
         log.error({ err: error }, 'auth.isMaster query failed');
         return false;
     }
@@ -119,6 +154,9 @@ async function getCompanyId(authKey) {
         const cid = row.akCompanyId;
         return typeof cid === 'number' && cid > 0 ? cid : -1;
     } catch (error) {
+        // A DB outage is not "no scoped key" — re-throw so attachAuth can
+        // surface 503 (#377). Logical failures still collapse to -1.
+        if (isDbUnavailable(error)) throw error;
         log.error({ err: error }, 'auth.getCompanyId query failed');
         return -1;
     }
@@ -277,28 +315,24 @@ async function attachAuth(req, res, next) {
     req.isMaster = false;
     req.companyId = -1;
     if (!authKey) return next();
-    // No try/catch here even though these are DB-touching calls:
-    // both `isMaster` and `getCompanyId` already wrap their query
-    // in try/catch internally and swallow infrastructure errors
-    // into a `false` / `-1` sentinel (with a `log.error`). So a
-    // DB outage surfaces as "auth failed" (403 downstream via
-    // requireAuth or per-controller checks), not "server error"
-    // — and the outer wrappers we had here were unreachable
-    // dead code that misled readers into thinking attachAuth
-    // distinguished the two. If the silent-swallow turns out to
-    // be the wrong behaviour for operators (DB-down looking like
-    // auth-fail), the right fix is to surface the throw from
-    // isMaster / getCompanyId themselves, not to layer a catch
-    // here that the inner function prevents from firing.
-    req.isMaster = await isMaster(authKey);
-    if (req.isMaster) {
-        // Master keys aren't scoped to a single company. Leave
-        // companyId at -1; handlers needing a target scope read
-        // it from req.params / req.body / req.query.
+    // isMaster / getCompanyId swallow LOGICAL failures into a false / -1
+    // sentinel (a genuinely unknown key), but re-throw when the DATABASE
+    // is unreachable (#377). We catch that here and answer 503 — so a DB
+    // outage is reported as an outage, not mistaken for a bad key (403).
+    try {
+        req.isMaster = await isMaster(authKey);
+        if (req.isMaster) {
+            // Master keys aren't scoped to a single company. Leave
+            // companyId at -1; handlers needing a target scope read
+            // it from req.params / req.body / req.query.
+            return next();
+        }
+        req.companyId = await getCompanyId(authKey);
         return next();
+    } catch (error) {
+        log.error({ err: error }, 'attachAuth: database unavailable');
+        return res.status(503).json({ message: 'Service temporarily unavailable.' });
     }
-    req.companyId = await getCompanyId(authKey);
-    return next();
 }
 
 /**
@@ -344,6 +378,7 @@ module.exports = {
     requireAuth,
     resolveAuth,
     hashKey,
+    isDbUnavailable,
     // Test-only seam: call with a stub db to drive auth functions
     // through caller-controlled fixtures; call with no args (or null)
     // to restore the production lookup. Production code MUST NOT call

--- a/tests/unit/auth-db-outage.test.js
+++ b/tests/unit/auth-db-outage.test.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// #377 — a DB outage must surface as 503, not 403. Uses auth's own
+// _setDbForTesting seam to drive the lookups against controlled fixtures.
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { isMaster, getCompanyId, attachAuth, isDbUnavailable, _setDbForTesting } from '../../app/middleware/auth.js';
+
+afterEach(() => _setDbForTesting(null));
+
+const connErr = () => Object.assign(new Error('conn'), { name: 'SequelizeConnectionRefusedError' });
+
+describe('auth DB-outage → 503 (#377)', () => {
+    test('isDbUnavailable classifies connection errors, not logical ones', () => {
+        expect(isDbUnavailable({ name: 'SequelizeConnectionRefusedError' })).toBe(true);
+        expect(isDbUnavailable({ name: 'SequelizeHostNotFoundError' })).toBe(true);
+        expect(isDbUnavailable({ original: { code: 'ECONNREFUSED' } })).toBe(true);
+        expect(isDbUnavailable({ parent: { code: 'ETIMEDOUT' } })).toBe(true);
+        expect(isDbUnavailable({ name: 'SequelizeDatabaseError' })).toBe(false); // a query error, not connectivity
+        expect(isDbUnavailable(new TypeError('findOne is not a function'))).toBe(false);
+        expect(isDbUnavailable(null)).toBe(false);
+    });
+
+    test('isMaster / getCompanyId re-throw on outage, sentinel otherwise', async () => {
+        const err = connErr();
+        _setDbForTesting({ ApiMaster: { findOne: vi.fn().mockRejectedValue(err) }, ApiKey: { findOne: vi.fn().mockRejectedValue(err) } });
+        await expect(isMaster('k')).rejects.toBe(err);
+        await expect(getCompanyId('k')).rejects.toBe(err);
+
+        const logic = new TypeError('boom');
+        _setDbForTesting({ ApiMaster: { findOne: vi.fn().mockRejectedValue(logic) }, ApiKey: { findOne: vi.fn().mockRejectedValue(logic) } });
+        expect(await isMaster('k')).toBe(false);
+        expect(await getCompanyId('k')).toBe(-1);
+    });
+
+    test('attachAuth answers 503 on a DB outage', async () => {
+        const err = connErr();
+        _setDbForTesting({ ApiMaster: { findOne: vi.fn().mockRejectedValue(err) }, ApiKey: { findOne: vi.fn().mockRejectedValue(err) } });
+        const req = { get: (h) => (h === 'authKey' ? 'k' : undefined) };
+        const captured = {};
+        const res = { status(c) { captured.code = c; return this; }, json(b) { captured.body = b; return this; } };
+        let nexted = false;
+        await attachAuth(req, res, () => { nexted = true; });
+        expect(captured.code).toBe(503);
+        expect(nexted).toBe(false);
+    });
+
+    test('attachAuth calls next() for a valid scoped key', async () => {
+        _setDbForTesting({ ApiMaster: { findOne: vi.fn().mockResolvedValue(null) }, ApiKey: { findOne: vi.fn().mockResolvedValue({ akCompanyId: 7 }) } });
+        const req = { get: (h) => (h === 'authKey' ? 'k' : undefined) };
+        const res = { status() { return this; }, json() { return this; } };
+        let nexted = false;
+        await attachAuth(req, res, () => { nexted = true; });
+        expect(nexted).toBe(true);
+        expect(req.companyId).toBe(7);
+        expect(req.isMaster).toBe(false);
+    });
+
+    test('attachAuth calls next() when no authKey is sent', async () => {
+        const req = { get: () => undefined };
+        const res = { status() { return this; }, json() { return this; } };
+        let nexted = false;
+        await attachAuth(req, res, () => { nexted = true; });
+        expect(nexted).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

When the database is down, the API answered **403 Forbidden** — making an outage look like a bad API key. It now answers **503 Service Unavailable**.

Closes #377.

## The bug

`isMaster` / `getCompanyId` wrapped their lookups in a try/catch that collapsed **every** failure — including a dropped DB connection — into the "unknown key" sentinel (`false` / `-1`). So a Postgres outage surfaced downstream as a 403, indistinguishable from a genuinely invalid credential. `attachAuth`'s own comment even called this out and prescribed the fix: *"surface the throw from isMaster / getCompanyId themselves."*

## The fix

- **`isDbUnavailable(err)`** classifies a *connectivity* outage: the specific Sequelize connection subclasses (`ConnectionRefused`, `HostNotFound`, `ConnectionTimedOut`, …) plus socket codes (`ECONNREFUSED`, `ETIMEDOUT`, …) and pg connection-class SQLSTATEs (`08xxx`, `57P01`, `53300`). The **base** `SequelizeConnectionError` name is deliberately *not* trusted alone — Sequelize also wraps a **bad-password (`28P01`)** in it, which is a *config* error, not a transient outage.
- `isMaster` / `getCompanyId` **re-throw** those; logical misses still collapse to the sentinel.
- **`attachAuth`** catches the throw and returns **503**.

Existing 403/400 behavior is unchanged — only a real reachability failure changes (403 → 503).

## Verification

`npm run lint` clean; `npm test` → **1566 passing**, including a new `auth-db-outage` suite (classifier cases; `isMaster`/`getCompanyId` re-throw-vs-sentinel; `attachAuth` 503-vs-`next()`) driven through auth's `_setDbForTesting` seam. The whole api-test suite still passes because a *logical* not-found (CI's working DB, no matching key row) returns `-1`, not a connection error. Lone failure is the pre-existing `Sequelize authenticates` connectivity check (this sandbox has no DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/