### PR TITLE
refactor(customer): consolidate GetCustomerCompanyId onto the auth helper (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly) versus **400** (validation / a bad cross-tenant foreign key),
   so the distinction reads as deliberate rather than incidental.
 
+### Changed
+- **Consolidate the customer→company lookup** (#378). `customercontroller`
+  dropped its hand-rolled raw-SQL `GetCustomerCompanyId` and now aliases
+  the shared `auth.getCompanyIdByCustomerId` (same semantics — empty/zero
+  → -1, archived excluded, but fetches only `custCompId` instead of
+  `SELECT *`). Tenant resolution lives in one place; the now-unused
+  `sequelize` import is gone. Behavior-preserving (covered by the existing
+  customer tests).
+
 ### Fixed
 - **Surface a database outage as 503, not 403** (#377). When Postgres is
   unreachable, the auth lookups previously swallowed the connection error

--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -2,7 +2,6 @@
 // Copyright 2026 Aaron K. Clark
 "use strict";
 
-const { sequelize } = require('../config/db.config.js');
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
@@ -11,13 +10,15 @@ const { makeBulkCreate } = require('./_bulk-helpers.js');
 const { escapeCsvCell } = require('./_csv-escape.js');
 const Customer = db.Customer;
 
-// IsMaster / GetCompanyId previously lived inline in this file and
-// were duplicated verbatim in timeentrycontroller.js. They moved to
-// app/middleware/auth.js — these aliases preserve the existing
-// PascalCase names used inside this controller body without churning
-// every call site.
+// IsMaster / GetCompanyId / GetCustomerCompanyId previously lived inline
+// in this file (and were duplicated across controllers). They moved to
+// app/middleware/auth.js — these aliases preserve the existing PascalCase
+// names used inside this controller body without churning every call site.
+// (#378 consolidated the customer→company lookup onto the auth helper,
+// dropping a hand-rolled raw-SQL duplicate.)
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+const GetCustomerCompanyId = auth.getCompanyIdByCustomerId;
 
 /**
  * Escape the three SQL LIKE/ILIKE metacharacters in a substring so
@@ -575,36 +576,6 @@ async function findAndRespond(customerId, res) {
     } catch (error) {
         log.error({ err: error }, 'Customer.findByPk failed');
         return res.status(500).json({ message: "Error!" });
-    }
-}
-
-/**
- * Resolve a customer id to its owning company id, or -1 if not found.
- * Empty / missing ids return -1 without dereferencing an empty array.
- */
-async function GetCustomerCompanyId(customerId) {
-    // customerId comes from req.params.id (always a string). Treat empty
-    // or zero as "not found" before hitting the DB.
-    const idStr = customerId == null ? '' : String(customerId);
-    if (idStr.length === 0 || idStr === '0') {
-        return -1;
-    }
-    try {
-        const customerResult = await db.sequelize.query(
-            'SELECT * FROM "dbo"."Customer" WHERE "custId" = ? AND "custArch" = false;',
-            { replacements: [customerId], type: sequelize.QueryTypes.SELECT },
-        );
-        if (!customerResult || customerResult.length === 0) {
-            return -1;
-        }
-        const custCompanyId = customerResult[0].custCompId;
-        if (typeof custCompanyId === 'number' && custCompanyId > 0) {
-            return custCompanyId;
-        }
-        return -1;
-    } catch (error) {
-        log.error({ err: error }, 'GetCustomerCompanyId query failed');
-        return -1;
     }
 }
 


### PR DESCRIPTION
## Summary

Two functions resolved a customer id → its owning company. This drops the duplicate so tenant resolution lives in one place.

Closes #378.

## Changes

- **`customercontroller`** dropped its hand-rolled **raw-SQL** `GetCustomerCompanyId` and now aliases the shared **`auth.getCompanyIdByCustomerId`** — the same helper other scoping code already uses.
- The two were functionally identical (empty/zero id → `-1`, archived customers excluded, positive `custCompId` or `-1`), but the auth helper is leaner: it fetches only `custCompId` via `findByPk` (archived-filtered by the model's `defaultScope`) instead of `SELECT *` with a hand-written `custArch = false` clause.
- Removed the now-unused `sequelize` import (it existed solely for that raw query).

## Verification

`npm run lint` clean (no unused import); `npm test` → **1566 passing**. This is **behavior-preserving** — the customer get/update/delete scoping is exercised by the **16 existing customer tests**, all green, so no new test is warranted. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/