### PR TITLE
refactor(auth): reuse attachAuth context — batch 4 (#374)

### DIFF
--- a/app/controllers/billingtypecontroller.js
+++ b/app/controllers/billingtypecontroller.js
@@ -11,6 +11,11 @@ const BillingType = db.BillingType;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['btName', 'btHourlyRate', 'btCompId'];
 const ALLOWED_FIELDS_UPDATE = ['btName', 'btHourlyRate'];
@@ -23,7 +28,7 @@ exports.create = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -38,7 +43,7 @@ exports.create = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -88,9 +93,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which BillingType ids are
         // populated across the whole tenant table by status code:
@@ -114,9 +119,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -170,9 +175,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET — don't let
         // a scoped caller distinguish "exists but not yours" from
         // "doesn't exist".
@@ -216,9 +221,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || billingType.btCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });

--- a/app/controllers/expensecontroller.js
+++ b/app/controllers/expensecontroller.js
@@ -11,6 +11,11 @@ const Expense = db.Expense;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = [
     'expCustId', 'expJobId', 'expCategory', 'expDescription', 'expDate', 'expAmount',
@@ -66,7 +71,7 @@ exports.create = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.body && req.body.expCompId);
@@ -74,7 +79,7 @@ exports.create = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify expCompId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -137,9 +142,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || expense.expCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -168,9 +173,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -227,9 +232,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || expense.expCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -284,9 +289,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || expense.expCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }

--- a/app/controllers/taskcontroller.js
+++ b/app/controllers/taskcontroller.js
@@ -8,8 +8,10 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const Task = db.Task;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
 
 const ALLOWED_FIELDS_CREATE = ['taskJobId', 'taskName', 'taskDesc', 'taskRate'];
@@ -43,9 +45,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "taskJobId must reference a job." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== jobCompanyId) {
             return res.status(403).json({ message: "Cannot create a task for a job in a company you do not belong to." });
         }
@@ -87,9 +89,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         let taskCompanyId;
         try {
             taskCompanyId = await GetCompanyIdByJobId(task.taskJobId);
@@ -130,9 +132,9 @@ exports.listByJob = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== jobCompanyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -173,9 +175,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         let taskCompanyId;
         try {
             taskCompanyId = await GetCompanyIdByJobId(task.taskJobId);

--- a/app/controllers/webhookcontroller.js
+++ b/app/controllers/webhookcontroller.js
@@ -9,8 +9,10 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const { deliver } = require('../services/webhook-delivery.js');
 const Webhook = db.Webhook;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['whkUrl', 'whkEvent', 'whkSecret', 'whkCompId'];
 const ALLOWED_FIELDS_UPDATE = ['whkUrl', 'whkEvent', 'whkSecret', 'whkActive'];
@@ -43,9 +45,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || wh.whkCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -63,7 +65,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -78,7 +80,7 @@ exports.create = async (req, res) => {
     if (!isMaster) {
         let companyId;
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -123,9 +125,9 @@ exports.getById = async (req, res) => {
     if (!wh || wh.whkArch) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || wh.whkCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -145,9 +147,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }


### PR DESCRIPTION
## Summary

Fourth batch of the #374 rollout — four more controllers reuse the auth context `attachAuth` resolved, instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted the handlers to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- `taskcontroller` — keeps `getCompanyIdByJobId` (a per-entity resolver attachAuth does **not** cache).
- `webhookcontroller`
- `billingtypecontroller` — retains its raw `IsMaster` / `GetCompanyId` aliases because they're exported via the `_internals` test seam; the handlers use the context helpers.
- `expensecontroller` — same `_internals` treatment.

**15 of ~35 controllers now on the pattern.** As before, behavior-preserving: cached `req.isMaster` / `req.companyId` when present, live-lookup fallback otherwise. The `...ByJobId` / `...ByCustomerId` per-entity resolvers are deliberately left as live lookups (not cached by attachAuth).

## Verification

`npm run lint` clean (no lingering `IsMaster(` / `GetCompanyId(` call sites; the `_internals` references remain valid); `npm test` → **1571 passing** — auth/scoping for all four controllers green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/