### PR TITLE
refactor(auth): reuse attachAuth context — batch 3 (#374)

### DIFF
--- a/app/controllers/phasecontroller.js
+++ b/app/controllers/phasecontroller.js
@@ -8,8 +8,10 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const Phase = db.Phase;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
 
 const ALLOWED_FIELDS_CREATE = ['phaseJobId', 'phaseName', 'phaseStartDate', 'phaseEndDate', 'phaseBudgetAmount'];
@@ -43,9 +45,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "phaseJobId must reference a job." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== jobCompanyId) {
             return res.status(403).json({ message: "Cannot create a phase for a job in a company you do not belong to." });
         }
@@ -87,9 +89,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         let phaseCompanyId;
         try {
             phaseCompanyId = await GetCompanyIdByJobId(phase.phaseJobId);
@@ -130,9 +132,9 @@ exports.listByJob = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== jobCompanyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -173,9 +175,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         let phaseCompanyId;
         try {
             phaseCompanyId = await GetCompanyIdByJobId(phase.phaseJobId);

--- a/app/controllers/rateschedulecontroller.js
+++ b/app/controllers/rateschedulecontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { rateOnDate } = require('../services/rate-schedule.js');
 const RateSchedule = db.RateSchedule;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['rschName', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo', 'rschCompId'];
 const ALLOWED_FIELDS_UPDATE = ['rschName', 'rschRate', 'rschEffectiveFrom', 'rschEffectiveTo'];
@@ -29,9 +31,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || rs.rschCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -49,7 +51,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -64,7 +66,7 @@ exports.create = async (req, res) => {
     if (!isMaster) {
         let companyId;
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -113,9 +115,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -152,7 +154,7 @@ exports.resolve = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.query.companyId);
@@ -160,7 +162,7 @@ exports.resolve = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify companyId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/receiptcontroller.js
+++ b/app/controllers/receiptcontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { CONTENT_TYPES } = require('../schemas/receipt.schema.js');
 const Receipt = db.Receipt;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB decoded
 // Metadata only — rcptData (the bytes) is deliberately excluded.
@@ -18,9 +20,9 @@ const SAFE_ATTRS = ['rcptId', 'rcptExpId', 'rcptCompId', 'rcptFilename', 'rcptCo
 
 /** Resolve the caller's company id (or null after responding). Master → null (any). */
 async function callerCompany(req, res) {
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (isMaster) return { isMaster: true, companyId: null };
-    const companyId = await GetCompanyId(req.get('authKey'));
+    const companyId = await CompanyIdFromReq(req, req.get('authKey'));
     if (companyId === -1) {
         res.status(403).json({ message: "Invalid Authorization Key." });
         return null;
@@ -75,9 +77,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "expId must reference an expense." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== expense.expCompId) {
             return res.status(403).json({ message: "Cannot attach a receipt to an expense in a company you do not belong to." });
         }
@@ -164,9 +166,9 @@ exports.listByExpense = async (req, res) => {
     if (!expense) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== expense.expCompId) {
             return res.status(404).json({ message: "Not found." });
         }

--- a/app/controllers/recurringinvoicecontroller.js
+++ b/app/controllers/recurringinvoicecontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { advanceDate } = require('../services/recurring-schedule.js');
 const RecurringInvoice = db.RecurringInvoice;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 const ALLOWED_FIELDS_UPDATE = ['recinvCadence', 'recinvNextRun', 'recinvActive', 'recinvNote'];
@@ -34,9 +36,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         let schedCompanyId;
         try {
             schedCompanyId = await GetCompanyIdByCustomerId(sched.recinvCustId);
@@ -80,9 +82,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "recinvCustId must reference a customer." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== custCompanyId) {
             return res.status(403).json({ message: "Cannot schedule invoices for a customer in a company you do not belong to." });
         }
@@ -138,9 +140,9 @@ exports.listByCustomer = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== custCompanyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -177,7 +179,7 @@ exports.listDue = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.query.companyId);
@@ -185,7 +187,7 @@ exports.listDue = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify companyId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/retainercontroller.js
+++ b/app/controllers/retainercontroller.js
@@ -9,8 +9,10 @@ const money = require('../services/money.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const Retainer = db.Retainer;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 /**
@@ -30,9 +32,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         let retCompanyId;
         try {
             retCompanyId = await GetCompanyIdByCustomerId(ret.retCustId);
@@ -77,9 +79,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "retCustId must reference a customer." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== custCompanyId) {
             return res.status(403).json({ message: "Cannot open a retainer for a customer in a company you do not belong to." });
         }
@@ -135,9 +137,9 @@ exports.listByCustomer = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== custCompanyId) {
             return res.status(404).json({ message: "Not found." });
         }

--- a/app/controllers/rolecontroller.js
+++ b/app/controllers/rolecontroller.js
@@ -8,8 +8,10 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const Role = db.Role;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['roleName', 'roleRate', 'roleCompId'];
 const ALLOWED_FIELDS_UPDATE = ['roleName', 'roleRate'];
@@ -27,7 +29,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -42,7 +44,7 @@ exports.create = async (req, res) => {
     if (!isMaster) {
         let companyId;
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -83,9 +85,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         // Cross-tenant single-entity reads are 404, not 403 (anti-enumeration).
         if (companyId === -1 || role.roleCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
@@ -117,9 +119,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }


### PR DESCRIPTION
## Summary

Third batch of the #374 rollout — six more controllers reuse the auth context `attachAuth` already resolved instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- `rateschedulecontroller`
- `recurringinvoicecontroller`
- `phasecontroller`
- `rolecontroller`
- `retainercontroller`
- `receiptcontroller`

Same behavior-preserving swap as batches 1–2: cached `req.isMaster` / `req.companyId` when present, live-lookup fallback otherwise. **11 of ~35 controllers now on the pattern.**

## Verification

`npm run lint` clean (no lingering `IsMaster` / `GetCompanyId` references in any of the six); `npm test` → **1571 passing** — the affected controllers' api tests (auth/scoping) all green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/