### PR TITLE
test(auth): guard the attachAuth-context pattern; fix reportcontroller straggler (#374)

### DIFF
--- a/app/controllers/reportcontroller.js
+++ b/app/controllers/reportcontroller.js
@@ -24,8 +24,10 @@ const { buildUtilization } = require('../services/report-utilization.js');
 const { renderRevenuePdf } = require('../services/report-pdf.js');
 const rate = require('../services/rate.js');
 
-const IsMaster = auth.isMaster;
-const GetCompanyId = auth.getCompanyId;
+// #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
+// instead of a second DB lookup; falls back to a live lookup if absent.
+const MasterFromReq = auth.masterFromReq;
+const CompanyIdFromReq = auth.companyIdFromReq;
 
 /** Parse a strict YYYY-MM-DD into a Date at UTC start/end of day, or null. */
 function parseDate(s, endOfDay) {
@@ -39,7 +41,7 @@ function parseDate(s, endOfDay) {
  * Returns { companyId } or { error: { status, message } }.
  */
 async function resolveCompany(req) {
-    const isMaster = await IsMaster(req.authKey);
+    const isMaster = await MasterFromReq(req, req.authKey);
     if (isMaster) {
         const companyId = Number(req.query.companyId);
         if (!Number.isInteger(companyId) || companyId <= 0) {
@@ -47,7 +49,7 @@ async function resolveCompany(req) {
         }
         return { companyId };
     }
-    const companyId = await GetCompanyId(req.authKey);
+    const companyId = await CompanyIdFromReq(req, req.authKey);
     if (companyId === -1) {
         return { error: { status: 403, message: "Invalid Authorization Key." } };
     }

--- a/tests/unit/attachauth-context-guard.test.js
+++ b/tests/unit/attachauth-context-guard.test.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Source-level regression pin for #374: controllers must reuse the auth
+// context attachAuth already resolved on every /v1 request, via
+// `auth.masterFromReq(req, …)` / `auth.companyIdFromReq(req, …)`, instead
+// of issuing a SECOND identical `isMaster` / `getCompanyId` DB lookup per
+// handler.
+//
+// A direct `IsMaster(...)` / `GetCompanyId(...)` CALL in a controller is
+// exactly the duplicate-round-trip pattern #374 eliminated. This grep-based
+// test pins the policy with one assertion per file so a future controller
+// (or a copy-paste of the old pattern) can't silently reintroduce it —
+// mirroring tests/unit/controller-error-shape.test.js.
+//
+// Notes on scope / false positives:
+//   * Only app/controllers/ is scanned. attachAuth itself (in
+//     app/middleware/auth.js) legitimately performs the ONE lookup — it is
+//     not a controller and is not scanned.
+//   * Some controllers retain `const IsMaster = auth.isMaster;` /
+//     `GetCompanyId` aliases purely to export them through an `_internals`
+//     test seam. Those appear as bare identifiers (`{ IsMaster,
+//     GetCompanyId }`) or in a declaration (`= auth.isMaster`), never
+//     immediately followed by `(`, so they do NOT trip the call pattern.
+//   * The per-entity resolvers `getCompanyIdBy{CustomerId,JobId,PovId,
+//     PohId}` are intentionally left live (attachAuth doesn't cache them).
+//     `\bGetCompanyId\s*\(` does not match `GetCompanyIdByCustomerId(` —
+//     the character after `GetCompanyId` there is a letter, not `(`.
+
+import { describe, test, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const CONTROLLERS = resolve(__dirname, '../../app/controllers');
+
+describe('controllers reuse attachAuth context instead of re-querying (#374)', () => {
+    const files = readdirSync(CONTROLLERS).filter((f) => f.endsWith('.js'));
+
+    test('the controllers directory is non-empty', () => {
+        // If the directory mysteriously empties, the per-file assertions
+        // below would vacuously pass. Pin a non-zero floor.
+        expect(files.length).toBeGreaterThan(0);
+    });
+
+    test.each(files)('%s calls masterFromReq/companyIdFromReq, not the raw lookup', (file) => {
+        const content = readFileSync(join(CONTROLLERS, file), 'utf8');
+        // A direct call to the raw helpers repeats attachAuth's DB lookup.
+        // Handlers must use the context-aware `MasterFromReq(req, …)` /
+        // `CompanyIdFromReq(req, …)` instead.
+        expect(content).not.toMatch(/\bIsMaster\s*\(/);
+        expect(content).not.toMatch(/\bGetCompanyId\s*\(/);
+    });
+});


### PR DESCRIPTION
## Summary

A source-level **guard-rail** locking in the #374 attachAuth-context pattern — and it immediately paid for itself by catching a controller the rollout missed.

Follow-up to #374 (already closed by #550).

## Changes

- **`tests/unit/attachauth-context-guard.test.js`** — a meta-test (one assertion per controller, mirroring `controller-error-shape.test.js`) that forbids a raw `IsMaster(...)` / `GetCompanyId(...)` **call** in any controller. Handlers must use `auth.masterFromReq(req, …)` / `companyIdFromReq(req, …)`, which reuse the single lookup `attachAuth` already did. This prevents any future controller from silently reintroducing the duplicate per-request DB round-trip.
- **`reportcontroller` fix** — writing the guard surfaced a straggler: its `resolveCompany` helper called `IsMaster(req.authKey)` / `GetCompanyId(req.authKey)` (a `req.authKey` arg shape the earlier rollout greps — which looked for `(authKey` and `(req.get` — didn't match). Converted to the context helpers.

A repo-wide grep for `IsMaster(` / `GetCompanyId(` calls is now **zero** across every controller.

## Design notes (no false positives)

- Only `app/controllers/` is scanned — `attachAuth` (in middleware) legitimately performs the one lookup.
- `_internals`/`_helpers` aliases appear as bare identifiers (`{ IsMaster, GetCompanyId }`) or declarations (`= auth.isMaster`), never followed by `(`, so they don't trip the call pattern.
- `\bGetCompanyId\s*\(` does **not** match `GetCompanyIdByCustomerId(` (the next char is a letter, not `(`); those per-entity resolvers stay live by design.

## Verification

`npm test` → **1617 passing** (+46: the guard's per-controller assertions), including the report api tests. `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/