### PR TITLE
fix(rates): bound rate/amount fields (400 not 500) + record rate design findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Rate / amount fields reject out-of-range values with a 400.** The rate
+  and money fields (`btHourlyRate`, `jobFlatRate`, `jobBudgetAmount`,
+  `taskRate`, `custDefaultRate`, `roleRate`, `rschRate`, `workerCostRate`)
+  had no upper bound, so a value above the `NUMERIC(14,2)` column limit
+  parsed fine and **overflowed to a 500** at write time. Each now caps at
+  `999,999,999.99` → a clean 400. Found by the rate-resolution review, which
+  verified the resolution arithmetic, precedence, `$0`-vs-unset handling,
+  effective-dating boundaries, and tenant scoping **sound** (the deeper
+  temporal findings — no rate snapshot, archive-fallthrough — are recorded
+  as design decisions in `docs/SECURITY-REVIEW-LOG.md`).
 - **Invoice PDF shows the discount line.** A discounted invoice's PDF
   rendered Subtotal / Tax / Total with **no Discount row**, so the printed
   document didn't add up — e.g. Subtotal 30.00 + Tax 2.06 shown against a

--- a/app/schemas/billingtype.schema.js
+++ b/app/schemas/billingtype.schema.js
@@ -22,7 +22,10 @@ const intIdParam = z.object({
 // validators (#172 / #180 / #194).
 const btHourlyRateField = z.coerce.number()
     .finite({ message: 'btHourlyRate must be a finite number.' })
-    .nonnegative();
+    .nonnegative()
+    // Cap well under the NUMERIC(14,2) column limit so an out-of-range rate
+    // returns a clean 400 instead of overflowing to a 500 at write time.
+    .max(999999999.99, { message: 'btHourlyRate exceeds the maximum allowed value.' });
 
 const createBillingTypeBody = z.object({
     btName: z.string().min(1).max(255),

--- a/app/schemas/customer.schema.js
+++ b/app/schemas/customer.schema.js
@@ -44,7 +44,7 @@ const createCustomerBody = z.object({
     custPhone: z.string().max(64).optional(),
     custEmail: z.string().email().max(255).optional(),
     custCompId: z.coerce.number().int().positive().optional(),
-    custDefaultRate: z.coerce.number().positive().optional(),
+    custDefaultRate: z.coerce.number().positive().max(999999999.99).optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: custCompanyName, custFName, custLName, custAddress1, custAddress2, custCity, custState, custZip, custPhone, custEmail, custCompId, custDefaultRate.',
 });

--- a/app/schemas/job.schema.js
+++ b/app/schemas/job.schema.js
@@ -11,9 +11,9 @@ const intIdParam = z.object({
 const createJobBody = z.object({
     jobCustId: z.coerce.number().int().positive(),
     jobDesc: z.string().min(1).max(10000),
-    jobFlatRate: z.coerce.number().positive().optional(),
+    jobFlatRate: z.coerce.number().positive().max(999999999.99).optional(),
     jobBudgetMinutes: z.coerce.number().int().positive().optional(),
-    jobBudgetAmount: z.coerce.number().positive().optional(),
+    jobBudgetAmount: z.coerce.number().positive().max(999999999.99).optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: jobCustId, jobDesc, jobFlatRate, jobBudgetMinutes, jobBudgetAmount.',
 });
@@ -21,9 +21,9 @@ const createJobBody = z.object({
 const updateJobBody = z.object({
     jobDesc: z.string().min(1).max(10000).optional(),
     jobInvoiced: z.boolean().optional(),
-    jobFlatRate: z.coerce.number().positive().nullable().optional(),
+    jobFlatRate: z.coerce.number().positive().max(999999999.99).nullable().optional(),
     jobBudgetMinutes: z.coerce.number().int().positive().nullable().optional(),
-    jobBudgetAmount: z.coerce.number().positive().nullable().optional(),
+    jobBudgetAmount: z.coerce.number().positive().max(999999999.99).nullable().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: jobDesc, jobInvoiced, jobFlatRate, jobBudgetMinutes, jobBudgetAmount.',
 });

--- a/app/schemas/rateschedule.schema.js
+++ b/app/schemas/rateschedule.schema.js
@@ -22,7 +22,7 @@ const TO_BEFORE_FROM = { message: 'rschEffectiveTo must be on or after rschEffec
  */
 const createRateScheduleBody = z.object({
     rschName: z.string().min(1).max(255),
-    rschRate: z.coerce.number().positive(),
+    rschRate: z.coerce.number().positive().max(999999999.99),
     rschEffectiveFrom: isoDate,
     rschEffectiveTo: isoDate.optional(),
     rschCompId: z.coerce.number().int().positive().optional(),
@@ -33,7 +33,7 @@ const createRateScheduleBody = z.object({
 /** PATCH /v1/rateschedule/:id — rschCompId is not patchable. */
 const updateRateScheduleBody = z.object({
     rschName: z.string().min(1).max(255).optional(),
-    rschRate: z.coerce.number().positive().optional(),
+    rschRate: z.coerce.number().positive().max(999999999.99).optional(),
     rschEffectiveFrom: isoDate.optional(),
     rschEffectiveTo: isoDate.nullable().optional(),
 }).strict({

--- a/app/schemas/role.schema.js
+++ b/app/schemas/role.schema.js
@@ -14,7 +14,7 @@ const intIdParam = z.object({
  */
 const createRoleBody = z.object({
     roleName: z.string().min(1).max(255),
-    roleRate: z.coerce.number().positive().optional(),
+    roleRate: z.coerce.number().positive().max(999999999.99).optional(),
     roleCompId: z.coerce.number().int().positive().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: roleName, roleRate, roleCompId.',
@@ -23,7 +23,7 @@ const createRoleBody = z.object({
 /** PATCH /v1/role/:id — roleCompId is not patchable. */
 const updateRoleBody = z.object({
     roleName: z.string().min(1).max(255).optional(),
-    roleRate: z.coerce.number().positive().nullable().optional(),
+    roleRate: z.coerce.number().positive().max(999999999.99).nullable().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: roleName, roleRate.',
 });

--- a/app/schemas/task.schema.js
+++ b/app/schemas/task.schema.js
@@ -13,7 +13,7 @@ const createTaskBody = z.object({
     taskJobId: z.coerce.number().int().positive(),
     taskName: z.string().min(1).max(255),
     taskDesc: z.string().max(10000).optional(),
-    taskRate: z.coerce.number().positive().optional(),
+    taskRate: z.coerce.number().positive().max(999999999.99).optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: taskJobId, taskName, taskDesc, taskRate.',
 });
@@ -22,7 +22,7 @@ const createTaskBody = z.object({
 const updateTaskBody = z.object({
     taskName: z.string().min(1).max(255).optional(),
     taskDesc: z.string().max(10000).nullable().optional(),
-    taskRate: z.coerce.number().positive().nullable().optional(),
+    taskRate: z.coerce.number().positive().max(999999999.99).nullable().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: taskName, taskDesc, taskRate.',
 });

--- a/app/schemas/worker.schema.js
+++ b/app/schemas/worker.schema.js
@@ -23,7 +23,7 @@ const createWorkerBody = z.object({
     workerDefaultBillType: z.coerce.number().int().positive(),
     workerCompId: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().optional(),
-    workerCostRate: z.coerce.number().positive().optional(),
+    workerCostRate: z.coerce.number().positive().max(999999999.99).optional(),
     workerRoleId: z.coerce.number().int().positive().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',
@@ -41,7 +41,7 @@ const updateWorkerBody = z.object({
     workerTitle: z.string().min(1).max(255).optional(),
     workerDefaultBillType: z.coerce.number().int().positive().optional(),
     workerTargetMinsPerWeek: z.coerce.number().int().positive().nullable().optional(),
-    workerCostRate: z.coerce.number().positive().nullable().optional(),
+    workerCostRate: z.coerce.number().positive().max(999999999.99).nullable().optional(),
     workerRoleId: z.coerce.number().int().positive().nullable().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -124,6 +124,25 @@ deliberately **not** implemented autonomously.
    call site catches), so this is defense-in-depth — but whether an escaped
    rejection should crash-and-restart or log-and-continue is a deliberate
    operational policy choice, so no global handler was added autonomously.
+10. **No rate snapshot; effective-dating is unwired from billing** (rate
+    review, MED-HIGH). `resolveHourlyRate` reads the *current* rate sources
+    at invoice/report time — nothing is captured on the `TimeEntry` at entry
+    time, and `rate.js` never calls `rate-schedule.js`, so the shipped
+    effective-dating feature influences **no** invoice line and editing a
+    rate retroactively re-prices a not-yet-invoiced backlog. Fixing it is a
+    product+schema decision: snapshot the resolved rate onto the entry at
+    creation, and/or drive resolution through `rateOnDate(entryDate)`. The
+    arithmetic and precedence themselves were verified sound.
+11. **Archiving a rate source silently re-rates entries to a lower tier**
+    (rate review, MED). Soft-deleting a referenced rate source (e.g. a
+    per-entry `BillingType` override) makes the `required:false` +
+    `defaultScope` join return `null`, so `resolveHourlyRate` falls through
+    to the next tier instead of flagging — a silent under-bill. The right
+    behavior (fall through vs. flag `unresolvedRate` vs. block the archive)
+    is a billing-policy choice, so it was not changed autonomously. (Minor,
+    same review: `btHourlyRate` is a `DOUBLE` while every other rate column
+    is `NUMERIC(14,2)` — a consistency migration; and `$0` is only settable
+    at the BillingType tier — a validation-symmetry choice.)
 
 ---
 

--- a/tests/unit/rate-bounds.test.js
+++ b/tests/unit/rate-bounds.test.js
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Rate / money fields are NUMERIC(14,2) columns. Without an upper bound a
+// caller could submit an out-of-range value that parses fine but overflows
+// the column → a 500 at write time. These pin the schema-level `.max()` so
+// an absurd rate returns a clean 400 instead. (Rate-resolution review.)
+
+import { describe, test, expect } from 'vitest';
+
+const { createBillingTypeBody } = require('../../app/schemas/billingtype.schema.js');
+const { createRoleBody } = require('../../app/schemas/role.schema.js');
+const { createJobBody } = require('../../app/schemas/job.schema.js');
+
+const OVER = 1e13; // > NUMERIC(14,2) max (999,999,999,999.99)
+
+describe('rate/amount fields reject out-of-range values (NUMERIC(14,2) overflow guard)', () => {
+    test('billingtype btHourlyRate: normal accepted, out-of-range rejected', () => {
+        expect(createBillingTypeBody.safeParse({ btName: 'Std', btHourlyRate: 250.5 }).success).toBe(true);
+        expect(createBillingTypeBody.safeParse({ btName: 'Std', btHourlyRate: 0 }).success).toBe(true); // $0 pro-bono honored
+        expect(createBillingTypeBody.safeParse({ btName: 'Std', btHourlyRate: OVER }).success).toBe(false);
+    });
+
+    test('role roleRate: out-of-range rejected', () => {
+        expect(createRoleBody.safeParse({ roleName: 'Eng', roleRate: 200 }).success).toBe(true);
+        expect(createRoleBody.safeParse({ roleName: 'Eng', roleRate: OVER }).success).toBe(false);
+    });
+
+    test('job jobFlatRate + jobBudgetAmount: out-of-range rejected', () => {
+        expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobFlatRate: 5000 }).success).toBe(true);
+        expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobFlatRate: OVER }).success).toBe(false);
+        expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobBudgetAmount: OVER }).success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

The rate-resolution review verified the **money-input logic sound** — precedence deterministic + documented, explicit `$0` honored (`!= null`, not `!rate`), `rate × time` exact via `money.js` on **exact minutes** (not the display-hours payroll bug), effective-dating boundaries inclusive + TZ-stable, every tier company-scoped, negatives blocked. One clean fix + two design-gated findings recorded.

## Fixed — out-of-range rate → 400, not 500

The rate/money fields (`btHourlyRate`, `jobFlatRate`, `jobBudgetAmount`, `taskRate`, `custDefaultRate`, `roleRate`, `rschRate`, `workerCostRate`) are `NUMERIC(14,2)` but their zod schemas had **no `.max()`**, so a value above the column limit (e.g. `1e13`) parsed fine and **overflowed to a 500** at write. Each now caps at `999,999,999.99` (well under the 12-digit limit, far above any real rate) → a clean **400**.

## Recorded as design decisions (not changed autonomously)

Logged in `docs/SECURITY-REVIEW-LOG.md` (items 10–11) — these need a product/schema call:

- **No rate snapshot; effective-dating unwired** (MED-HIGH). `resolveHourlyRate` reads the *current* rate sources at invoice/report time; nothing is captured on the `TimeEntry`, and `rate.js` never calls `rate-schedule.js`. So the shipped effective-dating feature influences **no** invoice line, and editing a rate retroactively re-prices a not-yet-invoiced backlog. Fix = snapshot the rate on the entry at creation and/or drive resolution through `rateOnDate(entryDate)`.
- **Archive → silent lower-tier fallthrough** (MED). Soft-deleting a referenced rate source makes the `required:false`/`defaultScope` join return `null`, so resolution silently falls to the next tier (e.g. a `$250` override → `$100` worker default) with no flag. The right behavior (fall through vs. flag vs. block the archive) is a billing policy.
- Minor: `btHourlyRate` is a `DOUBLE` while every other rate column is `NUMERIC(14,2)` (consistency migration); `$0` is only settable at the BillingType tier (validation symmetry).

## Verification

`npm test` → **1715 passing** (+ rate-bounds unit tests: normal accepted incl. `$0` at BillingType, out-of-range rejected); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/