### PR TITLE
security(tenant): tenant-check the inventory-item FK on PO lines, transactions, product entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Tenant-check the inventory-item FK on PO lines, inventory transactions,
+  and product entries.** Each of these entities validated its *parent* FK's
+  company (PO header / company / job) but left the secondary inventory FK
+  (`polInvtId` / `invtInitId` / `pentInvtId` → `InventoryItem`) **unchecked**,
+  so a company-scoped caller could attach a line / transaction / product to
+  **another tenant's** inventory item (or a dangling id — two of the three
+  have no DB FK constraint). New `auth.getCompanyIdByInvitId` +
+  `inventoryFkBelongsTo` reject a cross-tenant or missing inventory FK with a
+  generic `400` (one message for both, so the endpoint can't probe another
+  tenant's item ids) on create, update, **and** the bulk paths. Found by the
+  previously-unreviewed inventory / purchase-order subsystem review.
 - **Bound report-PDF rendering — the same event-loop-stall DoS.**
   `report-pdf.js` `drawTable` rendered every row's cells with no cap and no
   clip, and the customer name (`custName`) is caller-controlled — 100 rows

--- a/app/controllers/_bulk-helpers.js
+++ b/app/controllers/_bulk-helpers.js
@@ -41,6 +41,9 @@ function makeBulkCreate({
     archField,
     bodyKey,
     createdKey,
+    // Optional: an inventory-item FK carried on each entry that must
+    // belong to the caller's company. { field, belongsTo(value, compId) }.
+    secondaryFk,
 }) {
     return async function bulkCreate(req, res) {
         const authKey = req.get('authKey');
@@ -98,6 +101,12 @@ function makeBulkCreate({
                     });
                 }
                 p[compIdField] = authKeyCompanyId;
+                if (secondaryFk && p[secondaryFk.field] != null
+                    && !(await secondaryFk.belongsTo(p[secondaryFk.field], authKeyCompanyId))) {
+                    return res.status(400).json({
+                        message: `${bodyKey}[${i}]: invalid inventory item.`,
+                    });
+                }
             }
             // archField intentionally defaulted to false here so
             // partially-archived bulk inserts can't be smuggled in.
@@ -173,6 +182,9 @@ function makeBulkCreateIndirect({
     archField,
     bodyKey,
     createdKey,
+    // Optional: an inventory-item FK carried on each entry that must
+    // belong to the caller's company. { field, belongsTo(value, compId) }.
+    secondaryFk,
 }) {
     return async function bulkCreate(req, res) {
         const authKey = req.get('authKey');
@@ -239,6 +251,13 @@ function makeBulkCreateIndirect({
             if (!isAuthKeyMasterKey && parentCompId !== authKeyCompanyId) {
                 return res.status(403).json({
                     message: `${bodyKey}[${i}]: cannot create for a company you do not belong to.`,
+                });
+            }
+
+            if (!isAuthKeyMasterKey && secondaryFk && p[secondaryFk.field] != null
+                && !(await secondaryFk.belongsTo(p[secondaryFk.field], authKeyCompanyId))) {
+                return res.status(400).json({
+                    message: `${bodyKey}[${i}]: invalid inventory item.`,
                 });
             }
 

--- a/app/controllers/inventorytransactioncontroller.js
+++ b/app/controllers/inventorytransactioncontroller.js
@@ -59,6 +59,11 @@ exports.create = async (req, res) => {
             });
         }
         payload.invtCompanyId = authKeyCompanyId;
+        // The inventory-item FK (invtInitId) must belong to the caller's
+        // company — previously unchecked (cross-tenant / dangling reference).
+        if (!(await auth.inventoryFkBelongsTo(payload.invtInitId, authKeyCompanyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
     } else {
         if (payload.invtCompanyId === undefined || Number(payload.invtCompanyId) <= 0) {
             return res.status(400).json({
@@ -189,6 +194,13 @@ exports.update = async (req, res) => {
     if (Object.keys(updates).length === 0) {
         return res.status(400).json({ message: "No updatable fields supplied." });
     }
+    // A changed inventory-item FK must belong to the caller's company.
+    if (!isMaster && updates.invtInitId !== undefined) {
+        const companyId = await CompanyIdFromReq(req, authKey);
+        if (!(await auth.inventoryFkBelongsTo(updates.invtInitId, companyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
+    }
 
     try {
         await txn.update(updates);
@@ -242,6 +254,7 @@ exports.bulkCreate = makeBulkCreate({
     archField: 'invtArch',
     bodyKey: 'inventoryTransactions',
     createdKey: 'inventoryTransactions',
+    secondaryFk: { field: 'invtInitId', belongsTo: auth.inventoryFkBelongsTo },
 });
 
 exports._internals = { IsMaster, GetCompanyId };

--- a/app/controllers/productentrycontroller.js
+++ b/app/controllers/productentrycontroller.js
@@ -45,6 +45,12 @@ exports.create = async (req, res) => {
                 message: "Cannot create a product entry for a job in a company you do not belong to.",
             });
         }
+        // The secondary inventory-item FK must also belong to the caller's
+        // company — the parent job is scoped above, but pentInvtId was
+        // previously unchecked (cross-tenant / dangling reference).
+        if (!(await auth.inventoryFkBelongsTo(payload.pentInvtId, authCompanyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
     }
 
     payload.penArch = false;
@@ -173,6 +179,13 @@ exports.update = async (req, res) => {
     if (Object.keys(updates).length === 0) {
         return res.status(400).json({ message: "No updatable fields supplied." });
     }
+    // A changed inventory-item FK must belong to the caller's company.
+    if (!isMaster && updates.pentInvtId !== undefined) {
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
+        if (!(await auth.inventoryFkBelongsTo(updates.pentInvtId, authCompanyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
+    }
 
     try {
         await productEntry.update(updates);
@@ -228,6 +241,7 @@ exports.bulkCreate = makeBulkCreateIndirect({
     archField: 'penArch',
     bodyKey: 'productEntries',
     createdKey: 'productEntries',
+    secondaryFk: { field: 'pentInvtId', belongsTo: auth.inventoryFkBelongsTo },
 });
 
 exports._internals = { IsMaster, GetCompanyId, GetCompanyIdByJobId };

--- a/app/controllers/purchaseorderlinecontroller.js
+++ b/app/controllers/purchaseorderlinecontroller.js
@@ -50,6 +50,12 @@ exports.create = async (req, res) => {
                 message: "Cannot create a PO line for a header in a company you do not belong to.",
             });
         }
+        // The secondary inventory-item FK must also belong to the caller's
+        // company — the parent header is scoped above, but polInvtId was
+        // previously unchecked (cross-tenant / dangling reference).
+        if (!(await auth.inventoryFkBelongsTo(payload.polInvtId, authCompanyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
     }
 
     payload.polArch = false;
@@ -176,6 +182,13 @@ exports.update = async (req, res) => {
     if (Object.keys(updates).length === 0) {
         return res.status(400).json({ message: "No updatable fields supplied." });
     }
+    // A changed inventory-item FK must belong to the caller's company.
+    if (!isMaster && updates.polInvtId !== undefined) {
+        const authCompanyId = await CompanyIdFromReq(req, authKey);
+        if (!(await auth.inventoryFkBelongsTo(updates.polInvtId, authCompanyId))) {
+            return res.status(400).json({ message: "Invalid inventory item." });
+        }
+    }
 
     try {
         await line.update(updates);
@@ -231,6 +244,7 @@ exports.bulkCreate = makeBulkCreateIndirect({
     archField: 'polArch',
     bodyKey: 'purchaseOrderLines',
     createdKey: 'purchaseOrderLines',
+    secondaryFk: { field: 'polInvtId', belongsTo: auth.inventoryFkBelongsTo },
 });
 
 exports._internals = { IsMaster, GetCompanyId, GetCompanyIdByPohId };

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -300,6 +300,45 @@ async function getCompanyIdByJobId(jobId) {
 }
 
 /**
+ * Resolve an inventory-item id to its owning company id (invitCompId).
+ * Used to tenant-check the SECONDARY inventory FK carried by a
+ * PurchaseOrderLine (polInvtId), InventoryTransaction (invtInitId), and
+ * ProductEntry (pentInvtId): each already scopes on its PARENT FK, but the
+ * item FK was unchecked, so a scoped caller could point it at another
+ * tenant's item (or a dangling id). Returns -1 for missing/archived.
+ */
+async function getCompanyIdByInvitId(invitId) {
+    const idStr = invitId == null ? '' : String(invitId);
+    if (idStr.length === 0 || idStr === '0') return -1;
+    try {
+        const row = await getDb().InventoryItem.findByPk(invitId, {
+            attributes: ['invitCompId'],
+        });
+        if (!row) return -1;
+        const cid = row.invitCompId;
+        return typeof cid === 'number' && cid > 0 ? cid : -1;
+    } catch (error) {
+        log.error({ err: error }, 'auth.getCompanyIdByInvitId query failed');
+        return -1;
+    }
+}
+
+/**
+ * For a scoped (non-master) caller, an OPTIONAL secondary inventory-item
+ * FK must resolve to the caller's own company. Returns true when it is safe
+ * to proceed (the FK is absent/null, or the item belongs to `companyId`),
+ * false when it must be rejected (missing item OR cross-tenant). One boolean
+ * for both reject cases so callers surface a single generic 400 and the
+ * endpoint can't be used to probe another tenant's item ids. Master callers
+ * are trusted and should skip this check (as they do the parent-FK check).
+ */
+async function inventoryFkBelongsTo(invitIdValue, companyId) {
+    if (invitIdValue == null) return true;
+    const owner = await getCompanyIdByInvitId(invitIdValue);
+    return owner === companyId;
+}
+
+/**
  * Express middleware: ensures the authKey header is present and
  * stashes it on req.authKey. Does NOT validate the key against the
  * database — leaves that to controllers that may have different
@@ -393,6 +432,8 @@ module.exports = {
     getCompanyIdByJobId,
     getCompanyIdByPovId,
     getCompanyIdByPohId,
+    getCompanyIdByInvitId,
+    inventoryFkBelongsTo,
     requireAuthKey,
     attachAuth,
     requireAuth,

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -181,6 +181,27 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('getCompanyIdByInvitId / inventoryFkBelongsTo resolve against the real schema', async () => {
+        if (!connected) return;
+        const auth = require('../../app/middleware/auth.js');
+        const company = await db.Company.create({ compName: `${SENTINEL}-invtco`, compArch: false });
+        const item = await db.InventoryItem.create({
+            invitDescription: 'widget', invitQty: 5, invitCompId: company.compId, invitArch: false,
+        });
+        try {
+            // Proves the resolver's column name (invitCompId) + query are
+            // correct against real Postgres — a mock can't catch a typo'd column.
+            expect(await auth.getCompanyIdByInvitId(item.invitId)).toBe(company.compId);
+            expect(await auth.inventoryFkBelongsTo(item.invitId, company.compId)).toBe(true);
+            // cross-tenant + dangling both fail closed
+            expect(await auth.inventoryFkBelongsTo(item.invitId, company.compId + 99999)).toBe(false);
+            expect(await auth.getCompanyIdByInvitId(999999999)).toBe(-1);
+        } finally {
+            await item.destroy();
+            await company.destroy();
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -30,6 +30,7 @@ beforeEach(async () => {
         PurchaseOrderVendor: { findByPk: vi.fn() },
         PurchaseOrderHeader: { findByPk: vi.fn() },
         Job: { findByPk: vi.fn() },
+        InventoryItem: { findByPk: vi.fn() },
     };
     auth._setDbForTesting(stub);
 });
@@ -185,6 +186,42 @@ describe('auth.getCompanyIdByJobId', () => {
     test('returns -1 if the job has no customer linkage', async () => {
         stub.Job.findByPk.mockResolvedValueOnce({ jobId: 1, customer: null });
         expect(await auth.getCompanyIdByJobId(1)).toBe(-1);
+    });
+});
+
+describe('auth.getCompanyIdByInvitId', () => {
+    test('resolves an inventory item to its owning company', async () => {
+        stub.InventoryItem.findByPk.mockResolvedValueOnce({ invitCompId: 7 });
+        expect(await auth.getCompanyIdByInvitId(1)).toBe(7);
+    });
+    test('missing item → -1', async () => {
+        stub.InventoryItem.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByInvitId(1)).toBe(-1);
+    });
+    test('non-positive / absent id → -1 without a query', async () => {
+        expect(await auth.getCompanyIdByInvitId(0)).toBe(-1);
+        expect(await auth.getCompanyIdByInvitId(null)).toBe(-1);
+        expect(stub.InventoryItem.findByPk).not.toHaveBeenCalled();
+    });
+});
+
+describe('auth.inventoryFkBelongsTo (secondary-FK tenant guard)', () => {
+    test('absent / null FK is allowed with no query (the FK is optional)', async () => {
+        expect(await auth.inventoryFkBelongsTo(null, 7)).toBe(true);
+        expect(await auth.inventoryFkBelongsTo(undefined, 7)).toBe(true);
+        expect(stub.InventoryItem.findByPk).not.toHaveBeenCalled();
+    });
+    test('same-company item is allowed', async () => {
+        stub.InventoryItem.findByPk.mockResolvedValueOnce({ invitCompId: 7 });
+        expect(await auth.inventoryFkBelongsTo(5, 7)).toBe(true);
+    });
+    test('cross-tenant item is rejected', async () => {
+        stub.InventoryItem.findByPk.mockResolvedValueOnce({ invitCompId: 8 });
+        expect(await auth.inventoryFkBelongsTo(5, 7)).toBe(false);
+    });
+    test('missing / dangling item id is rejected', async () => {
+        stub.InventoryItem.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.inventoryFkBelongsTo(999999999, 7)).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary

An adversarial review of the **inventory + purchase-order subsystem** — a surface never examined before — found the tenant scoping, validation, and error-shape otherwise sound, but with one real **MEDIUM cross-tenant integrity break**.

`PurchaseOrderLine` (`polInvtId`), `InventoryTransaction` (`invtInitId`), and `ProductEntry` (`pentInvtId`) each carefully tenant-check their **parent** FK (header / company / job) — but the **secondary inventory-item FK is never checked**. So a company-scoped caller can attach a line / transaction / product to **another tenant's** `InventoryItem` (proven: `polInvtId: 999999999` and a cross-tenant id are both accepted). Two of the three have no DB FK constraint either, so a nonexistent id is silently stored as a dangling reference.

Impact is a cross-tenant integrity break today and a **latent read-back leak** the moment any future report `include`-joins `inventoryItem`.

## The fix

- **`auth.getCompanyIdByInvitId(invitId)`** — resolves an item to its `invitCompId` (`-1` if missing/archived), mirroring the existing resolver family.
- **`auth.inventoryFkBelongsTo(value, companyId)`** — `true` when the FK is absent or same-company, `false` for missing/cross-tenant.
- Applied on **create, update, and both bulk factories** (`makeBulkCreate` / `makeBulkCreateIndirect` via an optional `secondaryFk` config) for non-master callers → generic **`400 "Invalid inventory item."`** (one message for both missing and cross-tenant, so the endpoint can't probe another tenant's ids). Master keys are trusted and skip the check, consistent with the existing parent-FK handling.

## Verification

- **Unit:** `getCompanyIdByInvitId` + `inventoryFkBelongsTo` via the `_setDbForTesting` seam (same-company allowed; cross-tenant & missing rejected; absent allowed with no query).
- **Integration (real PG):** proves the resolver against the actual schema — the correct `invitCompId` column and a live cross-tenant/dangling check (a mock can't catch a typo'd column).
- `npm test` → **1660 passing**; the 149 PO/inventory/product/bulk api tests stay green; `npm run lint` clean.

## Not changed (informational findings, recorded for you)

- **PO money stored as `DOUBLE`, `money.js` bypassed** — but no PO total/extended-amount is computed anywhere, so nothing drifts today. Latent if a future consumer does raw `qty * price`.
- **Inventory transactions never move stock** (`invitQty` is set directly) — so there's no read-modify-write, hence no lost-update or sign bug. The movement log is currently decorative.

Both are product/architecture gaps, not correctness bugs — flagged here rather than fixed autonomously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/