### PR TITLE
security(mailer): reject CR/LF in subject/from — email header-injection guard (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Mailer rejects CR/LF in `subject` / `from` (email header-injection
+  guard)** (#68). `sendMail`'s validator checked the `to` address shape but
+  not `subject` or `from` for line breaks, so a user-controlled value — a
+  scheduled-report subject built from a company name, or a caller-supplied
+  `from` — could smuggle an extra SMTP header (`Bcc:`, …) or split the body
+  the moment a real SMTP transport is wired behind `setTransport`. All
+  header fields are now CRLF-rejected at the shared choke point. Latent
+  today (only the no-network capture transport is wired) — defense in depth
+  for the SMTP-adapter follow-up. Found by an adversarial data-egress
+  review that otherwise confirmed the path sound: recipient injection is
+  blocked, and share links are non-forgeable (signed, single-resource,
+  expiry-enforced) with no cross-tenant read and no SSRF.
 - **`rbac.permissionsFor` fails closed on prototype-named roles** (#448). A
   role string matching an `Object.prototype` key (`__proto__`,
   `constructor`, `toString`) resolved `PERMISSIONS[role]` to an inherited

--- a/app/services/mailer.js
+++ b/app/services/mailer.js
@@ -18,6 +18,11 @@
 const log = require('../config/logger.js');
 
 const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+// A CR or LF in any header field would let a user-controlled value (a
+// report subject built from a company name, a caller-supplied `from`)
+// smuggle extra SMTP headers (Bcc:, …) or split the body once a real SMTP
+// transport is wired behind setTransport(). Reject it at this choke point.
+const HEADER_CRLF = /[\r\n]/;
 const MAX_CAPTURED = 100;
 const captured = [];
 
@@ -50,6 +55,12 @@ function validate(message) {
     if (!message || typeof message !== 'object') return 'message is required';
     if (!message.to || !EMAIL_RE.test(String(message.to))) return 'a valid "to" address is required';
     if (!message.subject) return 'subject is required';
+    // Header-injection guard. `to` already can't hold whitespace (EMAIL_RE
+    // rejects \r\n), but guard subject / from (and to, belt-and-suspenders)
+    // so a newline can never reach an SMTP header.
+    if (HEADER_CRLF.test(String(message.subject))) return 'subject must not contain line breaks';
+    if (message.from != null && HEADER_CRLF.test(String(message.from))) return 'from must not contain line breaks';
+    if (HEADER_CRLF.test(String(message.to))) return 'to must not contain line breaks';
     return null;
 }
 

--- a/tests/unit/mailer.test.js
+++ b/tests/unit/mailer.test.js
@@ -28,6 +28,20 @@ describe('mailer (#68)', () => {
         await expect(sendMail({ to: 'a@b.com' })).rejects.toMatchObject({ code: 'EMAIL_INVALID' });
     });
 
+    test('rejects CR/LF in header fields (email header injection guard)', async () => {
+        // A newline in subject / from would smuggle an SMTP header (Bcc:, …)
+        // or split the body once a real SMTP transport is wired.
+        await expect(sendMail({ to: 'a@b.com', subject: 'Invoice\r\nBcc: evil@x.com' }))
+            .rejects.toMatchObject({ code: 'EMAIL_INVALID' });
+        await expect(sendMail({ to: 'a@b.com', subject: 'ok\ninjected' }))
+            .rejects.toMatchObject({ code: 'EMAIL_INVALID' });
+        await expect(sendMail({ to: 'a@b.com', subject: 'ok', from: 'a\r\nBcc: e@x.com <a@b.com>' }))
+            .rejects.toMatchObject({ code: 'EMAIL_INVALID' });
+        // A clean subject containing a company name (with punctuation) still sends.
+        const res = await sendMail({ to: 'a@b.com', subject: 'Monthly report — Acme Corp, Inc.', from: 'ok@x.com' });
+        expect(res.transport).toBe('capture');
+    });
+
     test('setTransport swaps the transport and sendMail uses it', async () => {
         const seen = [];
         setTransport({ name: 'stub', async send(m) { seen.push(m); return { ok: true }; } });


### PR DESCRIPTION
## Summary

The final data-egress review found the share-link path **sound on every axis** and one LOW/latent hardening — fixed here.

## Fixed — email header-injection guard

`mailer.validate()` checked the `to` address *shape* (`EMAIL_RE`, which rejects whitespace incl. CR/LF) but never inspected **`subject`** or **`from`** for line breaks, and `sendMail()` forwarded both verbatim to the transport. So a user-controlled value — a scheduled-report subject built from a **company name** (`report-email.js`), or a caller-supplied **`from`** — could smuggle an extra SMTP header (`Bcc:`, …) or split the body the moment a real SMTP transport is dropped in behind `setTransport()`.

Now CR/LF is rejected in `subject`, `from`, and `to` (belt-and-suspenders) at the shared choke point. **Latent today** — only the no-network capture transport is wired — so this is defense in depth for the SMTP-adapter follow-up. Tests: CRLF/LF in subject and CRLF in from → `EMAIL_INVALID`; a clean company-name subject (`Monthly report — Acme Corp, Inc.`) still sends.

`npm test` → **1644 passing**; lint clean.

## Review result — SOUND

Proven against the real modules:

- **Recipient (`to`) injection blocked** — `EMAIL_RE`'s `\s` + non-multiline `$` reject `victim@x.com\r\nBcc:…` and the single-`@` rule blocks a smuggled second recipient.
- **Share links non-forgeable + scoped** — the public read loads the invoice by the **signed JWT's** id (never a client param); tampered payload / `alg:none` / wrong-secret all → `null`; mint enforces `invCompanyId === companyId`. No cross-tenant read.
- **Expiry enforced on read** (finite numeric `exp`, `now > exp` → reject); **whitelisted projection** (raw payments collapsed to a `collected` sum, `invNotes`/`invCustId`/`invArch` absent); archived invoice → 404; uniform 401 on bad token (no oracle, since a valid signature can't be forged).
- **No SSRF** — `notifier` posts only to env-configured Slack/Teams URLs; the share read loads one bounded invoice.

Minor design note (not a defect): share links have no per-token revocation — a leaked link stays valid until `exp` (≤90 days); archiving the invoice or rotating `SHARE_SECRET` are the only kill switches. A `jti`/denylist would be needed if individual revocation is ever required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/