### PR TITLE
fix(invoice-pdf): render the discount line so a discounted invoice reconciles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Invoice PDF shows the discount line.** A discounted invoice's PDF
+  rendered Subtotal / Tax / Total with **no Discount row**, so the printed
+  document didn't add up — e.g. Subtotal 30.00 + Tax 2.06 shown against a
+  Total of 27.06, an unexplained 5.00 gap — even though the billed Total and
+  Balance Due were correct. The footer now emits a `Discount` deduction row
+  when a discount is present, so `Subtotal − Discount + Tax = Total`
+  reconciles on the page (the totals-row logic is extracted to a testable
+  `totalsRows` helper). Found by the invoice financial-computation review,
+  which otherwise verified the tax, balance, aging, and numbering math sound.
 - **Invoice rollup excludes REJECTED time entries** (#440). The
   time-entry → invoice rollup filtered on billable / job-linked /
   not-yet-invoiced but **not** on approval status, so an entry a reviewer

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -645,7 +645,7 @@ exports.pdf = async (req, res) => {
             description: (l.job && l.job.jobDesc) || `Job #${l.injbJobId}`,
             amount: l.injbAmount == null ? null : Number(l.injbAmount),
         })),
-        totals: { subtotal: invoice.invSubtotal, tax: invoice.invTax, total: invoice.invTotal },
+        totals: { subtotal: invoice.invSubtotal, discount: invoice.invDiscount, tax: invoice.invTax, total: invoice.invTotal },
         payment: billing,
         format: req.query.format, // 'summary' | 'detailed' (default) — #424
         currency: invoice.invCurrency, // #427

--- a/app/services/invoice-pdf.js
+++ b/app/services/invoice-pdf.js
@@ -45,6 +45,28 @@ function clip(val, max) {
     return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
+/**
+ * Ordered totals rows for the invoice footer, as [label, value, bold]
+ * tuples. Extracted from drawInvoice so the discount-visibility rule is
+ * unit-testable — the rendered PDF's text is compressed and can't be
+ * asserted on directly. The Discount row (shown as a deduction) is emitted
+ * only when a discount is present, so that Subtotal − Discount + Tax =
+ * Total reconciles on the printed page (tax is on the post-discount base).
+ */
+function totalsRows(totals, payment, usd) {
+    const rows = [['Subtotal', usd(totals.subtotal), false]];
+    if (totals.discount != null && Number(totals.discount) !== 0) {
+        rows.push(['Discount', '-' + usd(totals.discount), false]);
+    }
+    rows.push(['Tax', usd(totals.tax), false]);
+    rows.push(['Total', usd(totals.total), true]);
+    if (payment.amountPaid != null && payment.amountPaid !== 0) {
+        rows.push(['Paid', usd(payment.amountPaid), false]);
+    }
+    rows.push(['Balance Due', usd(payment.balance != null ? payment.balance : totals.total), true]);
+    return rows;
+}
+
 function drawInvoice(doc, data) {
     const company = data.company || {};
     const customer = data.customer || {};
@@ -122,13 +144,9 @@ function drawInvoice(doc, data) {
         doc.text(value, 430, y, { align: 'right', width: 115 });
         y += 16;
     };
-    totalRow('Subtotal', usd(totals.subtotal));
-    totalRow('Tax', usd(totals.tax));
-    totalRow('Total', usd(totals.total), true);
-    if (payment.amountPaid != null && payment.amountPaid !== 0) {
-        totalRow('Paid', usd(payment.amountPaid));
+    for (const [label, value, bold] of totalsRows(totals, payment, usd)) {
+        totalRow(label, value, bold);
     }
-    totalRow('Balance Due', usd(payment.balance != null ? payment.balance : totals.total), true);
 
     // ---- Notes / narrative (per-invoice, #423) ----
     if (invoice.notes) {
@@ -165,4 +183,4 @@ function renderInvoicePdf(data) {
     });
 }
 
-module.exports = { renderInvoicePdf, clip, MAX_DESC_CHARS, MAX_NOTES_CHARS, MAX_PDF_LINES };
+module.exports = { renderInvoicePdf, totalsRows, clip, MAX_DESC_CHARS, MAX_NOTES_CHARS, MAX_PDF_LINES };

--- a/tests/unit/invoice-pdf.test.js
+++ b/tests/unit/invoice-pdf.test.js
@@ -7,7 +7,11 @@
 
 import { describe, test, expect } from 'vitest';
 
-const { renderInvoicePdf, clip, MAX_DESC_CHARS, MAX_PDF_LINES } = require('../../app/services/invoice-pdf.js');
+const { renderInvoicePdf, totalsRows, clip, MAX_DESC_CHARS, MAX_PDF_LINES } = require('../../app/services/invoice-pdf.js');
+
+// A trivial money formatter for asserting the totals rows (the real one is
+// currency-aware; the row LOGIC is what we pin here).
+const usd = (n) => '$' + Number(n == null ? 0 : n).toFixed(2);
 
 const isPdf = (buf) => Buffer.isBuffer(buf) && buf.slice(0, 5).toString('latin1') === '%PDF-';
 
@@ -72,6 +76,30 @@ describe('invoice-pdf.renderInvoicePdf', () => {
         });
         expect(isPdf(eur)).toBe(true);
         expect(isPdf(other)).toBe(true);
+    });
+
+    test('totalsRows shows a Discount deduction so a discounted invoice reconciles', () => {
+        // Subtotal 30 − Discount 5 → taxable 25; Tax 2.06; Total 27.06.
+        const rows = totalsRows({ subtotal: 30, discount: 5, tax: 2.06, total: 27.06 }, { balance: 27.06 }, usd);
+        const labels = rows.map((r) => r[0]);
+        expect(labels).toEqual(['Subtotal', 'Discount', 'Tax', 'Total', 'Balance Due']);
+        const discount = rows.find((r) => r[0] === 'Discount');
+        expect(discount[1]).toBe('-$5.00'); // rendered as a deduction
+    });
+
+    test('totalsRows omits the Discount row when there is no discount', () => {
+        expect(totalsRows({ subtotal: 30, discount: 0, tax: 2.48, total: 32.48 }, {}, usd)
+            .map((r) => r[0])).not.toContain('Discount');
+        // absent discount field behaves the same as zero
+        expect(totalsRows({ subtotal: 30, tax: 2.48, total: 32.48 }, {}, usd)
+            .map((r) => r[0])).not.toContain('Discount');
+    });
+
+    test('totalsRows includes a Paid row only when a payment was made', () => {
+        expect(totalsRows({ subtotal: 30, tax: 0, total: 30 }, { amountPaid: 10, balance: 20 }, usd)
+            .map((r) => r[0])).toContain('Paid');
+        expect(totalsRows({ subtotal: 30, tax: 0, total: 30 }, { amountPaid: 0, balance: 30 }, usd)
+            .map((r) => r[0])).not.toContain('Paid');
     });
 
     test('clip bounds text length (guards the pdfkit event-loop stall)', () => {


### PR DESCRIPTION
## Summary

The invoice financial-computation review verified the tax, status/balance, AR-aging, and numbering math **sound** (money.js throughout, overdue boundary correct, aging buckets non-overlapping + TZ-stable, numbering atomic + company-scoped). It found one real user-facing defect: the **invoice PDF omits the discount line**.

## The defect

The customer-facing PDF prints Subtotal / Tax / Total with **no Discount row**. On a discounted invoice the page doesn't add up:

- Two lines summing to **30.00**, discount **5.00**, tax 8.25% →
- Stored (all correct): `invSubtotal 30.00, invDiscount 5.00, invTax 2.06, invTotal 27.06`
- PDF shows: `Subtotal 30.00 / Tax 2.06 / Total 27.06` → the reader computes `30.00 + 2.06 = 32.06` against a Total of `27.06` — an unexplained **5.00 gap**.

The **billed** amount (`invTotal` / Balance Due) is correct, and the JSON `getById` already exposes `invDiscount` — only the printed document couldn't reconcile, which invites customer disputes.

## The fix

- Pass `invDiscount` into the PDF totals and emit a **`Discount` deduction row** (`-$X.XX`) when a discount is present, so `Subtotal − Discount + Tax = Total` reconciles (tax is on the post-discount base).
- Extract the footer rows into a pure **`totalsRows(totals, payment, usd)`** helper. pdfkit compresses the rendered text so it can't be asserted directly; the row logic is now unit-tested instead (Discount shown/omitted; Paid shown only when paid).

## Verification

`npm test` → **1664 passing** (+3 `totalsRows` tests); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

## Also found (recorded, not fixed — no money impact)

- `invTaxRate` stored as `DECIMAL(6,4)` truncates >4-dp rates — but the stored rate is **write-only** (never read to recompute tax), so `invTax`/`invTotal` are unaffected; display/record fidelity only.
- A $0-total invoice derives status `paid` — defensible (nothing owed), flagged in case `open`/`void` is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/