### PR TITLE
refactor(auth): reuse attachAuth context — batch 7 (#374)

### DIFF
--- a/app/controllers/inventorytransactioncontroller.js
+++ b/app/controllers/inventorytransactioncontroller.js
@@ -19,6 +19,11 @@ const InventoryTransaction = db.InventoryTransaction;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['invtDirection', 'invtInitId', 'invtCompanyId'];
 const ALLOWED_FIELDS_UPDATE = ['invtDirection', 'invtInitId'];
@@ -31,7 +36,7 @@ exports.create = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -44,7 +49,7 @@ exports.create = async (req, res) => {
     }
 
     if (!isAuthKeyMasterKey) {
-        const authKeyCompanyId = await GetCompanyId(authKey);
+        const authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         if (authKeyCompanyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -90,9 +95,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which InventoryTransaction
         // ids are populated across the whole tenant table by status
@@ -117,9 +122,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -167,9 +172,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || txn.invtCompanyId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -211,9 +216,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || txn.invtCompanyId !== companyId) {
             return res.status(404).json({ message: "Not found." });

--- a/app/controllers/purchaseorderheadercontroller.js
+++ b/app/controllers/purchaseorderheadercontroller.js
@@ -17,6 +17,11 @@ const PurchaseOrderHeader = db.PurchaseOrderHeader;
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByPovId = auth.getCompanyIdByPovId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['pohDate', 'pohReference', 'pohTerms', 'pohPovId'];
 const ALLOWED_FIELDS_UPDATE = ['pohDate', 'pohReference', 'pohTerms'];
@@ -36,9 +41,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "pohPovId is required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const vendorCompanyId = await GetCompanyIdByPovId(payload.pohPovId);
         if (authCompanyId === -1 || vendorCompanyId === -1 || authCompanyId !== vendorCompanyId) {
             return res.status(403).json({
@@ -75,9 +80,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const vendorCompanyId = await GetCompanyIdByPovId(header.pohPovId);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which PurchaseOrderHeader ids
@@ -103,9 +108,9 @@ exports.listByVendor = async (req, res) => {
         return res.status(400).json({ message: "Invalid vendor id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const vendorCompanyId = await GetCompanyIdByPovId(targetVendorId);
         if (authCompanyId === -1 || vendorCompanyId === -1 || authCompanyId !== vendorCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
@@ -154,9 +159,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const vendorCompanyId = await GetCompanyIdByPovId(header.pohPovId);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || vendorCompanyId === -1 || authCompanyId !== vendorCompanyId) {
@@ -199,9 +204,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const vendorCompanyId = await GetCompanyIdByPovId(header.pohPovId);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || vendorCompanyId === -1 || authCompanyId !== vendorCompanyId) {

--- a/app/controllers/purchaseorderlinecontroller.js
+++ b/app/controllers/purchaseorderlinecontroller.js
@@ -17,6 +17,11 @@ const PurchaseOrderLine = db.PurchaseOrderLine;
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
 const GetCompanyIdByPohId = auth.getCompanyIdByPohId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = ['polpoh', 'polItemDesc', 'polQty', 'polPrice', 'polInvtId'];
 const ALLOWED_FIELDS_UPDATE = ['polItemDesc', 'polQty', 'polPrice', 'polInvtId'];
@@ -36,9 +41,9 @@ exports.create = async (req, res) => {
         return res.status(400).json({ message: "polpoh (PO header id) is required." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const headerCompanyId = await GetCompanyIdByPohId(payload.polpoh);
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
             return res.status(403).json({
@@ -75,9 +80,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which PurchaseOrderLine ids
@@ -102,9 +107,9 @@ exports.listByHeader = async (req, res) => {
         return res.status(400).json({ message: "Invalid header id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const headerCompanyId = await GetCompanyIdByPohId(targetHeaderId);
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
@@ -153,9 +158,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
         // Secure-404 on PATCH for the same reason as GET.
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {
@@ -198,9 +203,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const authCompanyId = await GetCompanyId(authKey);
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
         const headerCompanyId = await GetCompanyIdByPohId(line.polpoh);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (authCompanyId === -1 || headerCompanyId === -1 || authCompanyId !== headerCompanyId) {

--- a/app/controllers/purchaseordervendorcontroller.js
+++ b/app/controllers/purchaseordervendorcontroller.js
@@ -16,6 +16,11 @@ const PurchaseOrderVendor = db.PurchaseOrderVendor;
 
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 // The schema whitelist already validates fields; we re-state it here so
 // the controller doesn't trust the request body verbatim (mass-assignment
@@ -38,7 +43,7 @@ exports.create = async (req, res) => {
 
     let isAuthKeyMasterKey;
     try {
-        isAuthKeyMasterKey = await IsMaster(authKey);
+        isAuthKeyMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -53,7 +58,7 @@ exports.create = async (req, res) => {
     if (!isAuthKeyMasterKey) {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });
@@ -103,9 +108,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which PurchaseOrderVendor ids
         // are populated across the whole tenant table by status code.
@@ -129,9 +134,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -181,9 +186,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || vendor.povCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -225,9 +230,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || vendor.povCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });


### PR DESCRIPTION
## Summary

Seventh batch of the #374 rollout — four more controllers reuse the auth context `attachAuth` resolved instead of a second per-handler DB lookup.

Part of **#374** (rollout in progress — stays open).

## Changes

Converted the handlers to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- `inventorytransactioncontroller`
- `purchaseorderheadercontroller` — 5 `getCompanyIdByPovId` calls preserved.
- `purchaseorderlinecontroller` — 5 `getCompanyIdByPohId` calls preserved.
- `purchaseordervendorcontroller`

All keep their raw `IsMaster` / `GetCompanyId` aliases for the `_internals` seam and use the context helpers in the handlers. **28 of ~35 controllers now on the pattern — only the two largest (`invoice`, `timeentry`) remain**, which will get dedicated batches.

## Verification

`npm run lint` clean (no lingering `IsMaster(` / `GetCompanyId(` call sites; 10 per-entity resolver calls preserved); `npm test` → **1571 passing** — auth/scoping for all four controllers green. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/