### PR TITLE
refactor(auth): reuse attachAuth context — timeentry + finish rollout (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved on every `/v1` request, instead of each controller issuing a
   second identical DB lookup — a **pure optimization** (identical result,
   minus the round-trip; falls back to a live lookup when the context is
-  absent, e.g. direct calls in unit tests). The controllers are converted
-  to the pattern **in reviewable batches** (billablerule → reportschedule,
-  customfielddef, approvalchain, invitation → …); the remaining
-  hundreds-of-call-sites rollout continues incrementally.
+  absent, e.g. direct calls in unit tests). Rolled out across **every
+  controller** (~38, hundreds of call sites) in reviewable batches — each
+  behavior-preserving and validated by the full auth-scoping suite. The
+  per-entity resolvers (`getCompanyIdBy{CustomerId,JobId,PovId,PohId}`)
+  stay live, since attachAuth doesn't cache them.
 - **Consolidate the customer→company lookup** (#378). `customercontroller`
   dropped its hand-rolled raw-SQL `GetCustomerCompanyId` and now aliases
   the shared `auth.getCompanyIdByCustomerId` (same semantics — empty/zero

--- a/app/controllers/apikeycontroller.js
+++ b/app/controllers/apikeycontroller.js
@@ -17,7 +17,9 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const ApiKey = db.ApiKey;
 
-const IsMaster = auth.isMaster;
+// #374: reuse attachAuth's resolved context (req.isMaster) instead of a
+// second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
 const hashKey = auth.hashKey;
 
 // Metadata only — akKEY (the hash) is deliberately excluded.
@@ -40,7 +42,7 @@ async function requireMaster(req, res) {
     }
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'apikey: IsMaster failed');
         res.status(500).json({ message: "Error!" });

--- a/app/controllers/auditlogcontroller.js
+++ b/app/controllers/auditlogcontroller.js
@@ -8,8 +8,10 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const AuditLog = db.AuditLog;
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /**
  * GET /v1/auditlog/bycompany/:id — the audit trail for a company (#460).
@@ -29,9 +31,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/capacitycontroller.js
+++ b/app/controllers/capacitycontroller.js
@@ -7,8 +7,10 @@ const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildCapacity, weeksBetween } = require('../services/capacity.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Resolve the target company (or null after responding). Master keys pass ?companyId. */
 async function resolveCompany(req, res) {
@@ -17,7 +19,7 @@ async function resolveCompany(req, res) {
         res.status(403).json({ message: "Authorization key not sent." });
         return null;
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (isMaster) {
         const companyId = Number(req.query.companyId);
         if (!Number.isInteger(companyId) || companyId <= 0) {
@@ -26,7 +28,7 @@ async function resolveCompany(req, res) {
         }
         return companyId;
     }
-    const companyId = await GetCompanyId(authKey);
+    const companyId = await CompanyIdFromReq(req, authKey);
     if (companyId === -1) {
         res.status(403).json({ message: "Invalid Authorization Key." });
         return null;

--- a/app/controllers/gdprcontroller.js
+++ b/app/controllers/gdprcontroller.js
@@ -7,8 +7,10 @@ const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { anonymizedValues } = require('../services/gdpr.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Load a customer and enforce the secure-404 company scope. */
 async function findScopedCustomer(req, res) {
@@ -24,9 +26,9 @@ async function findScopedCustomer(req, res) {
         res.status(404).json({ message: "Not found." });
         return null;
     }
-    const isMaster = await IsMaster(req.get('authKey'));
+    const isMaster = await MasterFromReq(req, req.get('authKey'));
     if (!isMaster) {
-        const companyId = await GetCompanyId(req.get('authKey'));
+        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
         if (companyId === -1 || customer.custCompId !== companyId) {
             res.status(404).json({ message: "Not found." });
             return null;

--- a/app/controllers/notificationcontroller.js
+++ b/app/controllers/notificationcontroller.js
@@ -7,8 +7,10 @@ const auth = require('../middleware/auth.js');
 const { sendMail, currentTransport } = require('../services/mailer.js');
 const notifier = require('../services/notifier.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /**
  * POST /v1/notification/test — send a test email to verify the mail
@@ -24,7 +26,7 @@ exports.test = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'notification: IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -65,13 +67,13 @@ exports.dispatch = async (req, res) => {
 
     let isMaster;
     try {
-        isMaster = await IsMaster(authKey);
+        isMaster = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'notification dispatch: IsMaster failed');
         return res.status(500).json({ message: "Error!" });
     }
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }

--- a/app/controllers/payrollcontroller.js
+++ b/app/controllers/payrollcontroller.js
@@ -8,8 +8,10 @@ const auth = require('../middleware/auth.js');
 const { escapeCsvCell } = require('./_csv-escape.js');
 const { buildPayroll } = require('../services/payroll.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Resolve the target company (or null after responding). Master keys pass ?companyId. */
 async function resolveCompany(req, res) {
@@ -18,7 +20,7 @@ async function resolveCompany(req, res) {
         res.status(403).json({ message: "Authorization key not sent." });
         return null;
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (isMaster) {
         const companyId = Number(req.query.companyId);
         if (!Number.isInteger(companyId) || companyId <= 0) {
@@ -27,7 +29,7 @@ async function resolveCompany(req, res) {
         }
         return companyId;
     }
-    const companyId = await GetCompanyId(authKey);
+    const companyId = await CompanyIdFromReq(req, authKey);
     if (companyId === -1) {
         res.status(403).json({ message: "Invalid Authorization Key." });
         return null;

--- a/app/controllers/sharecontroller.js
+++ b/app/controllers/sharecontroller.js
@@ -14,8 +14,10 @@ const auth = require('../middleware/auth.js');
 const jwt = require('../services/jwt.js');
 const { resolveTtl, publicInvoiceView } = require('../services/share-link.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 const GetCompanyIdByCustomerId = auth.getCompanyIdByCustomerId;
 
 function secret() {
@@ -44,10 +46,10 @@ exports.createInvoiceShare = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
         const invCompanyId = await GetCompanyIdByCustomerId(invoice.invCustId);
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || invCompanyId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -20,6 +20,13 @@ const TimeEntry = db.TimeEntry;
 // preserve the existing call sites in the controller body.
 const IsMaster = auth.isMaster;
 const GetCompanyId = auth.getCompanyId;
+// #374: prefer attachAuth's resolved context in the handlers below; the
+// raw IsMaster / GetCompanyId above are retained only for the _internals
+// test seam. (Every call site is inside an exported handler with req in
+// scope; the req-less helpers — createOneEntry etc. — take companyId as a
+// param and never call these.)
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = [
     'teCustId', 'teWorkerId', 'teJobId', 'teBillTypeId', 'teDescription',
@@ -219,7 +226,7 @@ exports.create = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.body && req.body.teCompId);
@@ -227,7 +234,7 @@ exports.create = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify teCompId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -264,7 +271,7 @@ exports.bulk = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.body && req.body.teCompId);
@@ -272,7 +279,7 @@ exports.bulk = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify teCompId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -335,7 +342,7 @@ exports.start = async (req, res) => {
         return res.status(403).json({ message: "Authorization key not sent." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(req.body && req.body.teCompId);
@@ -343,7 +350,7 @@ exports.start = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify teCompId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -432,9 +439,9 @@ exports.stop = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || entry.teCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -477,9 +484,9 @@ exports.approval = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || entry.teCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -525,9 +532,9 @@ exports.copy = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || src.teCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -589,7 +596,7 @@ exports.approvalReminders = async (req, res) => {
     }
 
     const body = req.body || {};
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     let companyId;
     if (isMaster) {
         companyId = Number(body.companyId);
@@ -597,7 +604,7 @@ exports.approvalReminders = async (req, res) => {
             return res.status(400).json({ message: "Master-key requests must specify companyId." });
         }
     } else {
-        companyId = await GetCompanyId(authKey);
+        companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -688,9 +695,9 @@ exports.getById = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Cross-tenant access is reported as 404, not 403 — otherwise
         // a scoped caller can enumerate which TimeEntry ids are
         // populated across the whole tenant table by status code.
@@ -731,9 +738,9 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || companyId !== targetCompanyId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
         }
@@ -835,9 +842,9 @@ exports.listByWorker = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         if (companyId === -1 || worker.workerCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
         }
@@ -921,9 +928,9 @@ exports.update = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on PATCH for the same reason as GET.
         if (companyId === -1 || entry.teCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -1020,9 +1027,9 @@ exports.remove = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
-        const companyId = await GetCompanyId(authKey);
+        const companyId = await CompanyIdFromReq(req, authKey);
         // Secure-404 on DELETE for the same reason as GET / PATCH.
         if (companyId === -1 || entry.teCompId !== companyId) {
             return res.status(404).json({ message: "Not found." });
@@ -1075,7 +1082,7 @@ exports.exportCsv = async (req, res) => {
 
     let isMasterKey;
     try {
-        isMasterKey = await IsMaster(authKey);
+        isMasterKey = await MasterFromReq(req, authKey);
     } catch (error) {
         log.error({ err: error }, 'IsMaster failed');
         return res.status(500).json({ message: "Error!" });
@@ -1093,7 +1100,7 @@ exports.exportCsv = async (req, res) => {
     } else {
         let authKeyCompanyId;
         try {
-            authKeyCompanyId = await GetCompanyId(authKey);
+            authKeyCompanyId = await CompanyIdFromReq(req, authKey);
         } catch (error) {
             log.error({ err: error }, 'GetCompanyId failed');
             return res.status(500).json({ message: "Error!" });

--- a/app/controllers/versioninfocontroller.js
+++ b/app/controllers/versioninfocontroller.js
@@ -17,15 +17,18 @@ const { buildLinkHeader } = require('../middleware/pagination.js');
 const VersionInfo = db.VersionInfo;
 
 const IsMaster = auth.isMaster;
+// #374: prefer attachAuth's resolved context; IsMaster above is retained
+// only for the _internals test seam.
+const MasterFromReq = auth.masterFromReq;
 
 const ALLOWED_FIELDS = ['viVersion', 'viDate'];
 
-async function requireMaster(authKey, res) {
+async function requireMaster(req, authKey, res) {
     if (!authKey) {
         res.status(403).json({ message: "Authorization key not sent." });
         return false;
     }
-    const isMaster = await IsMaster(authKey);
+    const isMaster = await MasterFromReq(req, authKey);
     if (!isMaster) {
         res.status(403).json({ message: "Only master keys may mutate VersionInfo." });
         return false;
@@ -66,7 +69,7 @@ function requireValidAuth(req, res) {
 
 exports.create = async (req, res) => {
     const authKey = req.get('authKey');
-    if (!(await requireMaster(authKey, res))) return;
+    if (!(await requireMaster(req, authKey, res))) return;
 
     const body = req.body || {};
     const payload = {};
@@ -125,7 +128,7 @@ exports.list = async (req, res) => {
 
 exports.update = async (req, res) => {
     const authKey = req.get('authKey');
-    if (!(await requireMaster(authKey, res))) return;
+    if (!(await requireMaster(req, authKey, res))) return;
 
     let v;
     try {
@@ -156,7 +159,7 @@ exports.update = async (req, res) => {
 
 exports.remove = async (req, res) => {
     const authKey = req.get('authKey');
-    if (!(await requireMaster(authKey, res))) return;
+    if (!(await requireMaster(req, authKey, res))) return;
 
     let v;
     try {


### PR DESCRIPTION
## Summary

The **final** batch of the #374 rollout — converts the last controllers and **completes** the effort.

**Closes #374.**

## Changes

Converted to `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`:

- **`timeentrycontroller`** — the largest, 26 sites across 13 handlers. Every `authKey` is `req.get('authKey')` at the top of its handler; the `req`-less helpers (`createOneEntry(companyId, body)`, `checkEntryLinks`, …) take `companyId` as a param and never call these, so nothing there changed.
- **Service controllers** the earlier survey missed: `gdpr`, `auditlog`, `share`, `apikey`, `capacity`, `notification`, `payroll`.
- **`versioninfo`** — its master-check lived in a `req`-less `requireMaster(authKey, res)` helper; threaded `req` through (`requireMaster(req, authKey, res)`) so it reuses the context too.

## Completeness

A repo-wide grep for `await IsMaster(authKey)` / `await GetCompanyId(authKey)` / the `req.get` variants now returns **zero** across `app/controllers/`. Every controller reuses the single `isMaster`/`getCompanyId` lookup `attachAuth` already performed. The per-entity resolvers (`getCompanyIdBy{CustomerId,JobId,PovId,PohId}`) are intentionally left live — attachAuth doesn't cache them.

Controllers where `_internals` / `_helpers` export `IsMaster` / `GetCompanyId` keep those raw aliases (test seam) and use the context helpers in the handlers.

## Verification

`npm run lint` clean; `npm test` → **1571 passing**, including the **65 timeentry + 11 versioninfo api tests** (all auth/scoping paths green). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/