### PR TITLE
fix(time-lock): normalize date-time strings to UTC — close a period-lock bypass (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Close a closed-period lock bypass via a timezone offset** (#441).
+  `time-lock.js` derived an entry's calendar day from the literal
+  `YYYY-MM-DD` prefix of a `teStartedAt` **string** (wall-clock) but from
+  `toISOString()` (UTC) for a `Date`. An offset-bearing timestamp such as
+  `2026-07-07T01:00:00+05:00` — the instant `2026-07-06T20:00:00Z`, which
+  belongs to a *locked* day — was bucketed to `2026-07-07` and slipped
+  past the lock, so create/edit/delete was wrongly allowed in a closed
+  period (and, in reverse, a genuinely-editable entry could be wrongly
+  frozen). `dateOf` now normalizes a date-time string to the true UTC day
+  the instant falls on (a bare `YYYY-MM-DD` is still taken as-is), matching
+  the `Date` path; malformed dates resolve to `null` instead of a wrong
+  slice. Found by an adversarial date/time review; regression tests pin
+  both offset directions.
 - **Tenant-scope `teCustId` on time-entry create** (#373). Creating a time
   entry (single or bulk) now verifies the customer belongs to the
   effective company — a scoped key can no longer book time against another

--- a/app/services/time-lock.js
+++ b/app/services/time-lock.js
@@ -14,14 +14,29 @@
  * here. Returns a human-readable reason string when locked, else null.
  */
 
-/** 'YYYY-MM-DD' from a Date or ISO string, else null. */
+/**
+ * The UTC calendar day ('YYYY-MM-DD') of a Date or ISO string, else null.
+ *
+ * A Date is taken via toISOString (UTC). A string needs care: a bare
+ * 'YYYY-MM-DD' is already a zone-free calendar day, but a date-TIME string
+ * may carry a zone offset (the Zod `isoDatetime` validator accepts
+ * offsets). Both must resolve to the SAME UTC day a Date input would, or an
+ * offset like `+05:00` shifts the entry to the wrong day and can slip past
+ * the closed-period lock (#441) — e.g. `2026-07-07T01:00:00+05:00` is the
+ * instant `2026-07-06T20:00:00Z`, which belongs to the locked day.
+ */
 function dateOf(startedAt) {
     if (!startedAt) return null;
-    let s;
-    if (typeof startedAt === 'string') s = startedAt;
-    else if (startedAt instanceof Date) s = startedAt.toISOString();
-    else s = String(startedAt);
-    return /^\d{4}-\d{2}-\d{2}/.test(s) ? s.slice(0, 10) : null;
+    if (startedAt instanceof Date) {
+        return Number.isNaN(startedAt.getTime()) ? null : startedAt.toISOString().slice(0, 10);
+    }
+    const s = typeof startedAt === 'string' ? startedAt : String(startedAt);
+    if (!/^\d{4}-\d{2}-\d{2}/.test(s)) return null;
+    // Bare calendar day (no time component) — no zone to reconcile.
+    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s.slice(0, 10);
+    // Date-time string: normalize to the UTC day the instant falls on.
+    const dt = new Date(s);
+    return Number.isNaN(dt.getTime()) ? null : dt.toISOString().slice(0, 10);
 }
 
 /**

--- a/tests/unit/time-lock.test.js
+++ b/tests/unit/time-lock.test.js
@@ -12,6 +12,21 @@ describe('time-lock.dateOf', () => {
         expect(dateOf('2026-07-05T09:00:00Z')).toBe('2026-07-05');
         expect(dateOf(null)).toBeNull();
     });
+
+    test('resolves a zone offset to the true UTC calendar day (matches Date input)', () => {
+        // 2026-07-07T01:00:00+05:00 is the instant 2026-07-06T20:00:00Z.
+        expect(dateOf('2026-07-07T01:00:00+05:00')).toBe('2026-07-06');
+        expect(dateOf('2026-07-06T20:00:00-05:00')).toBe('2026-07-07');
+        // A Date input for the same instant agrees.
+        expect(dateOf(new Date('2026-07-07T01:00:00+05:00'))).toBe('2026-07-06');
+    });
+
+    test('a bare YYYY-MM-DD is taken as-is; invalid values are null', () => {
+        expect(dateOf('2026-07-06')).toBe('2026-07-06');
+        expect(dateOf('not-a-date')).toBeNull();
+        expect(dateOf('2026-13-45T00:00:00Z')).toBeNull(); // format-valid, calendar-invalid
+        expect(dateOf(new Date('nope'))).toBeNull();
+    });
 });
 
 describe('time-lock.lockReason', () => {
@@ -36,5 +51,16 @@ describe('time-lock.lockReason', () => {
         expect(lockReason({ approvalStatus: 'submitted', startedAt: '2026-01-01T09:00:00Z', lockDate: null }))
             .toBeNull();
         expect(lockReason({})).toBeNull();
+    });
+
+    test('a zone offset cannot slip an entry past the lock (regression)', () => {
+        // The instant 2026-07-06T20:00:00Z belongs to the locked day even
+        // though its wall-clock string reads 2026-07-07 — must stay locked.
+        expect(lockReason({ approvalStatus: 'open', startedAt: '2026-07-07T01:00:00+05:00', lockDate: '2026-07-06' }))
+            .toMatch(/period is locked/);
+        // Conversely, an instant that is genuinely after the lock stays
+        // editable even if its wall-clock string reads the locked day.
+        expect(lockReason({ approvalStatus: 'open', startedAt: '2026-07-06T20:00:00-05:00', lockDate: '2026-07-06' }))
+            .toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

An adversarial date/time correctness review found a **closed-period lock bypass** in `time-lock.js`. This fixes it and pins both directions with regression tests.

## The bug (security)

`dateOf()` derived an entry's calendar day two inconsistent ways:
- a **`Date`** → `toISOString()` → **UTC** day;
- a **string** → the literal `YYYY-MM-DD` prefix (`s.slice(0,10)`) → **wall-clock** day, ignoring any zone offset.

The Zod `isoDatetime` validator accepts offsets (`z.string().datetime({ offset: true })`), and `timeentrycontroller` passes the **raw request string** straight to `lockReason` on create, copy, and PATCH. So an offset-bearing `teStartedAt` desynchronised the two paths:

| `teStartedAt` | true instant | old `dateOf` | verdict vs lock `2026-07-06` |
|---|---|---|---|
| `2026-07-07T01:00:00+05:00` | `2026-07-06T20:00Z` (locked day) | `2026-07-07` | **ALLOWED — bypass** |
| `2026-07-06T20:00:00-05:00` | `2026-07-07T01:00Z` (after lock) | `2026-07-06` | **wrongly LOCKED** |

The first row is the security problem: a client could create/edit/delete in a **closed (or approved-period) lock window** by tacking a positive offset onto the timestamp.

## The fix

`dateOf()` now normalizes a **date-time** string to the UTC day its instant actually falls on (`new Date(s).toISOString().slice(0,10)`), while a **bare `YYYY-MM-DD`** (zone-free calendar day) is still taken as-is. The string and `Date` paths now agree. As a bonus, a format-valid-but-calendar-invalid date (e.g. `2026-13-45`) resolves to `null` instead of a wrong slice.

Verified: the evade string is now **LOCKED**, the after-lock string is now **ALLOWED**, and all unchanged cases (bare day, `Z` string, `Date` input) still map to the same UTC day.

## Verification

`npm run lint` clean; `npm test` → **1628 passing** (time-lock unit tier now 8, incl. regressions for both offset directions and the invalid-date cases). Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

> The same review noted two low-severity date items (a `weekKey` `RangeError` on a malformed date, and a payment-reminder exact-cutoff doc-vs-impl ambiguity), neither reachable through the normal path — I'll address those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/