### PR TITLE
docs(security): add the adversarial review log (findings + open decisions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the `minor-and-patch` Dependabot group.
 
 ### Documentation
+- **Adversarial security & correctness review log**
+  (`docs/SECURITY-REVIEW-LOG.md`). A subsystem-by-subsystem record of the
+  review — the findings fixed (a pre-auth idempotency DoS, a period-lock
+  timezone bypass, a payroll rounding error, an email header-injection
+  guard, and more), the controls verified sound (crypto/auth primitives,
+  multi-tenant scoping, the compliance data path, share links), and the
+  open items that need a **design decision** (RBAC enforcement, idempotency
+  concurrency, streamed GDPR export, per-link share revocation). Linked
+  from `docs/SECURITY-POSTURE.md`.
 - **Architecture & conventions guide** (`docs/ARCHITECTURE.md`). A
   maintainer-facing map of the system design — the request lifecycle, the
   multi-tenant auth model and `getCompanyId*` resolver family, the

--- a/docs/SECURITY-POSTURE.md
+++ b/docs/SECURITY-POSTURE.md
@@ -137,6 +137,9 @@ organizational and outside this repository's boundary.
 
 ## 4. References
 
+- [`SECURITY-REVIEW-LOG.md`](SECURITY-REVIEW-LOG.md) — adversarial review
+  log: findings fixed, controls verified sound, and the open items awaiting
+  a design decision.
 - [`SECURITY.md`](../SECURITY.md) — vulnerability disclosure policy.
 - [`README.md`](../README.md) — "Security notes" section.
 - [`CHANGELOG.md`](../CHANGELOG.md) — per-release control history.

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 Aaron K. Clark -->
+
+# Adversarial security & correctness review — log
+
+A record of a focused, subsystem-by-subsystem adversarial review of the
+codebase: what was examined, what was fixed, what was verified sound, and
+the **open items that need a design decision** rather than a code change.
+It complements [`SECURITY-POSTURE.md`](SECURITY-POSTURE.md) (the control
+inventory) and [`ARCHITECTURE.md`](ARCHITECTURE.md) (how the system fits
+together).
+
+## Method
+
+Each subsystem was read adversarially against its own tests, with every
+reported finding **reproduced by executing the real code** before it was
+accepted, and every fix landed with a regression test. The review targeted
+the highest-stakes surfaces first (money, auth, data egress) and treated a
+plausible-but-unproven finding as not-a-finding.
+
+## Fixes shipped
+
+| Subsystem | Finding | Severity | PR |
+|---|---|---|---|
+| Idempotency | Unbounded `canonicalJson` → **pre-auth process-crash DoS** (the author's fix `580109b` had never been merged to `main`); depth-bounded → 400, async mount hardened | **High** | #558 |
+| Time-lock | Closed-period lock **bypass** via a timezone offset in `teStartedAt` (string bucketed to wall-clock day, `Date` to UTC) | High | #555 |
+| Mailer | `subject` / `from` not CR/LF-checked → **email header injection** once an SMTP transport is wired (defense-in-depth) | Med/latent | #564 |
+| RBAC | `permissionsFor` threw on prototype-named roles (`__proto__`) instead of failing closed to `[]` | Low | #561 |
+| JWT | `verify` accepted a token lacking `exp` (never expired) — now fail-closed | Low/DiD | #557 |
+| Payroll | Labor cost computed from **2-dp display hours × rate** instead of exact `rate × minutes/60` (33–67¢/worker error) | Med | #554 |
+| Reports | `weekKey` threw `RangeError` on a calendar-invalid date; dunning cutoff excluded the exact-boundary day | Low | #556 |
+| Pagination | `buildLinkHeader` didn't floor `limit`/`offset` → fractional query params | Low | #559 |
+| Audit trail | Right-to-erasure event logged `alogEntityId = null` (nested `/gdpr/customer/:id/...` path not matched) | Low | #562 |
+| GDPR | Scrub test checked `PII_FIELDS` against itself → added a guard pinning it to the real `Customer` columns | Low | #563 |
+
+## Verified sound (proven, not assumed)
+
+- **Crypto/auth primitives** — JWT rejects `alg:none` and algorithm
+  confusion, compares signatures in constant time, enforces `exp`; scrypt
+  password verify is constant-time with a CSPRNG salt; reset/invite/share
+  tokens are `randomBytes(32)` **hashed at rest**; API keys are SHA-256 at
+  rest with empty-key guards.
+- **Multi-tenant scoping** — single-entity cross-tenant access is a
+  secure-404; the scope id comes from the auth context, never a client
+  param; the #374 rollout removed the duplicate per-request lookup without
+  changing any scope decision.
+- **Compliance data path** — GDPR export is tenant-scoped; the PII scrub is
+  column-complete vs the `Customer` DDL; **no secret can reach the audit
+  log** (it stores metadata only — no body, no field diff); the audit read
+  is company-scoped.
+- **Share links** — the public read loads its resource by the **signed
+  JWT's** id (not a client param), so a token can't be pivoted cross-tenant;
+  expiry is enforced on read; the projection is field-whitelisted; an
+  invalid token 404s uniformly with no forgeable oracle.
+
+## Open — needs a design decision (not a bug fix)
+
+These are real gaps whose remedy is a product/architecture choice; each was
+deliberately **not** implemented autonomously.
+
+1. **RBAC enforcement.** `rbac.canAssignRole` (the no-privilege-escalation
+   guard) is defined and unit-tested but has **no call sites** — the
+   role-write endpoints apply no cap. Wiring it needs an *enforced actor
+   role* source, which the API-key/company-scoped auth model doesn't yet
+   provide (the code's plan is "later, JWT-guarded routes"). Decide where
+   the actor role comes from, then gate `usercontroller.setRole` /
+   `user.create` / `invitationcontroller.create`.
+2. **Idempotency concurrent double-execution.** The cache row is written
+   *after* the handler, so two simultaneous same-key requests both execute
+   the side effect (a double-charge risk); sequential retries are correctly
+   deduped. The fix is a **pre-handler claim** (insert a pending row →
+   conflicting request replays or 409s) with release-on-5xx / `res.finish`
+   handling and a nullable-columns migration.
+3. **Streamed GDPR export.** `exportCustomer` issues un-`limit`ed
+   `findAll`s — an OOM/DoS vector for a very large customer. A cap conflicts
+   with GDPR's completeness requirement, so it wants a **streamed** export
+   rather than a truncating limit.
+4. **Per-link share revocation.** Share links are stateless JWTs, so an
+   individual link can't be revoked before its `exp` (≤90 days); the only
+   levers are archiving the invoice or rotating `SHARE_SECRET`. Add a
+   `jti` + denylist if individual revocation is required.
+5. **Master actions in the tenant audit trail** (informational). A master
+   key's mutations set `alogCompId = null`, so they don't appear in the
+   affected company's audit view — a completeness gap, not a leak.
+
+---
+
+Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/


### PR DESCRIPTION
## Summary

The capstone of a subsystem-by-subsystem adversarial security & correctness review. `docs/SECURITY-REVIEW-LOG.md` records, in one durable place: what was fixed, what was verified sound, and — most usefully — the **open items that need a design decision** rather than a code change.

## Why

The review spanned eight subsystems (billing, date/time, crypto/auth, idempotency, request-integrity, RBAC, data-handling, egress) and landed **11 fixes** (PRs #554–#564). This log consolidates that work so a maintainer can see the security posture at a glance and, importantly, act on the design-gated findings.

## Contents

- **Fixes shipped** — a table (subsystem → finding → severity → PR), headlined by the pre-auth idempotency DoS (#558, a fix the author had written but never merged to `main`).
- **Verified sound (proven, not assumed)** — crypto/auth primitives, multi-tenant scoping, the compliance data path, share links.
- **Open — needs a design decision** — the four items I deliberately did **not** implement autonomously because their remedy is a product/architecture choice:
  1. **RBAC enforcement** — `canAssignRole` is defined but unwired; needs an enforced actor-role source.
  2. **Idempotency concurrent double-execution** — needs a pre-handler claim (+ migration + failure handling).
  3. **Streamed GDPR export** — an un-`limit`ed export is a DoS vector; a cap conflicts with completeness.
  4. **Per-link share revocation** — stateless JWT links need a `jti`/denylist for individual revocation.

## Verification

Every internal link resolves; `npm test` → **1644 passing** (docs-only, no runtime change); lint clean. Linked from `docs/SECURITY-POSTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/