### PR TITLE
test(gdpr): guard PII_FIELDS against the actual Customer columns (#461)

### DIFF
--- a/tests/unit/gdpr.test.js
+++ b/tests/unit/gdpr.test.js
@@ -23,3 +23,36 @@ describe('gdpr (#461)', () => {
         expect(v.custZip).toBeNull();
     });
 });
+
+// Regression guard: pin PII_FIELDS against the ACTUAL Customer columns, not
+// against itself. The original unit test only checked anonymizedValues()
+// vs PII_FIELDS — so a future PII column added to the model but forgotten
+// in PII_FIELDS would leave residual personal data after a right-to-erasure
+// and no test would fail. This closes that gap.
+describe('gdpr scrub covers every Customer PII column (regression guard)', () => {
+    // db.config defines every model at require-time; rawAttributes is
+    // available without a live DB connection.
+    const db = require('../../app/config/db.config.js');
+
+    // Columns on Customer that are deliberately NOT personal data. Adding an
+    // entry here is a conscious "this is not PII" decision — which is exactly
+    // the point: a new column must be classified, not silently ignored.
+    const NON_PII = new Set([
+        'custId',          // primary key
+        'custArch',        // soft-delete flag
+        'custCompId',      // tenant scope (FK)
+        'custDefaultRate', // billing rate — not personal data
+        'createdAt',
+        'updatedAt',
+    ]);
+
+    test('PII_FIELDS equals (Customer columns − non-PII allowlist)', () => {
+        const cols = Object.keys(db.Customer.rawAttributes);
+        const expectedPII = cols.filter((c) => !NON_PII.has(c)).sort();
+        // If this fails, a column was added to the Customer model: either add
+        // it to gdpr.js PII_FIELDS (if it holds personal data) or to NON_PII
+        // above (if it does not). Silence here would mean a right-to-erasure
+        // request leaves residual PII behind.
+        expect([...PII_FIELDS].sort()).toEqual(expectedPII);
+    });
+});


### PR DESCRIPTION
## Summary

The final safe follow-up from the data-handling review. The review confirmed the GDPR scrub is currently **column-complete**, but noted the test proved it against **itself**: `anonymizedValues()` was only compared to `PII_FIELDS`, so a future PII column added to the `Customer` model but forgotten in `PII_FIELDS` would leave **residual personal data** after a right-to-erasure — and no test would fail.

## Change

Adds a regression guard that pins `PII_FIELDS` to **`Customer.rawAttributes` minus a non-PII allowlist** (`custId`, `custArch`, `custCompId`, `custDefaultRate`, `createdAt`, `updatedAt`). Any column added to the model must now be classified — as PII (→ `PII_FIELDS`) or explicitly non-PII (→ the allowlist) — never silently ignored. It matches exactly today (the 10 PII columns).

Test-only; no runtime change. `npm test` → **1643 passing**; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/