### PR TITLE
security(pdf): bound invoice-PDF rendering — stop an event-loop-stall DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Bound invoice-PDF rendering — stop a synchronous event-loop-stall
+  DoS.** `drawInvoice` rendered every line item synchronously with no cap,
+  and a long unbroken `jobDesc` (up to 10 000 chars) triggers pdfkit's
+  **superlinear** word-fit measurement — 100 such lines froze the
+  single-threaded event loop for ~6 s per `GET /v1/invoice/:id/pdf`,
+  stalling the **whole server** (including `/healthz`) from one
+  authenticated request; the rate limiter doesn't help because one request
+  blocks. Each rendered description / notes field is now clipped
+  (`MAX_DESC_CHARS` / `MAX_NOTES_CHARS`) and the line count capped
+  (`MAX_PDF_LINES`, the remainder summarised), bounding render time to well
+  under a second (measured 5.85 s → 0.13 s). Found by an adversarial
+  invoice-PDF review.
 - **Mailer rejects CR/LF in `subject` / `from` (email header-injection
   guard)** (#68). `sendMail`'s validator checked the `to` address shape but
   not `subject` or `from` for line breaks, so a user-controlled value — a

--- a/app/services/invoice-pdf.js
+++ b/app/services/invoice-pdf.js
@@ -28,6 +28,23 @@ function fmtMoney(n, currency) {
     return sym ? sym + money.toFixedString(n) : code + ' ' + money.toFixedString(n);
 }
 
+// Bound the text handed to pdfkit. A very long — especially unbroken —
+// string makes pdfkit's word-fit measurement SUPERLINEAR, freezing the
+// single-threaded event loop for seconds per PDF. `jobDesc` is
+// caller-controlled (up to 10k chars) and the line count is uncapped, so
+// one GET /v1/invoice/:id/pdf could otherwise stall the whole server
+// (100 long-description lines measured at ~6s of frozen loop). A printed
+// invoice line needs only a short label; excess is truncated with an
+// ellipsis and, past MAX_PDF_LINES, summarised.
+const MAX_DESC_CHARS = 300;
+const MAX_NOTES_CHARS = 4000;
+const MAX_PDF_LINES = 1000;
+
+function clip(val, max) {
+    const s = val == null ? '' : String(val);
+    return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
 function drawInvoice(doc, data) {
     const company = data.company || {};
     const customer = data.customer || {};
@@ -83,9 +100,14 @@ function drawInvoice(doc, data) {
         doc.text(usd(sum), 380, y, { align: 'right', width: 165 });
         y += 18;
     } else {
-        for (const line of lines) {
-            doc.text(String(line.description || ''), 50, y, { width: 320 });
+        for (const line of lines.slice(0, MAX_PDF_LINES)) {
+            doc.text(clip(line.description, MAX_DESC_CHARS), 50, y, { width: 320 });
             doc.text(usd(line.amount), 380, y, { align: 'right', width: 165 });
+            y += 18;
+        }
+        if (lines.length > MAX_PDF_LINES) {
+            doc.text(`… and ${lines.length - MAX_PDF_LINES} more line item(s) not shown — see the detailed export.`,
+                50, y, { width: 495 });
             y += 18;
         }
     }
@@ -113,7 +135,7 @@ function drawInvoice(doc, data) {
         y += 24;
         doc.fillColor('#000').fontSize(9).font('Helvetica-Bold').text('NOTES', 50, y);
         y += 14;
-        doc.fontSize(9).font('Helvetica').text(String(invoice.notes), 50, y, { width: 495 });
+        doc.fontSize(9).font('Helvetica').text(clip(invoice.notes, MAX_NOTES_CHARS), 50, y, { width: 495 });
     }
 
     // ---- Footer: company narrative/branding, else a default (#423) ----
@@ -143,4 +165,4 @@ function renderInvoicePdf(data) {
     });
 }
 
-module.exports = { renderInvoicePdf };
+module.exports = { renderInvoicePdf, clip, MAX_DESC_CHARS, MAX_NOTES_CHARS, MAX_PDF_LINES };

--- a/tests/unit/invoice-pdf.test.js
+++ b/tests/unit/invoice-pdf.test.js
@@ -7,7 +7,7 @@
 
 import { describe, test, expect } from 'vitest';
 
-const { renderInvoicePdf } = require('../../app/services/invoice-pdf.js');
+const { renderInvoicePdf, clip, MAX_DESC_CHARS, MAX_PDF_LINES } = require('../../app/services/invoice-pdf.js');
 
 const isPdf = (buf) => Buffer.isBuffer(buf) && buf.slice(0, 5).toString('latin1') === '%PDF-';
 
@@ -72,5 +72,30 @@ describe('invoice-pdf.renderInvoicePdf', () => {
         });
         expect(isPdf(eur)).toBe(true);
         expect(isPdf(other)).toBe(true);
+    });
+
+    test('clip bounds text length (guards the pdfkit event-loop stall)', () => {
+        expect(clip('short', 300)).toBe('short');
+        expect(clip(null, 300)).toBe('');
+        expect(clip(undefined, 300)).toBe('');
+        const out = clip('x'.repeat(10000), MAX_DESC_CHARS);
+        expect(out.length).toBe(MAX_DESC_CHARS);
+        expect(out.endsWith('…')).toBe(true);
+    });
+
+    test('a hostile invoice (many long unbroken descriptions) renders bounded, not frozen', async () => {
+        // Pre-fix this froze the single-threaded event loop for ~6s (100
+        // lines × 10k-char unbroken jobDesc → pdfkit superlinear word-fit),
+        // stalling the whole server. The clip + line cap keep it fast.
+        // Generous ceiling to avoid CI flake (fixed ≈130ms; unbounded ≈5850ms).
+        const bigDesc = 'x'.repeat(10000);
+        const lines = Array.from({ length: MAX_PDF_LINES + 200 }, () => ({ description: bigDesc, amount: 100 }));
+        const t = Date.now();
+        const buf = await renderInvoicePdf({
+            invoice: { number: 'INV-DOS', notes: 'y'.repeat(50000) },
+            lines, totals: { subtotal: 0, tax: 0, total: 0 }, payment: {},
+        });
+        expect(isPdf(buf)).toBe(true);
+        expect(Date.now() - t).toBeLessThan(2000);
     });
 });


### PR DESCRIPTION
## Summary

The invoice-PDF review confirmed most of the path robust (empty/partial data degrades gracefully, filename is sanitised, no metadata leak, the crash-on-bad-amount path is caught → 500) — but found a real **HIGH availability defect**: PDF rendering can freeze the whole server.

## The vulnerability

`drawInvoice` renders every line item **synchronously**, and a long **unbroken** `description` (from `jobDesc`, caller-controlled up to 10 000 chars) triggers pdfkit's **superlinear** word-fit measurement. Because Node is single-threaded and `await renderInvoicePdf(data)` doesn't yield during the synchronous layout, one `GET /v1/invoice/:id/pdf` blocks **every** request (including `/healthz`).

Measured against the real renderer:

| Invoice | Render time (event loop frozen) |
|---|---|
| 100 lines × 10k-char unbroken desc | **5.85 s** |
| 1000 lines × 10k-char desc | **~60 s** |
| (during a 6.1 s render, a 50 ms interval fired **0** times) | |

The 100/15 min rate limit doesn't help — a single request stalls the server, and re-sending is a freeze loop.

## The fix

- **Clip** each rendered `description` to `MAX_DESC_CHARS` (300) and `notes` to `MAX_NOTES_CHARS` (4000), with an ellipsis — this kills the superlinear per-line cost.
- **Cap** the rendered line count at `MAX_PDF_LINES` (1000) and summarise the remainder (`… and N more line item(s) — see the detailed export`).

Render time is now bounded: **5.85 s → 0.13 s** for the 100-line case; 5000 lines → 0.28 s. A printed invoice line only needs a short label, so no legitimate output is meaningfully affected; the full data remains in the CSV/detailed export.

## Verification

`npm test` → **1651 passing**, including a new `clip` unit test and a bounded-render regression (a hostile 1200-line × 10k-char-desc + 50k-notes invoice renders a valid PDF in **< 2 s**). `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

> The review also noted a latent item (no process-level `unhandledRejection` net — the same one flagged in the idempotency review), but the PDF render's only caller catches its rejection → 500, so there's no live escape path. Left for the maintainer as a defense-in-depth follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/