### PR TITLE
fix(reports): harden weekKey against invalid dates; include dunning boundary day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`report-timesheet.weekKey` no longer throws on a calendar-invalid
+  date** (#68). `isoDatePart` validates format only, so a value like
+  `2026-13-45` parsed to Invalid Date and `weekKey`'s `toISOString()` threw
+  `RangeError` — while `dayKey` tolerated the same input. `weekKey` now
+  returns its `unknown` sentinel instead, giving parity and keeping the
+  week-report path crash-safe. Found by an adversarial date/time review.
+- **Dunning digest includes an invoice due exactly `olderThanDays` ago**
+  (#10). The overdue cutoff used a strict `>= cutoff` skip, excluding an
+  invoice on the exact boundary even though the module contract flags
+  anything "at least `olderThanDays` days in the past". The boundary day is
+  now included (`> cutoff` skip); a regression test pins it. Found by the
+  same review.
 - **Payroll labor cost is computed from exact minutes, not pre-rounded
   hours** (#456). `payroll.js` multiplied each worker's *display* hours
   (already snapped to 2 decimals) by the cost rate, injecting up to

--- a/app/services/payment-reminders.js
+++ b/app/services/payment-reminders.js
@@ -38,8 +38,11 @@ function buildDunningDigest(invoices, opts = {}) {
         const outstanding = money.subtract(total, collected);
         if (outstanding <= 0) continue;
         const refDate = inv.dueDate || inv.date || null;
-        // Overdue when the reference date is strictly before the cutoff.
-        if (!refDate || !cutoff || refDate >= cutoff) continue;
+        // Flag when the reference date is on OR before the cutoff — i.e. the
+        // invoice is *at least* olderThanDays days in the past, matching the
+        // module contract. An invoice due exactly olderThanDays ago counts
+        // (previously a strict `>= cutoff` skip excluded that boundary day).
+        if (!refDate || !cutoff || refDate > cutoff) continue;
         rows.push({
             invId: inv.invId,
             invNumber: inv.invNumber || null,

--- a/app/services/report-timesheet.js
+++ b/app/services/report-timesheet.js
@@ -33,6 +33,11 @@ function weekKey(startedAt) {
     const d = isoDatePart(startedAt);
     if (d === 'unknown') return 'unknown';
     const dt = new Date(d + 'T00:00:00.000Z');
+    // isoDatePart validates FORMAT, not validity — a calendar-invalid date
+    // (e.g. '2026-13-45') parses to Invalid Date, and the toISOString below
+    // would throw RangeError. Return the 'unknown' sentinel instead, giving
+    // parity with dayKey (which tolerates the same input).
+    if (Number.isNaN(dt.getTime())) return 'unknown';
     const dow = dt.getUTCDay();          // 0=Sun..6=Sat
     const backToMonday = dow === 0 ? 6 : dow - 1;
     dt.setUTCDate(dt.getUTCDate() - backToMonday);

--- a/tests/unit/payment-reminders.test.js
+++ b/tests/unit/payment-reminders.test.js
@@ -41,6 +41,16 @@ describe('buildDunningDigest (#10)', () => {
         expect(buildDunningDigest(invs, { today: TODAY, olderThanDays: 30 }).count).toBe(0); // within 30-day grace
     });
 
+    test('an invoice due exactly olderThanDays ago is included (boundary)', () => {
+        // today 2026-03-01, olderThanDays 30 → cutoff 2026-01-30. An invoice
+        // due exactly on the cutoff is "at least 30 days in the past" and
+        // must be flagged; one day newer (2026-01-31) is still within grace.
+        expect(buildDunningDigest([{ invId: 1, dueDate: '2026-01-30', total: 100, collected: 0 }],
+            { today: TODAY, olderThanDays: 30 }).count).toBe(1);
+        expect(buildDunningDigest([{ invId: 2, dueDate: '2026-01-31', total: 100, collected: 0 }],
+            { today: TODAY, olderThanDays: 30 }).count).toBe(0);
+    });
+
     test('falls back to invoice date when no due date', () => {
         const d = buildDunningDigest([
             { invId: 1, date: '2026-01-01', total: 200, collected: 0 },

--- a/tests/unit/report-timesheet.test.js
+++ b/tests/unit/report-timesheet.test.js
@@ -19,6 +19,13 @@ describe('report-timesheet keys', () => {
         // 2026-07-06 is a Monday → itself.
         expect(weekKey('2026-07-06T09:00:00Z')).toBe('2026-07-06');
     });
+    test('weekKey returns the "unknown" sentinel on a calendar-invalid date (no throw)', () => {
+        // isoDatePart only validates format; '2026-13-45' parses to Invalid
+        // Date. weekKey must not throw RangeError — parity with dayKey.
+        expect(() => weekKey('2026-13-45')).not.toThrow();
+        expect(weekKey('2026-13-45')).toBe('unknown');
+        expect(weekKey('nope')).toBe('unknown');
+    });
 });
 
 describe('report-timesheet.buildTimesheet', () => {


### PR DESCRIPTION
## Summary

The two low-severity findings from the adversarial date/time review (the higher-severity period-lock bypass shipped separately in #555).

## Changes

**1. `report-timesheet.weekKey` — crash-hardening (#68)**

`isoDatePart` validates *format* only (`/^\d{4}-\d{2}-\d{2}/`), so a calendar-invalid value like `2026-13-45` passed through, parsed to `Invalid Date`, and `weekKey`'s `toISOString()` threw `RangeError` — while `dayKey` tolerated the identical input (returned the raw string). `weekKey` now guards `Number.isNaN(dt.getTime())` and returns its documented `unknown` sentinel, giving parity with `dayKey` and keeping the weekly-report path crash-safe.

**2. Dunning digest boundary (#10)**

`payment-reminders` skipped an invoice with `refDate >= cutoff`, which excluded an invoice due *exactly* `olderThanDays` ago — even though the module docstring flags anything "at least `olderThanDays` days in the past". Changed to `> cutoff`, so the boundary day is included (an invoice due exactly 30 days ago now appears in a 30-day digest; 29 days still doesn't).

## Verification

Both verified with node (invalid date → `unknown`, no throw; exactly-30-days-old → flagged, 29 → not). Regression tests added to both suites. **No existing test outcomes change** — neither boundary was previously covered. `npm run lint` clean; `npm test` → **1630 passing**. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/