### PR TITLE
fix(audit): record the data subject id of a GDPR erase/export (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Audit trail records the data subject of a GDPR erase/export** (#462).
+  `entityIdOf` only captured a record id immediately after the entity
+  segment, so `/v1/gdpr/customer/:id/erase` (id two segments deep) logged
+  `alogEntityId = null` — the DCAA trail lost *which* customer a
+  right-to-erasure / export request affected, i.e. the single most
+  sensitive action recorded without its target. The matcher now also
+  handles one nested sub-resource segment, while still excluding `by*` list
+  qualifiers (a `bycompany/5` id stays `null`). Found by an adversarial
+  data-handling review that otherwise confirmed the compliance path sound
+  (export is tenant-scoped, the PII scrub is column-complete, and **no
+  secret can reach the audit log** — it stores metadata only).
 - **`buildLinkHeader` floors `limit` / `offset` / `count` to integers.** A
   fractional value would otherwise leak into the generated RFC-5988
   pagination links (e.g. `offset=94.5`). Latent today — controllers pass

--- a/app/services/audit-trail.js
+++ b/app/services/audit-trail.js
@@ -9,9 +9,23 @@
  * the before/after field changes a DCAA trail must retain.
  */
 
-/** The numeric record id in a /v1/<entity>/<id>[/...] path, or null. */
+/**
+ * The numeric record id in a /v1/<entity>/<id>[/...] path, or null. Also
+ * matches ONE nested segment — /v1/<entity>/<sub>/<id>[/...] — so the
+ * subject id of a nested action such as /v1/gdpr/customer/<id>/erase is
+ * captured for the audit trail. Previously that path logged
+ * `alogEntityId = null`, so the DCAA trail lost which data subject a
+ * right-to-erasure (or export) request affected — the most sensitive
+ * action, recorded without its target. The intermediate segment is
+ * optional and single, so normal `/v1/<entity>/<id>` paths are unchanged.
+ */
 function entityIdOf(path) {
-    const m = /^\/v1\/[a-zA-Z-]+\/(\d+)(?:\/|$|\?)/.exec(path || '');
+    // The optional intermediate segment excludes `by*` list qualifiers
+    // (bycompany / byjob / bycustomer / …) so a list path like
+    // /v1/timeentry/bycompany/3 still yields null (3 is a company id, not the
+    // record id) — only a genuine sub-resource such as gdpr/customer/<id>
+    // is matched.
+    const m = /^\/v1\/[a-zA-Z-]+\/(?:(?!by)[a-zA-Z-]+\/)?(\d+)(?:\/|$|\?)/.exec(path || '');
     return m ? Number(m[1]) : null;
 }
 

--- a/tests/unit/audit-trail.test.js
+++ b/tests/unit/audit-trail.test.js
@@ -14,6 +14,16 @@ describe('audit-trail (#462)', () => {
         expect(entityIdOf('')).toBeNull();
     });
 
+    test('entityIdOf captures the subject id of a nested action (GDPR erase/export)', () => {
+        // The right-to-erasure/export path carries the customer id two
+        // segments deep; it must be recorded so the DCAA trail names the
+        // data subject (previously logged as null).
+        expect(entityIdOf('/v1/gdpr/customer/123/erase')).toBe(123);
+        expect(entityIdOf('/v1/gdpr/customer/7/export')).toBe(7);
+        // A `by*` list qualifier is still NOT treated as a record id.
+        expect(entityIdOf('/v1/customer/bycompany/5')).toBeNull();
+    });
+
     test('diffFields reports changed / added / removed fields', () => {
         expect(diffFields({ a: 1, b: 2 }, { a: 1, b: 3 })).toEqual({ b: { from: 2, to: 3 } });
         expect(diffFields({ a: 1 }, { a: 1, b: 5 })).toEqual({ b: { from: null, to: 5 } });


### PR DESCRIPTION
## Summary

An adversarial review of the data-handling / compliance path found it **largely sound** — no cross-tenant leak, a column-complete PII scrub, and **no secret can reach the audit log**. It surfaced one clean audit-completeness fix (here) and a few low/informational items (documented below).

## Fixed here — the erasure audit event now names its subject

`entityIdOf()` matched a record id only *immediately* after the entity segment (`/v1/<entity>/<id>`). The GDPR right-to-erasure/export paths carry the customer id **two segments deep** (`/v1/gdpr/customer/123/erase`), so they were logged with `alogEntityId = null` — the DCAA trail recorded the single most sensitive, destructive action **without which data subject it affected**.

The matcher now also accepts one nested sub-resource segment, while a `(?!by)` negative lookahead keeps `by*` list qualifiers excluded (so `/v1/timeentry/bycompany/3` → `null`, since `3` is a company id, not the record id). Normal `/v1/<entity>/<id>` paths are unchanged. Regression test added.

`npm test` → **1642 passing**; lint clean.

## Review result — verified SOUND

- **Export is tenant-scoped** — `findScopedCustomer` requires `isMaster || custCompId === companyId` (secure-404); the scope id comes from the auth context, never a client param; child rows key to the verified `custId`.
- **PII scrub is complete** — `PII_FIELDS` matches the Customer DDL's PII columns exactly (name/company/address/city/state/zip/phone/email); invoices hold no name/address snapshot.
- **No secrets in the audit log** — `audit.js` writes only metadata (actor, method, path-minus-querystring, entity, id, status); no body/diff; `diffFields` has zero production callers.
- **Audit read is company-scoped**; **authz** is master-or-own-company; **no injection** (parameterized Sequelize, `Number()`-coerced ids).

## Documented for follow-up (not in this PR)

- **Unbounded GDPR export (LOW-MED).** `exportCustomer` does 7 un-`limit`ed `findAll`s — an OOM/DoS vector for a very large customer. The naive fix (a cap) conflicts with GDPR's *completeness* requirement, so it wants a **streamed export** design rather than a truncating limit — a deliberate change worth its own PR.
- **A real-scrub / cross-tenant test** for the GDPR endpoints (the current unit test checks `anonymizedValues()` against `PII_FIELDS` itself, not the model, so a future PII column added without updating `PII_FIELDS` wouldn't fail a test). Worth adding as a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/