### PR TITLE
fix(billing): exclude rejected time entries from the invoice rollup (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Invoice rollup excludes REJECTED time entries** (#440). The
+  time-entry → invoice rollup filtered on billable / job-linked /
+  not-yet-invoiced but **not** on approval status, so an entry a reviewer
+  had explicitly *rejected* still rolled into an invoice — padded hours a
+  manager killed would bill the client anyway. The rollup now excludes
+  `teApprovalStatus = 'rejected'` (open / submitted / approved still bill —
+  approval is not otherwise a billing gate; that broader policy is an open
+  decision in `docs/SECURITY-REVIEW-LOG.md`). Found by an adversarial
+  approval-workflow review; an integration test pins the filter against
+  real Postgres.
 - **Audit trail records the data subject of a GDPR erase/export** (#462).
   `entityIdOf` only captured a record id immediately after the entity
   segment, so `/v1/gdpr/customer/:id/erase` (id two segments deep) logged

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -323,6 +323,13 @@ exports.rollup = async (req, res) => {
         teBillable: true,
         teInvJobId: null,
         teJobId: { [Op.ne]: null },
+        // A reviewer's explicit REJECTION must stop the entry from being
+        // invoiced — otherwise padded hours a manager rejected still bill.
+        // open / submitted / approved all still roll up (approval is not
+        // otherwise a billing gate; see docs/SECURITY-REVIEW-LOG.md for the
+        // open "should approval gate billing?" decision). The column is
+        // NOT NULL (default 'open'), so a plain `!=` is null-safe.
+        teApprovalStatus: { [Op.ne]: 'rejected' },
     };
     const from = req.body.from ? new Date(req.body.from + 'T00:00:00.000Z') : null;
     const to = req.body.to ? new Date(req.body.to + 'T23:59:59.999Z') : null;

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -82,6 +82,23 @@ deliberately **not** implemented autonomously.
 5. **Master actions in the tenant audit trail** (informational). A master
    key's mutations set `alogCompId = null`, so they don't appear in the
    affected company's audit view — a completeness gap, not a leak.
+6. **Multi-level approval chain is not enforced.** `ApprovalChain` is a
+   standalone advisory calculator; the time-entry approval action calls
+   only `applyAction` (a single `teApprovalStatus` enum) and marks an entry
+   fully approved on the **first** `approve`, skipping every configured
+   level. Enforcing a chain needs per-level approval tracking on the entry
+   (a new counter/table), not just the enum.
+7. **Should approval gate billing?** After the rejected-exclusion fix,
+   `open` / `submitted` time still rolls into invoices — correct for
+   companies that don't use the approval feature, but a company that
+   *requires* approval before billing has no such gate. Requiring
+   `approved` would break the default (approval-less) flow, so which
+   policy applies is a per-tenant product decision.
+8. **Approver authorization / separation of duties.** The approval action
+   requires only a valid company key (no role check, no "not the logged-time
+   worker" check) — the same root cause as item 1 (RBAC is not enforced;
+   API keys resolve to a company, not a user). Self-approval is currently
+   unpreventable.
 
 ---
 

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -145,6 +145,42 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         expect(Array.isArray(withLinks)).toBe(true);
     });
 
+    test('rollup query excludes REJECTED time entries (billing gate)', async () => {
+        if (!connected) return;
+        const { Op } = db.Sequelize;
+        const company = await db.Company.create({ compName: `${SENTINEL}-rollupco`, compArch: false });
+        const customer = await db.Customer.create({
+            custCompanyName: `${SENTINEL}-rollupcust`, custFName: 'Roll', custLName: 'Up',
+            custCompId: company.compId, custArch: false,
+        });
+        const job = await db.Job.create({ jobCustId: customer.custId, jobDesc: 'rollup job' });
+        const mk = (status) => db.TimeEntry.create({
+            teCustId: customer.custId, teCompId: company.compId,
+            teStartedAt: new Date('2026-02-01T09:00:00.000Z'), teMinutes: 60,
+            teBillable: true, teJobId: job.jobId, teInvJobId: null, teApprovalStatus: status,
+        });
+        const [approved, rejected, submitted] = await Promise.all([mk('approved'), mk('rejected'), mk('submitted')]);
+        try {
+            // The exact filter invoicecontroller.rollup applies.
+            const rows = await db.TimeEntry.findAll({
+                where: {
+                    teCustId: customer.custId, teBillable: true, teInvJobId: null,
+                    teJobId: { [Op.ne]: null }, teApprovalStatus: { [Op.ne]: 'rejected' },
+                },
+                attributes: ['teId', 'teApprovalStatus'],
+            });
+            const ids = rows.map((r) => r.teId);
+            expect(ids).toContain(approved.teId);   // approved bills
+            expect(ids).toContain(submitted.teId);  // submitted still bills (approval isn't the gate)
+            expect(ids).not.toContain(rejected.teId); // a rejection keeps it OUT of the invoice
+        } finally {
+            await db.TimeEntry.destroy({ where: { teId: [approved.teId, rejected.teId, submitted.teId] } });
+            await job.destroy();
+            await customer.destroy();
+            await company.destroy();
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration


### PR DESCRIPTION
## Summary

An adversarial review of the approval workflow found the **state machine and post-approval edit/delete lock sound** — but the **billing gate had a hole**: the invoice rollup never checked approval status, so time a reviewer explicitly **rejected** still billed the client.

## Fixed — a rejection now keeps time out of the invoice

The time-entry → invoice rollup (`invoicecontroller`) filtered on `teBillable` / `teJobId` / `teInvJobId` but **not** `teApprovalStatus`, so `open`, `submitted`, and **`rejected`** entries all rolled in identically. Padded hours a manager killed would still invoice.

Added `teApprovalStatus != 'rejected'` to the rollup WHERE. The column is `NOT NULL` (default `'open'`, backfilled by the #440 migration), so a plain `!=` is null-safe. `open` / `submitted` / `approved` **still bill** — approval isn't otherwise a billing gate today, and requiring `approved` would break the default approval-less flow (see the open decision below).

## Verification

- Generated WHERE SQL now includes `AND "teApprovalStatus" != 'rejected'`.
- New **integration test** (real Postgres, runs in CI) creates approved / rejected / submitted entries and asserts only the non-rejected ones are picked up.
- The 48 invoice api tests stay green; `npm test` → **1645 passing**; lint clean.

## Design-gated findings recorded (not fixed here)

The review's other findings are product/architecture decisions, now logged in `docs/SECURITY-REVIEW-LOG.md`:

- **Multi-level approval chain is not enforced** — `ApprovalChain` is advisory; the entry stores a single status enum, so a chain can't be tracked without a new per-level counter.
- **Should approval gate billing at all?** — `open`/`submitted` still bill; a tenant that *requires* approval-before-billing needs an explicit policy toggle.
- **Approver authorization / self-approval** — the approve action requires only a company key (same root cause as the deferred RBAC enforcement); self-approval is unpreventable until an actor-role source exists.

## Verified sound

Full transition matrix correct (double-approve / reject-of-approved / skip-submit all → 409); approved entries frozen against **both** edit and delete with no unlock-then-edit path; approval endpoint secure-404 scoped; chain calculator fail-closed on partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/