### PR TITLE
refactor(auth): reuse attachAuth context — batch 6 (#374)

### DIFF
--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -19,6 +19,11 @@ const Customer = db.Customer;
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCustomerCompanyId = auth.getCompanyIdByCustomerId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _helpers
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /**
  * Escape the three SQL LIKE/ILIKE metacharacters in a substring so
@@ -64,7 +69,7 @@ exports.getCustomerById = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -77,7 +82,7 @@ exports.getCustomerById = async (req, res) => {
     let custCompanyId, authKeyCompanyId;
     try {
         custCompanyId = await GetCustomerCompanyId(customerId);
-        authKeyCompanyId = await GetCompanyId(authKey);
+        authKeyCompanyId = await CompanyIdFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'Company lookup failed');
         return res.status(500).json({ message: "Error!" });
@@ -127,7 +132,7 @@ exports.createCustomer = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -155,7 +160,7 @@ exports.createCustomer = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -214,7 +219,7 @@ exports.getAllByCompanyId = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -223,7 +228,7 @@ exports.getAllByCompanyId = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -300,7 +305,7 @@ exports.exportCsv = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -318,7 +323,7 @@ exports.exportCsv = async (req, res) => {
     } else {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -446,7 +451,7 @@ exports.search = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -465,7 +470,7 @@ exports.search = async (req, res) => {
     } else {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });

--- a/app/controllers/inventoryitemcontroller.js
+++ b/app/controllers/inventoryitemcontroller.js
@@ -11,6 +11,11 @@ const InventoryItem = db.InventoryItem;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['invitDescription', 'invitQty', 'invitCompId'];
 const ALLOWED_FIELDS_UPDATE = ['invitDescription', 'invitQty'];
@@ -23,7 +28,7 @@ exports.create = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -38,7 +43,7 @@ exports.create = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -88,9 +93,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which InventoryItem ids are
         // populated across the whole tenant table by status code.
@@ -114,9 +119,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -170,9 +175,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || inventoryItem.invitCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -214,9 +219,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || inventoryItem.invitCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });

--- a/app/controllers/invoicejobcontroller.js
+++ b/app/controllers/invoicejobcontroller.js
@@ -17,6 +17,11 @@ const InvoiceJob = db.InvoiceJob;
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['injbInvId', 'injbJobId', 'injbAmount'];
 const ALLOWED_FIELDS_UPDATE = ['injbAmount'];
@@ -36,9 +41,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "injbInvId and injbJobId are required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(payload.injbJobId);
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
             return res.status(403).json({
@@ -75,9 +80,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which InvoiceJob ids are
@@ -102,13 +107,13 @@ exports.listByInvoice = async (req, res) => {
         return res.status(400).json({ message: "Invalid invoice id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     // For non-master, we'd want to verify the invoice's company. To keep
     // this lookup cheap we resolve a single row from InvoiceJob and walk
     // its job to compId. If the invoice has no lines yet, non-master
     // callers get 403 (they can use the Invoice GET to verify access first).
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         if (authCompanyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -172,9 +177,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
@@ -217,9 +222,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(invoiceJob.injbJobId);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {

--- a/app/controllers/productentrycontroller.js
+++ b/app/controllers/productentrycontroller.js
@@ -12,6 +12,11 @@ const ProductEntry = db.ProductEntry;
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByJobId = auth.getCompanyIdByJobId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['pentQty', 'pentJobId', 'pentInvtId', 'pentTaxable'];
 const ALLOWED_FIELDS_UPDATE = ['pentQty', 'pentInvtId', 'pentTaxable'];
@@ -31,9 +36,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "pentJobId is required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(payload.pentJobId);
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
             return res.status(403).json({
@@ -70,9 +75,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which ProductEntry ids are
@@ -97,9 +102,9 @@ exports.listByJob = async (req, res) => {
         return res.status(400).json({ message: "Invalid job id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(targetJobId);
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
@@ -150,9 +155,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {
@@ -195,9 +200,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const jobCompanyId = await GetCompanyIdByJobId(productEntry.pentJobId);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || jobCompanyId === -1 || authCompanyId !== jobCompanyId) {

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -11,6 +11,11 @@ const Worker = db.Worker;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = [
     'workerFName', 'workerLName', 'workerTitle',
@@ -35,7 +40,7 @@ exports.create = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -50,7 +55,7 @@ exports.create = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -109,9 +114,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which Worker ids are
         // populated across the whole tenant table by status code.
@@ -140,9 +145,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -201,9 +206,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || worker.workerCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -250,9 +255,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || worker.workerCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });


### PR DESCRIPTION
## Summary

Sixth batch of the #374 rollout — five more controllers reuse the auth context `attachAuth` resolved instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted the handlers to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- `customercontroller` — keeps `IsMaster` / `GetCompanyId` / `GetCustomerCompanyId` for the `_helpers` seam; the per-customer `GetCustomerCompanyId` resolver stays live.
- `workercontroller`
- `invoicejobcontroller` — 5 `getCompanyIdByJobId` calls preserved.
- `inventoryitemcontroller`
- `productentrycontroller` — 5 `getCompanyIdByJobId` calls preserved.

**24 of ~35 controllers now on the pattern.** Behavior-preserving; the per-entity `...ByJobId` / `...ByCustomerId` resolvers are intentionally left as live lookups (attachAuth doesn't cache them).

## Verification

`npm run lint` clean (no lingering `IsMaster(` / `GetCompanyId(` call sites; 12 per-entity resolver calls preserved; `_internals` / `_helpers` references valid); `npm test` → **1571 passing** — auth/scoping for all five controllers green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/