### PR TITLE
test(webhook): cover webhook-delivery.js — the last untested service (#69)

### DIFF
--- a/tests/unit/webhook-delivery.test.js
+++ b/tests/unit/webhook-delivery.test.js
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit coverage for app/services/webhook-delivery.js (#69). The module
+// owns the ONE network side effect (a POST via global fetch) and is
+// contractually "best-effort": it must never throw and always resolve to a
+// result object. We stub global fetch and drive it through the success,
+// non-2xx, no-url, no-secret, and failure branches; the signing envelope
+// comes from the real webhook-signer (pure), so the signature assertion is
+// end-to-end.
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import { deliver } from '../../app/services/webhook-delivery.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('webhook-delivery: deliver()', () => {
+    test('returns {ok:false, error:"no url"} without calling fetch when there is no url', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        expect(await deliver(null, 'invoice.created', { a: 1 })).toEqual({ ok: false, error: 'no url' });
+        expect(await deliver({ whkUrl: '' }, 'invoice.created', {})).toEqual({ ok: false, error: 'no url' });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('POSTs a signed JSON envelope and returns {ok, status} on a completed request', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const webhook = { whkId: 7, whkUrl: 'https://example.test/hook', whkSecret: 's3cr3t' };
+        const result = await deliver(webhook, 'invoice.created', { invId: 42 });
+
+        expect(result).toEqual({ ok: true, status: 200 });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe('https://example.test/hook');
+        expect(opts.method).toBe('POST');
+        expect(opts.headers['Content-Type']).toBe('application/json');
+        expect(opts.headers['X-Webhook-Event']).toBe('invoice.created');
+
+        // Body is the { event, timestamp, data } envelope. The timestamp is
+        // an ISO string stamped at send time, so assert its shape, not value.
+        const sent = JSON.parse(opts.body);
+        expect(sent.event).toBe('invoice.created');
+        expect(sent.data).toEqual({ invId: 42 });
+        expect(typeof sent.timestamp).toBe('string');
+        expect(Number.isNaN(Date.parse(sent.timestamp))).toBe(false);
+
+        // The signature is HMAC-SHA256 over the EXACT bytes that were sent.
+        const expectedSig = 'sha256=' + crypto.createHmac('sha256', 's3cr3t').update(opts.body).digest('hex');
+        expect(opts.headers['X-Webhook-Signature']).toBe(expectedSig);
+
+        // A timeout signal guards against a hung endpoint stalling the request.
+        expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    test('omits the signature header when the webhook has no secret', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await deliver({ whkUrl: 'https://example.test/hook', whkId: 1 }, 'payment.recorded', null);
+        expect(result).toEqual({ ok: true, status: 204 });
+
+        const [, opts] = fetchMock.mock.calls[0];
+        expect(opts.headers).not.toHaveProperty('X-Webhook-Signature');
+        // A null data payload still serializes to a valid envelope.
+        expect(JSON.parse(opts.body)).toMatchObject({ event: 'payment.recorded', data: null });
+    });
+
+    test('reports a non-2xx response as {ok:false, status}', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+        vi.stubGlobal('fetch', fetchMock);
+        expect(await deliver({ whkUrl: 'https://x.test', whkSecret: 'k' }, 'invoice.created', {}))
+            .toEqual({ ok: false, status: 500 });
+    });
+
+    test('never throws — a fetch rejection resolves to {ok:false, error:<message>}', async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await deliver({ whkUrl: 'https://x.test', whkId: 9, whkSecret: 'k' }, 'invoice.created', {});
+        expect(result).toEqual({ ok: false, error: 'ECONNREFUSED' });
+    });
+
+    test('falls back to a generic error string when the thrown value has no message', async () => {
+        const fetchMock = vi.fn().mockRejectedValue({}); // e.g. a non-Error rejection
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await deliver({ whkUrl: 'https://x.test' }, 'invoice.created', {});
+        expect(result).toEqual({ ok: false, error: 'delivery failed' });
+    });
+});


### PR DESCRIPTION
## Summary

Closes the last service test-coverage gap. A sweep of `app/services/` found exactly one module with no dedicated test reference — `webhook-delivery.js` — so this adds it. Every service now has coverage.

## Changes

`tests/unit/webhook-delivery.test.js` — 6 cases over `deliver()`, the module that owns the one network side effect (a `POST` via global `fetch`) and is contractually best-effort (never throws, always resolves to a result):

- **No url** → `{ ok:false, error:"no url" }` and `fetch` is never called.
- **Success** → the signed `{ event, timestamp, data }` envelope is POSTed; the `X-Webhook-Signature` is verified end-to-end as HMAC-SHA256 over the exact bytes sent (using the **real** `webhook-signer`), and a timeout `AbortSignal` is present.
- **No secret** → the signature header is omitted.
- **Non-2xx** → `{ ok:false, status }`.
- **fetch rejects** → resolves to `{ ok:false, error:<message> }` (never throws), with a generic-string fallback for a non-Error rejection.

Global `fetch` is stubbed via `vi.stubGlobal`; the pure signer runs for real, so the signature path is exercised genuinely rather than mocked.

## Verification

`npm run lint` clean; `npm test` → **1624 passing** (+6). A re-audit of `app/services/` reports **zero untested services**. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/