### PR TITLE
refactor(auth): reuse attachAuth context — batch 2 (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved on every `/v1` request, instead of each controller issuing a
   second identical DB lookup — a **pure optimization** (identical result,
   minus the round-trip; falls back to a live lookup when the context is
-  absent, e.g. direct calls in unit tests). `billablerulecontroller` is
-  converted as the reference implementation; rolling the pattern out to the
-  remaining controllers (~35, hundreds of call sites) is a mechanical
-  follow-up best done in reviewable batches.
+  absent, e.g. direct calls in unit tests). The controllers are converted
+  to the pattern **in reviewable batches** (billablerule → reportschedule,
+  customfielddef, approvalchain, invitation → …); the remaining
+  hundreds-of-call-sites rollout continues incrementally.
 - **Consolidate the customer→company lookup** (#378). `customercontroller`
   dropped its hand-rolled raw-SQL `GetCustomerCompanyId` and now aliases
   the shared `auth.getCompanyIdByCustomerId` (same semantics — empty/zero

--- a/app/controllers/approvalchaincontroller.js
+++ b/app/controllers/approvalchaincontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { normalizeLevels, nextStep, canApproveAt } = require('../services/approval-chain.js');
 const ApprovalChain = db.ApprovalChain;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Load a chain and enforce the secure-404 company scope. */
 async function findScoped(req, res) {
@@ -26,9 +28,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || chain.apchCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -46,7 +48,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -56,7 +58,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -116,9 +118,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/customfielddefcontroller.js
+++ b/app/controllers/customfielddefcontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { validateAgainstDefs } = require('../services/custom-field.js');
 const CustomFieldDef = db.CustomFieldDef;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Load a def and enforce the secure-404 company scope. */
 async function findScoped(req, res) {
@@ -26,9 +28,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || def.cfdCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -44,7 +46,7 @@ async function resolveCompany(req, res, fromBody) {
         res.status(403).json({ message: "Authorization key not sent." });
         return null;
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (isMaster) {
         const companyId = Number(fromBody ? (req.body || {}).companyId : req.query.companyId);
         if (!Number.isInteger(companyId) || companyId <= 0) {
@@ -53,7 +55,7 @@ async function resolveCompany(req, res, fromBody) {
         }
         return companyId;
     }
-    const companyId = await GetCompanyId(authKey);
+    const companyId = await CompanyIdFromReq(req, authKey);
     if (companyId === -1) {
         res.status(403).json({ message: "Invalid Authorization Key." });
         return null;
@@ -70,7 +72,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -80,7 +82,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -148,9 +150,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/invitationcontroller.js
+++ b/app/controllers/invitationcontroller.js
@@ -12,8 +12,10 @@ const { sendMail } = require('../services/mailer.js');
 const { isInviteValid, INVITE_TTL_SEC } = require('../services/invitation.js');
 const Invitation = db.Invitation;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 // invtTokenHash is write-only.
 const SAFE_ATTRS = ['invtId', 'invtCompId', 'invtEmail', 'invtRole', 'invtExpires', 'invtAcceptedAt', 'invtArch', 'createdAt', 'updatedAt'];
@@ -34,7 +36,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -44,7 +46,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -169,9 +171,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -215,9 +217,9 @@ exports.remove = async (req, res) => {
     if (!invite || invite.invtArch) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || invite.invtCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }

--- a/app/controllers/reportschedulecontroller.js
+++ b/app/controllers/reportschedulecontroller.js
@@ -13,8 +13,10 @@ const { formatReport } = require('../services/report-email.js');
 const { sendMail } = require('../services/mailer.js');
 const ReportSchedule = db.ReportSchedule;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_UPDATE = ['rptschReport', 'rptschTo', 'rptschCadence', 'rptschNextRun', 'rptschActive'];
 
@@ -36,9 +38,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || sched.rptschCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -56,7 +58,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -66,7 +68,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -123,9 +125,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -159,7 +161,7 @@ exports.listDue = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.query.companyId);
@@ -167,7 +169,7 @@ exports.listDue = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify companyId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }


### PR DESCRIPTION
## Summary

Second batch of the #374 rollout — convert four more controllers to reuse the auth context `attachAuth` already resolved, instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)` (the helpers landed in #542):

- `reportschedulecontroller`
- `customfielddefcontroller`
- `approvalchaincontroller`
- `invitationcontroller`

Each `IsMaster(authKey)` / `GetCompanyId(authKey)` → the context-aware helper, which returns `req.isMaster` / `req.companyId` when `attachAuth` populated them and **falls back to a live lookup** otherwise — so it's byte-for-byte behavior-preserving, just without the extra round-trip.

## Verification

`npm run lint` clean (no lingering `IsMaster`/`GetCompanyId` references); `npm test` → **1571 passing**, including the **27 api tests across these four controllers**, all green — the auth-scoping behavior (403/404/create/list) is unchanged. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/