### PR TITLE
fix(payroll): compute labor cost from exact minutes, not pre-rounded hours (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Payroll labor cost is computed from exact minutes, not pre-rounded
+  hours** (#456). `payroll.js` multiplied each worker's *display* hours
+  (already snapped to 2 decimals) by the cost rate, injecting up to
+  `0.005 × rate` of error per worker — e.g. 50 min @ $100/hr produced
+  `$83.00` instead of the correct `$83.33` — and accumulating it in the
+  grand `costTotal`. Cost now derives from `rate × minutes/60`, rounded
+  once, matching the billing-side calc in `rate.js`. Surfaced by an
+  adversarial correctness review of the money path; a regression test with
+  non-exact-hour minutes now pins it.
 - **`PORT=0` is honored instead of being silently coerced to 3000**
   (#124). `server.js` resolved its listen port via
   `parseInt(process.env.PORT, 10) || 3000`, which short-circuited on

--- a/app/services/payroll.js
+++ b/app/services/payroll.js
@@ -47,7 +47,12 @@ function buildPayroll(entries, workers, opts = {}) {
         const name = w ? [w.workerFName, w.workerLName].filter(Boolean).join(' ') || null : null;
         const costRate = (w && w.workerCostRate != null) ? Number(w.workerCostRate) : null;
         const totalHours = hoursFromMinutes(agg.totalMinutes);
-        const rowCost = costRate != null ? money.multiply(totalHours, costRate) : null;
+        // Labor cost is rate × exact minutes/60, rounded ONCE — NOT rate ×
+        // the 2-dp display hours. Pre-rounding the hours first injects up to
+        // 0.005×rate of error per worker (e.g. 50 min @ $100/hr: the display
+        // 0.83 h × 100 = 83.00, but the correct 100 × 50/60 = 83.33).
+        // Mirrors the rate × teMinutes/60 calc in rate.js.
+        const rowCost = costRate != null ? money.multiply(costRate, agg.totalMinutes / 60) : null;
         rows.push({
             workerId: agg.workerId,
             workerName: name,

--- a/tests/unit/payroll.test.js
+++ b/tests/unit/payroll.test.js
@@ -49,6 +49,28 @@ describe('payroll (#456)', () => {
         expect(norate.totalHours).toBe(0.75);
     });
 
+    test('labor cost is rate × exact minutes, not rate × the 2-dp display hours (regression)', () => {
+        // 50 min @ $100/hr: display hours round to 0.83, but the cost must be
+        // 100 × 50/60 = 83.3333 → 83.33 — NOT 0.83 × 100 = 83.00. Computing
+        // cost from the pre-rounded hours understated it by $0.33 here, and
+        // those errors accumulated in the grand total.
+        const workers = [
+            { workerId: 1, workerFName: 'A', workerCostRate: 100 },
+            { workerId: 2, workerFName: 'B', workerCostRate: 200 },
+        ];
+        const entries = [
+            { teWorkerId: 1, teMinutes: 50, teBillable: true }, // 100 × 50/60 = 83.33
+            { teWorkerId: 2, teMinutes: 25, teBillable: true }, // 200 × 25/60 = 83.33
+        ];
+        const { rows, totals } = buildPayroll(entries, workers);
+        const a = rows.find((r) => r.workerId === 1);
+        const b = rows.find((r) => r.workerId === 2);
+        expect(a.totalHours).toBe(0.83); // display hours stay 2-dp
+        expect(a.costTotal).toBe(83.33); // cost derived from exact minutes
+        expect(b.costTotal).toBe(83.33);
+        expect(totals.costTotal).toBe(166.66);
+    });
+
     test('totals sum hours and known costs; rows sorted by workerId', () => {
         const { rows, totals } = buildPayroll(ENTRIES, WORKERS);
         expect(rows.map((r) => r.workerId)).toEqual([1, 2, 3]);


### PR DESCRIPTION
## Summary

An adversarial correctness review of the billing/money path found **one real, reachable money bug** in `payroll.js`. This fixes it and pins it with a regression test.

## The bug

`buildPayroll` computed each worker's labor cost as:

```js
const totalHours = hoursFromMinutes(agg.totalMinutes);       // rounds minutes/60 to 2 dp
const rowCost = money.multiply(totalHours, costRate);        // then × rate
```

That's `rate × round(minutes/60, 2)` — it multiplies the **2-decimal display hours** by the rate. Correct labor cost is `rate × minutes/60`, rounded **once**. Pre-rounding the hours injects up to `0.005 × rate` of error per worker, and those errors accumulate in the grand `costTotal`.

| Input | Old (buggy) | Correct |
|---|---|---|
| 50 min @ $100/hr | `$83.00` | `$83.33` |
| 10 min @ $100/hr | `$17.00` | `$16.67` |
| 25 min @ $200/hr | `$84.00` | `$83.33` |

The sibling `rate.js` already does the billing-side calc the right way — `money.multiply(rate, teMinutes/60)` — so the two money paths disagreed. `payroll.js`'s own header even claims "hours × cost rate, **exact money**", which it wasn't.

## The fix

```js
const rowCost = costRate != null ? money.multiply(costRate, agg.totalMinutes / 60) : null;
```

`totalHours` is kept for display only. Cost derives from exact minutes, rounded once by `money.multiply`.

## Why it survived

The existing unit tests only used exact-hour inputs (60 / 30 / 120 / 45 min → whole/half hours), where the pre-rounding is a no-op, and the api test asserted nothing about cost. Added a regression case with **non-exact** minutes (50 min @ $100 → `83.33`, 25 min @ $200 → `83.33`, grand `166.66`) that fails on the old code.

## Verification

`npm run lint` clean; `npm test` → **1625 passing** (payroll unit tier now 10, incl. the regression). No other module in the reviewed set (`money.js`, invoice rollup/tax/status/aging, rate resolution/effective-dating, billable-rules, expense markup) had a reachable defect — the review confirmed their edge cases (half-away-from-zero rounding, aging bucket boundaries, effective-date ties, first-match ordering) are handled correctly. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/