### PR TITLE
security(pdf): bound report-PDF rendering — same event-loop-stall DoS (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Bound report-PDF rendering — the same event-loop-stall DoS.**
+  `report-pdf.js` `drawTable` rendered every row's cells with no cap and no
+  clip, and the customer name (`custName`) is caller-controlled — 100 rows
+  × a 10 000-char name froze the single-threaded event loop ~9 s per
+  revenue-report PDF (worse than the invoice case). Cells are now clipped
+  (`MAX_CELL_CHARS`) and the row count capped (`MAX_TABLE_ROWS`, remainder
+  summarised), bounding render time to well under a second (9 s → 0.11 s).
+  Sibling fix to the invoice-PDF bound below; found by extending the same
+  review to the report renderer.
 - **Bound invoice-PDF rendering — stop a synchronous event-loop-stall
   DoS.** `drawInvoice` rendered every line item synchronously with no cap,
   and a long unbroken `jobDesc` (up to 10 000 chars) triggers pdfkit's

--- a/app/services/report-pdf.js
+++ b/app/services/report-pdf.js
@@ -22,6 +22,19 @@ function fmtMoney(n, currency) {
     return sym ? sym + money.toFixedString(n) : code + ' ' + money.toFixedString(n);
 }
 
+// Bound the text handed to pdfkit. A long — especially unbroken — string
+// makes its word-fit measurement SUPERLINEAR and freezes the single-
+// threaded event loop (measured ~9s for 100 rows × a 10k-char custName),
+// so an uncapped report with a caller-controlled customer name could stall
+// the whole server. Cells are clipped and the row count capped. (Same
+// class of DoS fixed in invoice-pdf.js.)
+const MAX_CELL_CHARS = 200;
+const MAX_TABLE_ROWS = 2000;
+function clip(val, max) {
+    const s = val == null ? '' : String(val);
+    return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
 /** Draw a simple table; returns the y after the last row. Paginates at the page foot. */
 function drawTable(doc, y, headers, rows, cols) {
     doc.fontSize(9).font('Helvetica-Bold').fillColor('#000');
@@ -34,9 +47,15 @@ function drawTable(doc, y, headers, rows, cols) {
         doc.fillColor('#666').text('No data for this range.', 50, y);
         return y + 16;
     }
-    for (const r of rows) {
+    for (const r of rows.slice(0, MAX_TABLE_ROWS)) {
         if (y > 770) { doc.addPage(); y = 50; }
-        r.forEach((cell, i) => doc.text(String(cell), cols[i].x, y, { width: cols[i].w, align: cols[i].align || 'left' }));
+        r.forEach((cell, i) => doc.text(clip(cell, MAX_CELL_CHARS), cols[i].x, y, { width: cols[i].w, align: cols[i].align || 'left' }));
+        y += 14;
+    }
+    if (rows.length > MAX_TABLE_ROWS) {
+        if (y > 770) { doc.addPage(); y = 50; }
+        doc.fillColor('#666').text(`… and ${rows.length - MAX_TABLE_ROWS} more row(s) not shown.`, 50, y);
+        doc.fillColor('#000');
         y += 14;
     }
     return y;
@@ -132,4 +151,4 @@ function renderRevenuePdf(data) {
     });
 }
 
-module.exports = { renderRevenuePdf };
+module.exports = { renderRevenuePdf, clip, MAX_CELL_CHARS, MAX_TABLE_ROWS };

--- a/tests/unit/report-pdf.test.js
+++ b/tests/unit/report-pdf.test.js
@@ -2,7 +2,7 @@
 // Copyright 2026 Aaron K. Clark
 
 import { describe, test, expect } from 'vitest';
-import { renderRevenuePdf } from '../../app/services/report-pdf.js';
+import { renderRevenuePdf, clip, MAX_CELL_CHARS, MAX_TABLE_ROWS } from '../../app/services/report-pdf.js';
 
 const sample = {
     company: { name: 'Acme Consulting', footer: 'Thanks!' },
@@ -33,5 +33,27 @@ describe('renderRevenuePdf (#433)', () => {
         const pdf = await renderRevenuePdf({ totals: {}, byCustomer: [], byPeriod: [] });
         expect(Buffer.isBuffer(pdf)).toBe(true);
         expect(pdf.slice(0, 5).toString('latin1')).toBe('%PDF-');
+    });
+
+    test('clip bounds cell text (guards the pdfkit event-loop stall)', () => {
+        expect(clip('ok', MAX_CELL_CHARS)).toBe('ok');
+        expect(clip(null, MAX_CELL_CHARS)).toBe('');
+        const out = clip('x'.repeat(10000), MAX_CELL_CHARS);
+        expect(out.length).toBe(MAX_CELL_CHARS);
+        expect(out.endsWith('…')).toBe(true);
+    });
+
+    test('a report with many long customer names renders bounded, not frozen', async () => {
+        // Pre-fix: 100 rows × a 10k-char custName froze the event loop ~9s.
+        // Clip + row cap keep it fast. Generous ceiling to avoid CI flake
+        // (fixed ≈110ms; unbounded ≈8900ms).
+        const bigName = 'x'.repeat(10000);
+        const byCustomer = Array.from({ length: MAX_TABLE_ROWS + 200 }, () => ({
+            custName: bigName, invoiceCount: 1, revenue: 100, collected: 50, outstanding: 50,
+        }));
+        const t = Date.now();
+        const pdf = await renderRevenuePdf({ byCustomer, totals: {} });
+        expect(pdf.slice(0, 5).toString('latin1')).toBe('%PDF-');
+        expect(Date.now() - t).toBeLessThan(2000);
     });
 });


### PR DESCRIPTION
## Summary

Extending the invoice-PDF review to its **sibling renderer** immediately found the **same HIGH DoS**. `report-pdf.js` `drawTable` renders every row's cells as raw `String(cell)` with **no row cap and no per-cell clip**, and `custName` (line 83) is caller-controlled.

## The vulnerability

Same pdfkit superlinear word-fit stall as #568. Measured against the real renderer:

- **100 rows × a 10 000-char `custName` → 8.9 s** of frozen event loop per revenue-report PDF (worse than the invoice case).

One authenticated `GET` for a revenue report stalls the whole server.

## The fix (mirrors #568)

- **Clip** each cell to `MAX_CELL_CHARS` (200) with an ellipsis.
- **Cap** the rendered row count at `MAX_TABLE_ROWS` (2000), summarising the remainder (`… and N more row(s) not shown`).

Render time is now bounded: **8.9 s → 0.11 s** (100 rows); 5000 rows → 0.33 s. A table cell only needs a short value, so no legitimate report is meaningfully affected.

## Verification

`npm test` → **1653 passing**, incl. a `clip` unit test and a bounded-render regression (2200 rows × 10k-char name → valid PDF in **< 2 s**). `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/