### PR TITLE
security(rbac): fail closed on prototype-named roles in permissionsFor (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **`rbac.permissionsFor` fails closed on prototype-named roles** (#448). A
+  role string matching an `Object.prototype` key (`__proto__`,
+  `constructor`, `toString`) resolved `PERMISSIONS[role]` to an inherited
+  non-array and threw `TypeError` on `.slice()`, rather than returning `[]`
+  as it does for any other unknown role. Guarded with `hasOwnProperty` so a
+  non-own key reads as unknown → no permissions (and no throw), propagating
+  through `hasPermission` / `canAssignRole`. Not currently exploitable
+  (role writes pass through `isRole` / `z.enum(ROLES)`), but removes a
+  landmine for when `canAssignRole` is wired to user-supplied input. Found
+  by an adversarial RBAC review.
 - **Bound `canonicalJson` recursion — close a pre-auth DoS in the
   idempotency middleware.** The middleware hashed the request body via an
   **unbounded** recursive `canonicalJson`, so a deeply-nested JSON body

--- a/app/services/rbac.js
+++ b/app/services/rbac.js
@@ -42,7 +42,15 @@ function roleRank(role) {
 
 /** The permission strings granted to `role` (empty for unknown roles). */
 function permissionsFor(role) {
-    return (PERMISSIONS[role] || []).slice();
+    // hasOwnProperty guard: a prototype-named role ('__proto__',
+    // 'constructor', 'toString', …) would otherwise resolve PERMISSIONS[role]
+    // to an inherited non-array and throw a TypeError on `.slice()`. Treat
+    // anything that isn't an OWN role key as unknown → [] (fail-closed),
+    // matching the docstring — and keeping hasPermission / canAssignRole
+    // robust for the day they are wired to user-supplied input.
+    return Object.prototype.hasOwnProperty.call(PERMISSIONS, role)
+        ? PERMISSIONS[role].slice()
+        : [];
 }
 
 /** Does `role` grant `permission`? */

--- a/tests/unit/rbac.test.js
+++ b/tests/unit/rbac.test.js
@@ -38,6 +38,21 @@ describe('rbac (#448)', () => {
         expect(hasPermission('ghost', 'time:read')).toBe(false);
     });
 
+    test('prototype-named roles/permissions fail closed (no throw)', () => {
+        // PERMISSIONS[role] must not resolve to an inherited object; a
+        // prototype key has to read as an unknown role → [] / false, never a
+        // TypeError from calling .slice() on Object.prototype.__proto__ etc.
+        for (const k of ['__proto__', 'constructor', 'toString', 'hasOwnProperty']) {
+            expect(() => permissionsFor(k)).not.toThrow();
+            expect(permissionsFor(k)).toEqual([]);
+            expect(hasPermission(k, 'time:read')).toBe(false);
+            expect(canAssignRole(k, 'owner')).toBe(false);
+        }
+        // A prototype key as the PERMISSION also grants nothing.
+        expect(hasPermission('owner', '__proto__')).toBe(false);
+        expect(hasPermission('owner', 'toString')).toBe(false);
+    });
+
     test('canAssignRole: needs manage-roles and no privilege escalation', () => {
         // Admin can assign member/viewer/manager/admin, but NOT owner.
         expect(canAssignRole('admin', 'member')).toBe(true);


### PR DESCRIPTION
## Summary

An adversarial RBAC review found the **core is sound** — no lower role can mint a higher one, and unknown/wrong-case roles fail closed. It surfaced one clean hardening (fixed here) and one larger structural finding (documented below for a design decision).

## Fixed here — prototype-named roles fail closed

`permissionsFor(role)` did `(PERMISSIONS[role] || []).slice()`. For a role string that names an `Object.prototype` key (`__proto__`, `constructor`, `toString`, `hasOwnProperty`), `PERMISSIONS[role]` resolves to an **inherited non-array**, so `.slice()` threw `TypeError` instead of returning `[]` the way it does for every other unknown role — and that propagated through `hasPermission` / `canAssignRole`.

Guarded with `Object.prototype.hasOwnProperty.call(PERMISSIONS, role)`: a non-own key now reads as unknown → no permissions, no throw. **Not currently exploitable** (role writes pass through `isRole` / `z.enum(ROLES)`, so such a string can't be persisted), but it removes a landmine for when `canAssignRole` is wired to user input, and fixes a documented correctness gap. Regression test added (`__proto__`/`constructor`/`toString`/`hasOwnProperty` → `[]`, `false`, no throw).

`npm test` → **1641 passing**; lint clean.

## Documented for a design decision — `canAssignRole` is not enforced (HIGH, but design-gated)

The review's central finding: **`canAssignRole` is defined and unit-tested but has zero call sites in `app/`**. So the role-writing endpoints (`PATCH /v1/user/:id/role`, `POST /v1/user`, `POST /v1/invitation` → public `accept`) apply **no privilege cap** — a company-scoped caller can assign any role including `owner` (proven: `viewer→owner` self-promotion; self-provisioned owner via invite).

**Why this isn't a one-line fix:** `rbac.js`'s own header says the model is currently **advisory** — surfaced via `/v1/me` and `/v1/user/:id/permissions` "so a client (and, **later**, JWT-guarded routes) can enforce it." There is no middleware that derives an **enforced actor role** for a request (auth is API-key/company-scoped, not user+role-scoped). Wiring `canAssignRole` requires first choosing **where the actor's role comes from** (a JWT claim? an API-key→user mapping?) — i.e. building the RBAC **enforcement layer**. That's a product/security **design decision**, not a bug fix, so I've deliberately not invented an enforcement model autonomously. Recommended once the actor-role source exists: call `canAssignRole(actorRole, targetRole)` in `usercontroller.setRole` / `user.create` and `invitationcontroller.create`, and default new users to least-privilege.

The review also confirmed **blocked**: hierarchy ordering correct, cumulative permissions correct, cross-tenant role-set → secure-404, `__proto__` as a *permission* → false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/