### PR TITLE
security(ssrf): block SSRF in outbound webhook delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Block SSRF in outbound webhook delivery.** A tenant registers its own
+  `whkUrl` and the server POSTs to it, previously with only a **structural**
+  URL check — so a webhook (or its `POST /v1/webhook/:id/ping`) pointed at
+  `http://169.254.169.254/` (cloud metadata), `http://127.0.0.1:6379/`, or
+  any private / link-local host was delivered, `fetch` **followed
+  redirects** (a public→internal 302 bypassed a naive registration check),
+  and the `ping` response status leaked back as an internal-reachability
+  oracle. New `app/services/ssrf-guard.js` (`safeFetch`) pins the scheme to
+  http(s), resolves the destination and **rejects any loopback / link-local
+  / private / reserved / IPv4-mapped-to-those IP**, and **re-validates every
+  redirect hop**; the webhook schema also pins the scheme at registration.
+  Found by the outbound-HTTP SSRF review, which verified the HMAC signing,
+  write-only secret handling, timeout, and no-response-body-read as sound
+  (and confirmed the notifier is not a tenant-controlled URL surface).
 - **Tenant-check the inventory-item FK on PO lines, inventory transactions,
   and product entries.** Each of these entities validated its *parent* FK's
   company (PO header / company / job) but left the secondary inventory FK

--- a/app/schemas/webhook.schema.js
+++ b/app/schemas/webhook.schema.js
@@ -9,7 +9,11 @@ const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
 });
 
-const url = z.string().url().max(2048);
+// Pin the scheme to http(s) at registration time (defense-in-depth; the
+// send-time SSRF guard in ssrf-guard.js is the real choke point and also
+// blocks private/loopback/link-local destinations + redirects to them).
+const url = z.string().url().max(2048)
+    .refine((s) => /^https?:\/\//i.test(s), { message: 'whkUrl must be an http(s) URL.' });
 const event = z.enum(WEBHOOK_EVENTS);
 const secret = z.string().min(8).max(255);
 

--- a/app/services/ssrf-guard.js
+++ b/app/services/ssrf-guard.js
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * ssrf-guard.js — SSRF protection for outbound requests to a
+ * tenant-controlled URL (currently webhook delivery, #69).
+ *
+ * A tenant can register any `whkUrl`; without this guard the server would
+ * happily POST to `http://169.254.169.254/…` (cloud metadata),
+ * `http://127.0.0.1:6379/` (internal Redis), or a private-range host, and
+ * a redirect from a public host could hop to an internal one. This module:
+ *
+ *   1. pins the scheme to http/https,
+ *   2. resolves the destination host and rejects the request if ANY
+ *      resolved IP is loopback / link-local / private / reserved /
+ *      IPv4-mapped-to-one-of-those, and
+ *   3. follows redirects MANUALLY, re-validating every hop (so a
+ *      public → internal 302 can't bypass the check).
+ *
+ * Pure Node stdlib (node:dns + node:net) — no dependency, works on every
+ * supported Node. NOTE (documented residual): a resolve-then-connect
+ * design has a narrow DNS-rebinding TOCTOU window; closing it fully needs
+ * connect-time IP pinning (a custom dispatcher). The proven attacks
+ * (direct internal URL, redirect-to-internal) are fully closed here.
+ */
+
+const dns = require('node:dns').promises;
+const net = require('node:net');
+
+class SsrfBlockedError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'SsrfBlockedError';
+    }
+}
+
+// IPv4 ranges that must never be reachable from a tenant URL. Covers
+// loopback, RFC1918 private, link-local (incl. 169.254.169.254 metadata),
+// CGNAT, "this network", TEST-NET, benchmarking, multicast, reserved, and
+// the broadcast address.
+const V4_BLOCKS = [
+    ['0.0.0.0', 8], ['10.0.0.0', 8], ['100.64.0.0', 10], ['127.0.0.0', 8],
+    ['169.254.0.0', 16], ['172.16.0.0', 12], ['192.0.0.0', 24], ['192.0.2.0', 24],
+    ['192.168.0.0', 16], ['198.18.0.0', 15], ['198.51.100.0', 24], ['203.0.113.0', 24],
+    ['224.0.0.0', 4], ['240.0.0.0', 4], ['255.255.255.255', 32],
+];
+
+function v4ToInt(ip) {
+    const p = ip.split('.');
+    return (((+p[0] << 24) >>> 0) + (+p[1] << 16) + (+p[2] << 8) + (+p[3])) >>> 0;
+}
+
+function v4InBlock(ipInt, base, bits) {
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (ipInt & mask) === (v4ToInt(base) & mask);
+}
+
+function isBlockedV4(ip) {
+    const ipInt = v4ToInt(ip);
+    return V4_BLOCKS.some(([base, bits]) => v4InBlock(ipInt, base, bits));
+}
+
+/**
+ * Extract the embedded IPv4 (dotted) from an IPv4-mapped / -embedded IPv6,
+ * or null. Handles the compressed hex form the URL parser canonicalizes to
+ * (`::ffff:a9fe:a9fe` for `::ffff:169.254.169.254`), the dotted mapped form,
+ * and a trailing dotted v4 (e.g. NAT64 `64:ff9b::a.b.c.d`).
+ */
+function embeddedV4(lower) {
+    let m = lower.match(/^::ffff:(?:0:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (m) {
+        const hi = parseInt(m[1], 16);
+        const lo = parseInt(m[2], 16);
+        return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+    }
+    m = lower.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (m && net.isIP(m[1]) === 4) return m[1];
+    return null;
+}
+
+/**
+ * True if `ip` is a non-public (loopback/link-local/private/reserved)
+ * address that a tenant-controlled URL must not reach. Fails CLOSED: a
+ * value that isn't a recognizable public IP is treated as blocked.
+ */
+function isBlockedIp(ip) {
+    const fam = net.isIP(ip);
+    if (fam === 4) return isBlockedV4(ip);
+    if (fam === 6) {
+        const lower = ip.toLowerCase();
+        const v4 = embeddedV4(lower);
+        if (v4) return isBlockedV4(v4);
+        // A mapped address we couldn't parse to a v4 → fail closed.
+        if (lower.startsWith('::ffff:')) return true;
+        if (lower === '::1' || lower === '::') return true;      // loopback / unspecified
+        if (/^f[cd]/.test(lower)) return true;                    // fc00::/7 unique-local
+        if (/^fe[89ab]/.test(lower)) return true;                 // fe80::/10 link-local
+        if (/^ff/.test(lower)) return true;                       // ff00::/8 multicast
+        return false;
+    }
+    return true; // not a valid IP literal → fail closed
+}
+
+/**
+ * Validate a destination URL: scheme must be http/https, and every IP the
+ * host resolves to must be public. Throws SsrfBlockedError otherwise.
+ * Returns the resolved IPs on success.
+ */
+async function assertPublicUrl(rawUrl) {
+    let u;
+    try {
+        u = new URL(rawUrl);
+    } catch (_) {
+        throw new SsrfBlockedError('invalid url');
+    }
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+        throw new SsrfBlockedError(`scheme not allowed: ${u.protocol}`);
+    }
+    const host = u.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+    let ips;
+    if (net.isIP(host)) {
+        ips = [host];
+    } else {
+        let records;
+        try {
+            records = await dns.lookup(host, { all: true });
+        } catch (_) {
+            throw new SsrfBlockedError('dns lookup failed');
+        }
+        ips = records.map((r) => r.address);
+    }
+    if (ips.length === 0) throw new SsrfBlockedError('no address');
+    for (const ip of ips) {
+        if (isBlockedIp(ip)) throw new SsrfBlockedError(`blocked destination ${ip}`);
+    }
+    return ips;
+}
+
+/**
+ * fetch() wrapper that enforces the SSRF guard on the initial URL AND on
+ * every redirect hop (redirect handled manually so a public → internal
+ * redirect can't bypass validation). Same signature/return as fetch;
+ * throws SsrfBlockedError if any hop targets a non-public host.
+ */
+async function safeFetch(rawUrl, options = {}, maxRedirects = 3) {
+    let current = rawUrl;
+    for (let hop = 0; ; hop += 1) {
+        await assertPublicUrl(current);
+        const res = await fetch(current, { ...options, redirect: 'manual' });
+        if (res.status >= 300 && res.status < 400) {
+            const loc = res.headers.get('location');
+            if (!loc) return res;
+            if (hop >= maxRedirects) throw new SsrfBlockedError('too many redirects');
+            current = new URL(loc, current).href; // re-validated at loop top
+            continue;
+        }
+        return res;
+    }
+}
+
+module.exports = { isBlockedIp, assertPublicUrl, safeFetch, SsrfBlockedError };

--- a/app/services/webhook-delivery.js
+++ b/app/services/webhook-delivery.js
@@ -13,6 +13,7 @@
 
 const log = require('../config/logger.js');
 const { buildEvent, signPayload } = require('./webhook-signer.js');
+const { safeFetch } = require('./ssrf-guard.js');
 
 const TIMEOUT_MS = 5000;
 
@@ -31,7 +32,11 @@ async function deliver(webhook, event, data) {
     if (sig) headers['X-Webhook-Signature'] = sig;
 
     try {
-        const res = await fetch(url, {
+        // safeFetch enforces the SSRF guard (scheme + resolved-IP denylist)
+        // on the URL AND every redirect hop — a tenant can put any host in
+        // whkUrl, so this must not reach loopback / link-local / private
+        // ranges (e.g. cloud metadata at 169.254.169.254). See ssrf-guard.js.
+        const res = await safeFetch(url, {
             method: 'POST',
             headers,
             body,

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -22,6 +22,7 @@ plausible-but-unproven finding as not-a-finding.
 
 | Subsystem | Finding | Severity | PR |
 |---|---|---|---|
+| Webhooks (SSRF) | Tenant `whkUrl` fetched with only a structural check → **SSRF** to cloud metadata / loopback / private hosts (redirect-following bypass; `ping` status oracle); added a resolved-IP denylist + scheme pin + per-hop redirect re-validation (`ssrf-guard.js`) | **High** | #573 |
 | Idempotency | Unbounded `canonicalJson` → **pre-auth process-crash DoS** (the author's fix `580109b` had never been merged to `main`); depth-bounded → 400, async mount hardened | **High** | #558 |
 | Invoice PDF | Unbounded line count × long unbroken `jobDesc` → pdfkit superlinear word-fit **froze the event loop** (~6 s/req) — one authed request stalled the whole server; descriptions/notes clipped, line count capped | **High** | #568 |
 | Report PDF | Same pdfkit **event-loop-stall DoS** in `report-pdf.js` `drawTable` (uncapped rows × caller-controlled `custName`, ~9 s/req); cells clipped, rows capped | **High** | #569 |

--- a/tests/unit/ssrf-guard.test.js
+++ b/tests/unit/ssrf-guard.test.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the outbound-request SSRF guard (app/services/ssrf-guard.js).
+// Pins the denylist + scheme + redirect re-validation so a tenant webhook
+// URL can never reach loopback / link-local / private / metadata hosts.
+
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+const { isBlockedIp, assertPublicUrl, safeFetch, SsrfBlockedError } = require('../../app/services/ssrf-guard.js');
+
+describe('isBlockedIp', () => {
+    test.each([
+        '127.0.0.1', '127.5.6.7', '10.0.0.5', '172.16.0.1', '172.31.255.255',
+        '192.168.1.1', '169.254.169.254', '100.64.0.1', '0.0.0.0', '255.255.255.255',
+        '224.0.0.1', '240.0.0.1',
+        '::1', '::', 'fc00::1', 'fd12:3456::1', 'fe80::1', 'ff02::1',
+        '::ffff:169.254.169.254', '::ffff:a9fe:a9fe', '::ffff:127.0.0.1', '::ffff:7f00:1',
+    ])('blocks non-public %s', (ip) => {
+        expect(isBlockedIp(ip)).toBe(true);
+    });
+
+    test.each([
+        '8.8.8.8', '1.1.1.1', '93.184.216.34', '203.0.114.1',
+        '2606:4700:4700::1111', '::ffff:8.8.8.8', '::ffff:808:808',
+    ])('allows public %s', (ip) => {
+        expect(isBlockedIp(ip)).toBe(false);
+    });
+
+    test('fails closed on a non-IP string', () => {
+        expect(isBlockedIp('not-an-ip')).toBe(true);
+        expect(isBlockedIp('')).toBe(true);
+    });
+});
+
+describe('assertPublicUrl', () => {
+    test.each([
+        'http://127.0.0.1:6379/',
+        'http://169.254.169.254/latest/meta-data/',
+        'http://[::1]/',
+        'http://10.0.0.5/internal',
+        'http://[::ffff:169.254.169.254]/',
+    ])('rejects internal literal %s', async (url) => {
+        await expect(assertPublicUrl(url)).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test.each(['file:///etc/passwd', 'gopher://x/', 'ftp://host/'])('rejects non-http(s) scheme %s', async (url) => {
+        await expect(assertPublicUrl(url)).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test('rejects a malformed url', async () => {
+        await expect(assertPublicUrl('http://')).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test('allows a public IP literal', async () => {
+        await expect(assertPublicUrl('http://8.8.8.8/hook')).resolves.toBeDefined();
+    });
+});
+
+describe('safeFetch', () => {
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    test('blocks a direct internal URL without ever calling fetch', async () => {
+        const spy = vi.fn();
+        vi.stubGlobal('fetch', spy);
+        await expect(safeFetch('http://127.0.0.1/')).rejects.toBeInstanceOf(SsrfBlockedError);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('blocks a public → internal redirect (re-validates each hop)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            status: 302, ok: false, headers: { get: () => 'http://127.0.0.1/latest/meta-data/' },
+        }));
+        await expect(safeFetch('http://8.8.8.8/hook')).rejects.toBeInstanceOf(SsrfBlockedError);
+    });
+
+    test('caps redirect chains even among public hosts', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            status: 302, ok: false, headers: { get: () => 'http://1.1.1.1/next' },
+        }));
+        await expect(safeFetch('http://8.8.8.8/hook', {}, 3)).rejects.toThrow(/too many redirects/);
+    });
+
+    test('returns the response for a public non-redirect destination', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200, ok: true, headers: { get: () => null } }));
+        const res = await safeFetch('http://8.8.8.8/hook');
+        expect(res.status).toBe(200);
+    });
+});

--- a/tests/unit/webhook-delivery.test.js
+++ b/tests/unit/webhook-delivery.test.js
@@ -24,18 +24,34 @@ describe('webhook-delivery: deliver()', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
+    test('SSRF: an internal/metadata destination is blocked before fetch is called', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        // A tenant-controlled whkUrl pointed at cloud metadata / loopback
+        // must not be reached (see ssrf-guard.js). deliver() stays
+        // best-effort: it returns {ok:false} rather than throwing.
+        for (const whkUrl of ['http://169.254.169.254/latest/meta-data/', 'http://127.0.0.1:6379/', 'http://[::1]/']) {
+            const r = await deliver({ whkUrl, whkSecret: 'k' }, 'invoice.created', {});
+            expect(r.ok).toBe(false);
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    // NOTE: the success-path URLs below are public IP literals (not hostnames)
+    // so the SSRF guard passes without a real DNS lookup — fetch is mocked, so
+    // no connection is actually made.
     test('POSTs a signed JSON envelope and returns {ok, status} on a completed request', async () => {
         const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
         vi.stubGlobal('fetch', fetchMock);
 
-        const webhook = { whkId: 7, whkUrl: 'https://example.test/hook', whkSecret: 's3cr3t' };
+        const webhook = { whkId: 7, whkUrl: 'http://8.8.8.8/hook', whkSecret: 's3cr3t' };
         const result = await deliver(webhook, 'invoice.created', { invId: 42 });
 
         expect(result).toEqual({ ok: true, status: 200 });
         expect(fetchMock).toHaveBeenCalledTimes(1);
 
         const [url, opts] = fetchMock.mock.calls[0];
-        expect(url).toBe('https://example.test/hook');
+        expect(url).toBe('http://8.8.8.8/hook');
         expect(opts.method).toBe('POST');
         expect(opts.headers['Content-Type']).toBe('application/json');
         expect(opts.headers['X-Webhook-Event']).toBe('invoice.created');
@@ -60,7 +76,7 @@ describe('webhook-delivery: deliver()', () => {
         const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
         vi.stubGlobal('fetch', fetchMock);
 
-        const result = await deliver({ whkUrl: 'https://example.test/hook', whkId: 1 }, 'payment.recorded', null);
+        const result = await deliver({ whkUrl: 'http://8.8.8.8/hook', whkId: 1 }, 'payment.recorded', null);
         expect(result).toEqual({ ok: true, status: 204 });
 
         const [, opts] = fetchMock.mock.calls[0];
@@ -72,21 +88,21 @@ describe('webhook-delivery: deliver()', () => {
     test('reports a non-2xx response as {ok:false, status}', async () => {
         const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
         vi.stubGlobal('fetch', fetchMock);
-        expect(await deliver({ whkUrl: 'https://x.test', whkSecret: 'k' }, 'invoice.created', {}))
+        expect(await deliver({ whkUrl: 'http://8.8.8.8', whkSecret: 'k' }, 'invoice.created', {}))
             .toEqual({ ok: false, status: 500 });
     });
 
     test('never throws — a fetch rejection resolves to {ok:false, error:<message>}', async () => {
         const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
         vi.stubGlobal('fetch', fetchMock);
-        const result = await deliver({ whkUrl: 'https://x.test', whkId: 9, whkSecret: 'k' }, 'invoice.created', {});
+        const result = await deliver({ whkUrl: 'http://8.8.8.8', whkId: 9, whkSecret: 'k' }, 'invoice.created', {});
         expect(result).toEqual({ ok: false, error: 'ECONNREFUSED' });
     });
 
     test('falls back to a generic error string when the thrown value has no message', async () => {
         const fetchMock = vi.fn().mockRejectedValue({}); // e.g. a non-Error rejection
         vi.stubGlobal('fetch', fetchMock);
-        const result = await deliver({ whkUrl: 'https://x.test' }, 'invoice.created', {});
+        const result = await deliver({ whkUrl: 'http://8.8.8.8' }, 'invoice.created', {});
         expect(result).toEqual({ ok: false, error: 'delivery failed' });
     });
 });


### PR DESCRIPTION
## Summary

The outbound-HTTP review found a **concrete, executed HIGH-severity SSRF** in webhook delivery. A tenant registers its own `whkUrl` and the server POSTs to it, previously validated by only a structural `z.string().url()`.

## The vulnerability (proven)

- A webhook — or its `POST /v1/webhook/:id/ping` — pointed at an internal host is delivered. The review drove the real `deliver()` against a loopback service and reached it; the schema accepts every SSRF target verbatim:
  ```
  http://169.254.169.254/latest/meta-data/   http://127.0.0.1:6379/   http://[::1]/
  http://10.0.0.5/internal   http://metadata.google.internal/...
  ```
- **Redirect bypass:** global `fetch` follows 3xx, so a public host that 302-redirects to `http://127.0.0.1/…` reaches the internal target (proven) — defeating any registration-time URL check.
- **Oracle:** `ping` returns `{delivered, status}`, leaking internal reachability / port state (semi-blind; the body is never read).

Both are authenticated with the tenant's own company key and scoped to its own webhook, so any tenant can trigger it.

## The fix — `app/services/ssrf-guard.js`

- **`safeFetch(url)`**: pins the scheme to http(s); resolves the destination and **rejects any resolved IP** that is loopback / link-local / private / reserved / CGNAT / IPv4-mapped-to-those (`isBlockedIp` covers the v4 CIDRs and IPv6 `::1` / `::` / `fc00::/7` / `fe80::/10` / `ff00::/8` and the `::ffff:` mapped forms **including the compressed-hex canonicalization** `::ffff:a9fe:a9fe` — a real bypass I caught mid-fix).
- **Redirects followed manually, every hop re-validated** — a public→internal 302 can't slip through.
- `webhook-delivery.js` calls `safeFetch`; the guard's throw is caught by the existing best-effort handler → `{ok:false}`.
- `webhook.schema.js` pins `whkUrl` to http(s) at registration (defense-in-depth).

Pure Node stdlib (`node:dns` + `node:net`) — no dependency. **Documented residual:** a narrow DNS-rebinding TOCTOU window remains (a full close needs connect-time IP pinning via a custom dispatcher); the *proven* attacks are closed.

## Verification

- `ssrf-guard` unit suite: denylist across all ranges incl. IPv4-mapped IPv6 (hex + dotted), scheme rejection, malformed URLs, and **redirect re-validation + cap** via a mocked fetch.
- End-to-end `webhook-delivery` test: an internal/metadata `whkUrl` is blocked **before** fetch is called.
- `npm test` → **1711 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

## Verified sound (not changed)

HMAC-SHA256 signing over the exact sent bytes with the per-webhook secret; secret is write-only (never returned/logged); 5s timeout; response body never read (no size DoS, caps the oracle to a status); no ambient auth attached; the **notifier is not a tenant-URL surface** (env-configured Slack/Teams URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/