### PR TITLE
docs(openapi): align the TimeEntry component with the model + schema (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Documentation
+- **Align the OpenAPI `TimeEntry` component with the model + schema** (#372).
+  The published component omitted `teWorkerId` / `teJobId` / `teBillTypeId`
+  / `teTaskId` (and `teTags`, plus the read-only `teApprovalStatus` /
+  `teInvJobId`) even though the create/update schema accepts them and the
+  model stores them — so the spec (and the generated Postman collection)
+  understated the API. The component now lists all of them. (Regenerate
+  `setup/TimeTrackerAPI.postman_collection.json` from the spec to propagate.)
 - **Cross-tenant response-code policy** (#375). The README's "Secure-404 on
   cross-tenant access" section now spells out, in a table, exactly when the
   API returns **404** (a specific row you don't own — anti-enumeration)

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -299,11 +299,20 @@ const timeEntrySchema = {
         teId: { type: 'integer', readOnly: true },
         teCustId: { type: 'integer' },
         teCompId: { type: 'integer', readOnly: true },
+        // Billing links (#372: these were accepted by the create/update
+        // schema and stored by the model, but missing from this component).
+        teWorkerId: { type: 'integer', nullable: true, description: 'Worker who logged the time (#385).' },
+        teJobId: { type: 'integer', nullable: true, description: 'Job the time rolls up to (#386).' },
+        teBillTypeId: { type: 'integer', nullable: true, description: 'Per-entry billing-type rate override.' },
+        teTaskId: { type: 'integer', nullable: true, description: 'Task under the job (#407).' },
         teDescription: { type: 'string', maxLength: 10000 },
         teStartedAt: { type: 'string', format: 'date-time' },
         teEndedAt: { type: 'string', format: 'date-time', nullable: true },
         teMinutes: { type: 'integer', nullable: true, readOnly: true },
         teBillable: { type: 'boolean', default: true },
+        teTags: { type: 'array', items: { type: 'string' }, nullable: true, description: 'Free-form tags (#397).' },
+        teApprovalStatus: { type: 'string', enum: ['open', 'submitted', 'approved', 'rejected'], readOnly: true, description: 'Timesheet approval state (#440).' },
+        teInvJobId: { type: 'integer', nullable: true, readOnly: true, description: 'Set when the entry is rolled into an invoice.' },
         teArch: { type: 'boolean', readOnly: true },
     },
 };


### PR DESCRIPTION
## Summary

The OpenAPI `TimeEntry` component had drifted from reality — it didn't list the billing-link fields the API actually accepts and stores.

Closes #372.

## The drift

The create/update **validation schema** accepts `teWorkerId`, `teJobId`, `teBillTypeId`, `teTaskId`, `teTags`, and the **model** persists those plus the server-managed `teApprovalStatus` and `teInvJobId` — but the published `#/components/schemas/TimeEntry` listed only `teId`, `teCustId`, `teCompId`, `teDescription`, `teStartedAt`, `teEndedAt`, `teMinutes`, `teBillable`, `teArch`. So the spec (and the Postman collection generated from it) understated the API: a client reading the docs wouldn't know it could link a worker/job/task or tag an entry.

## Fix

The component now lists every field, matching the model and the create/update schema:

- **Billing links:** `teWorkerId` (#385), `teJobId` (#386), `teBillTypeId`, `teTaskId` (#407).
- **`teTags`** (array of strings, #397).
- **Read-only, server-managed:** `teApprovalStatus` (enum, #440) and `teInvJobId` (set on invoice rollup).

## Verification

`npm run lint` clean; `npm test` → **1566 passing**, including the OpenAPI test suite (the component now parses with all 16 properties). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

> Follow-up: regenerate `setup/TimeTrackerAPI.postman_collection.json` from the spec (per the README's documented `openapi-to-postmanv2` step) to propagate the new fields into the shipped collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/