### PR TITLE
refactor(auth): reuse attachAuth context to avoid duplicate lookups (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the distinction reads as deliberate rather than incidental.
 
 ### Changed
+- **Reuse attachAuth's context to avoid duplicate auth lookups** (#374).
+  New `auth.masterFromReq(req, authKey)` / `companyIdFromReq(req, authKey)`
+  return the `req.isMaster` / `req.companyId` that `attachAuth` already
+  resolved on every `/v1` request, instead of each controller issuing a
+  second identical DB lookup — a **pure optimization** (identical result,
+  minus the round-trip; falls back to a live lookup when the context is
+  absent, e.g. direct calls in unit tests). `billablerulecontroller` is
+  converted as the reference implementation; rolling the pattern out to the
+  remaining controllers (~35, hundreds of call sites) is a mechanical
+  follow-up best done in reviewable batches.
 - **Consolidate the customer→company lookup** (#378). `customercontroller`
   dropped its hand-rolled raw-SQL `GetCustomerCompanyId` and now aliases
   the shared `auth.getCompanyIdByCustomerId` (same semantics — empty/zero

--- a/app/controllers/billablerulecontroller.js
+++ b/app/controllers/billablerulecontroller.js
@@ -9,8 +9,11 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { evaluate } = require('../services/billable-rules.js');
 const BillableRule = db.BillableRule;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of issuing a second identical DB lookup per handler; both fall
+// back to a live lookup when the context is absent (direct calls / tests).
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const MATCH_FIELDS = ['bruName', 'bruPriority', 'bruMatchJobId', 'bruMatchTaskId', 'bruMatchCategory', 'bruBillable', 'bruActive'];
 
@@ -28,9 +31,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || rule.bruCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -46,7 +49,7 @@ async function resolveCompany(req, res) {
         res.status(403).json({ message: "Authorization key not sent." });
         return null;
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (isMaster) {
         const companyId = Number((req.body || {}).companyId);
         if (!Number.isInteger(companyId) || companyId <= 0) {
@@ -55,7 +58,7 @@ async function resolveCompany(req, res) {
         }
         return companyId;
     }
-    const companyId = await GetCompanyId(authKey);
+    const companyId = await CompanyIdFromReq(req, authKey);
     if (companyId === -1) {
         res.status(403).json({ message: "Invalid Authorization Key." });
         return null;
@@ -72,7 +75,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -82,7 +85,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -141,9 +144,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -163,6 +163,26 @@ async function getCompanyId(authKey) {
 }
 
 /**
+ * Reuse the auth context attachAuth already resolved onto the request
+ * (req.isMaster / req.companyId) instead of issuing a second identical DB
+ * lookup per handler (#374). Falls back to a fresh lookup when the context
+ * is absent — e.g. a handler invoked directly, outside the /v1 middleware
+ * chain (as some unit tests do). PURE optimization: with the context
+ * present the result is identical to calling isMaster / getCompanyId, just
+ * without the extra round-trip. Controllers pass both `req` and the raw
+ * `authKey` so the fallback has what it needs.
+ */
+async function masterFromReq(req, authKey) {
+    if (req && typeof req.isMaster === 'boolean') return req.isMaster;
+    return isMaster(authKey);
+}
+
+async function companyIdFromReq(req, authKey) {
+    if (req && typeof req.companyId === 'number') return req.companyId;
+    return getCompanyId(authKey);
+}
+
+/**
  * Resolve a customer id to its owning company id.
  *
  * Used by entities that don't have their own *CompId column and instead
@@ -379,6 +399,8 @@ module.exports = {
     resolveAuth,
     hashKey,
     isDbUnavailable,
+    masterFromReq,
+    companyIdFromReq,
     // Test-only seam: call with a stub db to drive auth functions
     // through caller-controlled fixtures; call with no args (or null)
     // to restore the production lookup. Production code MUST NOT call

--- a/tests/unit/auth-context.test.js
+++ b/tests/unit/auth-context.test.js
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// #374 — reuse attachAuth's resolved context instead of a second DB lookup.
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { masterFromReq, companyIdFromReq, _setDbForTesting } from '../../app/middleware/auth.js';
+
+afterEach(() => _setDbForTesting(null));
+
+describe('auth context reuse (#374)', () => {
+    test('masterFromReq returns the cached req.isMaster', async () => {
+        expect(await masterFromReq({ isMaster: true }, 'k')).toBe(true);
+        expect(await masterFromReq({ isMaster: false }, 'k')).toBe(false);
+    });
+
+    test('companyIdFromReq returns the cached req.companyId (incl. the -1 sentinel)', async () => {
+        expect(await companyIdFromReq({ companyId: 7 }, 'k')).toBe(7);
+        expect(await companyIdFromReq({ companyId: -1 }, 'k')).toBe(-1);
+    });
+
+    test('falls back to a live lookup when the context is absent', async () => {
+        _setDbForTesting({
+            ApiMaster: { findOne: vi.fn().mockResolvedValue({ amId: 3 }) },
+            ApiKey: { findOne: vi.fn().mockResolvedValue({ akCompanyId: 9 }) },
+        });
+        expect(await masterFromReq({}, 'k')).toBe(true);        // no cached isMaster → lookup
+        expect(await companyIdFromReq(undefined, 'k')).toBe(9); // no req → lookup
+    });
+
+    test('the cached path does NOT touch the database', async () => {
+        const findOne = vi.fn().mockRejectedValue(new Error('should not be called'));
+        _setDbForTesting({ ApiMaster: { findOne }, ApiKey: { findOne } });
+        expect(await masterFromReq({ isMaster: false }, 'k')).toBe(false);
+        expect(await companyIdFromReq({ companyId: 5 }, 'k')).toBe(5);
+        expect(findOne).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

`attachAuth` already resolves `req.isMaster` / `req.companyId` on every `/v1` request — then each controller **re-runs the same two DB lookups**. This lands the mechanism to reuse that context, plus one reference conversion.

Part of **#374** (see "Scope" — this is deliberately *not* the full sweep, so the issue stays open).

## Changes

- **`auth.masterFromReq(req, authKey)` / `auth.companyIdFromReq(req, authKey)`** — return the `req.isMaster` / `req.companyId` `attachAuth` already resolved, and **fall back to a live lookup** when the context is absent (a handler invoked directly, outside the middleware chain — as some unit tests do). It's a **pure optimization**: with the context present the result is byte-identical to `isMaster` / `getCompanyId`, just without the extra round-trip.
- **`billablerulecontroller`** converted as the **reference implementation** (6 call sites) — every `IsMaster(authKey)` / `GetCompanyId(authKey)` → `MasterFromReq(req, …)` / `CompanyIdFromReq(req, …)`.

## Scope (why not the whole sweep)

The pattern touches **~35 controllers and ~270 call sites**. A single autonomous PR that rewrote every one would be an unreviewable diff and a real chance to introduce a cross-tenant scoping bug. So this lands the **tested primitive + one exemplar**; the remaining controllers are a **mechanical, low-risk follow-up** best done in reviewable batches. The issue stays open until that's complete.

## Verification

`npm run lint` clean; `npm test` → **1571 passing**, incl. a new `auth-context` suite (cached value returned incl. the `-1` sentinel; fallback lookup when absent; **the cached path provably never touches the DB**) and the **6 existing billablerule api tests still green** (scoping unchanged). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/