### PR TITLE
fix(pagination): floor limit/offset/count in buildLinkHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`buildLinkHeader` floors `limit` / `offset` / `count` to integers.** A
+  fractional value would otherwise leak into the generated RFC-5988
+  pagination links (e.g. `offset=94.5`). Latent today — controllers pass
+  integer-parsed values — but the helper is now robust to a float; `NaN` /
+  negative inputs still return `null`. Found by an adversarial review of
+  the request-integrity middleware.
 - **`report-timesheet.weekKey` no longer throws on a calendar-invalid
   date** (#68). `isoDatePart` validates format only, so a value like
   `2026-13-45` parsed to Invalid Date and `weekKey`'s `toISOString()` threw

--- a/app/middleware/pagination.js
+++ b/app/middleware/pagination.js
@@ -24,9 +24,14 @@
  */
 
 function buildLinkHeader({ req, limit, offset, count }) {
-    const lim = Number(limit);
-    const off = Number(offset);
-    const total = Number(count);
+    // Coerce to INTEGERS. Flooring guards a caller that passes a fractional
+    // value — otherwise `offset=94.5` / `limit=10.5` would leak into the
+    // generated next/prev/first/last links. `Math.floor(NaN)` stays NaN and
+    // a negative floors to a negative, so the finite/range guards below
+    // still reject bad input rather than silently coercing it to 0.
+    const lim = Math.floor(Number(limit));
+    const off = Math.floor(Number(offset));
+    const total = Math.floor(Number(count));
     if (!Number.isFinite(lim) || lim <= 0) return null;
     if (!Number.isFinite(off) || off < 0) return null;
     if (!Number.isFinite(total) || total < 0) return null;

--- a/tests/unit/pagination.test.js
+++ b/tests/unit/pagination.test.js
@@ -74,6 +74,16 @@ describe('buildLinkHeader', () => {
         expect(link).toContain('offset=90'); // last page anchor
     });
 
+    test('fractional limit/offset are floored to integers in the generated links', () => {
+        const link = buildLinkHeader({ req: fakeReq(), limit: 10.5, offset: 10.5, count: 100 });
+        // No fractional query params leak into the Link header.
+        expect(link).not.toMatch(/(limit|offset)=\d+\.\d+/);
+        // limit floors to 10; prev floors to 0; next to 20.
+        expect(link).toContain('limit=10');
+        expect(link).toContain('offset=0');  // prev/first
+        expect(link).toContain('offset=20'); // next (10 + 10)
+    });
+
     describe('PUBLIC_BASE_URL pins the Link header base', () => {
         // Save + restore env so we don't leak into sibling tests.
         const ORIG = process.env.PUBLIC_BASE_URL;


### PR DESCRIPTION
## Summary

The safe, unambiguous item from the idempotency/request-integrity review: `buildLinkHeader` didn't truncate its numeric inputs, so a fractional `limit`/`offset` would emit fractional query params (e.g. `offset=94.5`) into the generated RFC-5988 pagination links.

## Change

Floor `limit` / `offset` / `count` to integers. The finite/range guards still run on the floored value, so `NaN` / negative inputs continue to return `null` (a negative floors to a negative; `Math.floor(NaN)` stays `NaN`). Latent today — every controller passes `parseInt`-ed values — but the helper is now robust to a float.

Regression test asserts a fractional `limit`/`offset` yields no `\d+\.\d+` query params. `npm test` → **1640 passing**; lint clean.

## Deferred review findings (from the same review)

Two idempotency findings are **intentionally not** in this PR:

- **Concurrent same-key double-execution (MEDIUM).** The cache row is written *after* the handler, so two simultaneous same-key requests both miss and both run the side effect (a double-charge risk). Sequential retries — the common case — are correctly deduped. The fix is a **pre-handler claim** (insert a pending row → conflicting concurrent request replays or 409s), which needs a nullable-columns migration, release-on-5xx / `res.on('finish')` failure handling, and careful race testing. That's payment-critical concurrency where a subtle bug could *block legitimate retries*, so it warrants a deliberate, reviewed design rather than an autonomous one-shot.
- **4xx responses cached for the full TTL (LOW).** Deterministic validation errors replaying is fine; a transient 4xx (e.g. 409/423) being stuck for 24h is a semantics call for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/