### PR TITLE
refactor(auth): reuse attachAuth context — batch 5 (#374)

### DIFF
--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -22,6 +22,11 @@ const Company = db.Company;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = [
     'compName', 'compAddress1', 'compAddress2', 'compCity',
@@ -35,7 +40,7 @@ exports.create = async (req, res) => {
     if (!authKey) {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
         return res.status(403).json({ message: "Only master keys may create companies." });
     }
@@ -73,9 +78,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access (caller's company doesn't match the
         // looked-up company) is reported as 404, not 403. Returning
         // 403 here would let a non-master caller enumerate which
@@ -95,7 +100,7 @@ exports.list = async (req, res) => {
     if (!authKey) {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
         return res.status(403).json({ message: "Only master keys may list all companies." });
     }
@@ -147,9 +152,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Same secure-404 pattern as getById: don't let a non-master
         // caller distinguish "this company exists but isn't yours"
         // from "this id doesn't exist" by status code.
@@ -181,7 +186,7 @@ exports.remove = async (req, res) => {
     if (!authKey) {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
         return res.status(403).json({ message: "Only master keys may archive companies." });
     }

--- a/app/controllers/customerpaymentcontroller.js
+++ b/app/controllers/customerpaymentcontroller.js
@@ -11,6 +11,11 @@ const CustomerPayment = db.CustomerPayment;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 const ALLOWED_FIELDS_CREATE = ['cpayCustId', 'cpayInvId', 'cpayDescription', 'cpayDate', 'cpayAmount'];
@@ -53,9 +58,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "cpayCustId is required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         if (authCompanyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -106,9 +111,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which CustomerPayment ids are
@@ -134,9 +139,9 @@ exports.listByCustomer = async (req, res) => {
         return res.status(400).json({ message: "Invalid customer id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const custCompanyId = await GetCompanyIdByCustomerId(targetCustomerId);
         if (authCompanyId === -1 || custCompanyId === -1 || authCompanyId !== custCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
@@ -187,9 +192,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || cpCompanyId === -1 || authCompanyId !== cpCompanyId) {
@@ -243,9 +248,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const cpCompanyId = await GetCompanyIdByCustomerId(payment.cpayCustId);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || cpCompanyId === -1 || authCompanyId !== cpCompanyId) {

--- a/app/controllers/jobcontroller.js
+++ b/app/controllers/jobcontroller.js
@@ -18,6 +18,11 @@ const Job = db.Job;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 const ALLOWED_FIELDS_CREATE = ['jobCustId', 'jobDesc', 'jobFlatRate', 'jobBudgetMinutes', 'jobBudgetAmount'];
@@ -38,9 +43,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "jobCustId is required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         if (authCompanyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -81,9 +86,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which Job ids are populated
@@ -108,9 +113,9 @@ exports.listByCustomer = async (req, res) => {
         return res.status(400).json({ message: "Invalid customer id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const custCompanyId = await GetCompanyIdByCustomerId(targetCustomerId);
         if (authCompanyId === -1 || custCompanyId === -1 || authCompanyId !== custCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
@@ -162,9 +167,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
@@ -207,9 +212,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByCustomerId(job.jobCustId);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {

--- a/app/controllers/usercontroller.js
+++ b/app/controllers/usercontroller.js
@@ -10,8 +10,10 @@ const { hashPassword } = require('../services/password.js');
 const rbac = require('../services/rbac.js');
 const User = db.User;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 // userPasswordHash is deliberately excluded — it is write-only.
 const SAFE_ATTRS = ['userId', 'userCompId', 'userEmail', 'userName', 'userRole', 'userArch', 'createdAt', 'updatedAt'];
@@ -42,9 +44,9 @@ async function findScoped(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || user.userCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;
@@ -62,7 +64,7 @@ exports.create = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -72,7 +74,7 @@ exports.create = async (req, res) => {
     let companyId;
     if (!isMaster) {
         try {
-            companyId = await GetCompanyId(authKey);
+            companyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -135,9 +137,9 @@ exports.getById = async (req, res) => {
     if (!user || user.userArch) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || user.userCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -157,9 +159,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }


### PR DESCRIPTION
## Summary

Fifth batch of the #374 rollout — four more controllers reuse the auth context `attachAuth` resolved instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted the handlers to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- `usercontroller` — clean rename.
- `companycontroller` — keeps its `IsMaster` / `GetCompanyId` aliases for the `_internals` test seam.
- `customerpaymentcontroller` — same `_internals` treatment; its 5 `getCompanyIdByCustomerId` calls stay live (a per-customer resolver attachAuth does **not** cache).
- `jobcontroller` — same, 5 `getCompanyIdByCustomerId` calls preserved.

**19 of ~35 controllers now on the pattern.** Behavior-preserving: cached `req.isMaster` / `req.companyId` when present, live-lookup fallback otherwise. The per-entity `...ByCustomerId` resolvers are intentionally left as live lookups.

## Verification

`npm run lint` clean (no lingering `IsMaster(` / `GetCompanyId(` call sites; the 10 `...ByCustomerId` resolver calls preserved; `_internals` references remain valid); `npm test` → **1571 passing** — auth/scoping for all four controllers green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/