### PR TITLE
fix(jwt): require the exp claim in verify — fail-closed (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **JWT `verify` requires the `exp` claim (fail-closed)** (#445). `verify`
+  checked expiry only when `exp` was present, so a token minted without one
+  (or with a non-numeric `exp`) never expired — despite the module
+  documenting that verify "enforces the exp claim". It now rejects any
+  token lacking a finite numeric `exp`. No app token is affected (`sign`
+  always sets `exp`); this only fails closed against a hand-crafted or
+  future exp-less token. Defense-in-depth from an adversarial crypto/auth
+  review that otherwise found the JWT/scrypt/token-hashing primitives sound
+  (alg-none rejected, algorithm-confusion immune, constant-time compares,
+  CSPRNG tokens hashed at rest).
 - **Close a closed-period lock bypass via a timezone offset** (#441).
   `time-lock.js` derived an entry's calendar day from the literal
   `YYYY-MM-DD` prefix of a `teStartedAt` **string** (wall-clock) but from

--- a/app/services/jwt.js
+++ b/app/services/jwt.js
@@ -42,7 +42,13 @@ function verify(token, secret) {
     } catch (_) {
         return null;
     }
-    if (body && body.exp && Math.floor(Date.now() / 1000) > body.exp) return null;
+    // Enforce the exp claim. A token must carry a finite numeric exp and
+    // must not be past it. Rejecting a token that lacks exp is fail-closed:
+    // sign() always sets one, so an exp-less token was NOT minted here (it
+    // would otherwise never expire). This matches the module's documented
+    // contract that verify "enforces the exp claim".
+    if (!body || !Number.isFinite(body.exp)) return null;
+    if (Math.floor(Date.now() / 1000) > body.exp) return null;
     return body;
 }
 

--- a/tests/unit/jwt.test.js
+++ b/tests/unit/jwt.test.js
@@ -2,6 +2,7 @@
 // Copyright 2026 Aaron K. Clark
 
 import { describe, test, expect } from 'vitest';
+import crypto from 'node:crypto';
 import { sign, verify } from '../../app/services/jwt.js';
 
 const SECRET = 'unit-test-secret';
@@ -38,5 +39,19 @@ describe('jwt (#445)', () => {
         expect(verify('not.a.jwt', SECRET)).toBeNull();
         expect(verify('', SECRET)).toBeNull();
         expect(verify(null, SECRET)).toBeNull();
+    });
+
+    test('verify rejects a validly-signed token that lacks an exp claim (fail-closed)', () => {
+        // Mint a token with a CORRECT HMAC signature but no exp — it would
+        // otherwise never expire. verify must reject it, not accept it.
+        const b64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+        const data = `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 1, iat: 1 })}`; // no exp
+        const sig = crypto.createHmac('sha256', SECRET).update(data).digest('base64url');
+        expect(verify(`${data}.${sig}`, SECRET)).toBeNull();
+
+        // A non-numeric exp is likewise rejected.
+        const data2 = `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 1, exp: 'soon' })}`;
+        const sig2 = crypto.createHmac('sha256', SECRET).update(data2).digest('base64url');
+        expect(verify(`${data2}.${sig2}`, SECRET)).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

A security-focused adversarial review of the crypto/auth primitives found **no exploitable vulnerabilities** — the JWT / scrypt / token-hashing code is sound. It surfaced one **defense-in-depth** item, fixed here.

## The hardening

`jwt.verify()` checked expiry only when `body.exp` was truthy:

```js
if (body && body.exp && Math.floor(Date.now()/1000) > body.exp) return null;
return body;
```

So a token minted **without** an `exp` claim (or with a non-numeric one) was accepted and **never expired** — even though the module docstring states verify "enforces the `exp` claim". `verify()` now requires a finite numeric `exp`:

```js
if (!body || !Number.isFinite(body.exp)) return null;
if (Math.floor(Date.now()/1000) > body.exp) return null;
return body;
```

**No application token is affected** — `sign()` always sets `exp` (default `now + 3600`), so every legitimately-minted token still verifies. This only **fails closed** against a hand-crafted (secret-signed) or future exp-less token, and makes the code match its documented contract.

## Review result (for the record)

The rest of the review was a clean bill of health, each defense proven by executing the real code:
- **JWT**: `alg:none` rejected, algorithm-confusion immune (single symmetric secret, header never trusted), constant-time signature compare (`timingSafeEqual` with a length/empty guard), signature verified before body parse.
- **Password**: scrypt + `randomBytes(16)` salt, constant-time verify, malformed stored hashes → `false` (no throw).
- **Tokens** (reset / invite / share): `randomBytes(32)` CSPRNG, **hashed at rest** (SHA-256), no raw-token `===` anywhere.
- **API keys / `/metrics` bearer**: 256-bit CSPRNG, hash-only storage, empty-key guards, constant-time metrics gate.

## Verification

`npm run lint` clean; `npm test` → **1631 passing**, incl. a new jwt case that mints a validly-signed token with no `exp` (and one with a non-numeric `exp`) and asserts `verify` returns `null`. Login tokens (from `sign()`) still verify. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/