### PR TITLE
fix(expenses): bound expMarkupPct (400 not 500) — expenses/receipts review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Expense markup is bounded (400, not 500).** `expMarkupPct` (a fraction,
+  `0.15` = +15%) had no upper bound, so a value ≥ 100 overflowed its
+  `DECIMAL(6,4)` column → a **500** at write (and a fraction-vs-percent typo
+  like `15` silently billed 1500%). It now caps at `99.9999` → a clean 400
+  (`>100%` markup stays allowed). Found by the expenses/receipts review,
+  which verified the markup math exact via `money.js`, the roll-up
+  billable-only + un-invoiced + transaction-marked (no double-bill), receipt
+  bytes stored in Postgres `bytea` (no disk → no path traversal), uploads
+  triple-bounded (100kb → 10M-char → 5MB), and content-type enum-constrained
+  and served inert (SVG/HTML rejected).
 - **Rate / amount fields reject out-of-range values with a 400.** The rate
   and money fields (`btHourlyRate`, `jobFlatRate`, `jobBudgetAmount`,
   `taskRate`, `custDefaultRate`, `roleRate`, `rschRate`, `workerCostRate`)

--- a/app/schemas/expense.schema.js
+++ b/app/schemas/expense.schema.js
@@ -30,7 +30,10 @@ const createExpenseBody = z.object({
     expCategory: z.string().max(255).optional(),
     expDescription: z.string().max(10000).optional(),
     expBillable: z.boolean().optional(),
-    expMarkupPct: z.coerce.number().min(0).optional(),
+    // A fraction (0.15 = +15%). Cap at the DECIMAL(6,4) column max so an
+    // out-of-range markup returns a clean 400 instead of overflowing to a
+    // 500 at write; >100% (>1.0) is intentionally allowed.
+    expMarkupPct: z.coerce.number().min(0).max(99.9999).optional(),
     expDate: isoDate,
     expAmount: expAmountField,
 }).strict({
@@ -47,7 +50,7 @@ const updateExpenseBody = z.object({
     expCategory: z.string().max(255).nullable().optional(),
     expDescription: z.string().max(10000).nullable().optional(),
     expBillable: z.boolean().optional(),
-    expMarkupPct: z.coerce.number().min(0).nullable().optional(),
+    expMarkupPct: z.coerce.number().min(0).max(99.9999).nullable().optional(),
     expDate: isoDate.optional(),
     expAmount: expAmountField.optional(),
 }).strict({

--- a/tests/unit/rate-bounds.test.js
+++ b/tests/unit/rate-bounds.test.js
@@ -11,6 +11,7 @@ import { describe, test, expect } from 'vitest';
 const { createBillingTypeBody } = require('../../app/schemas/billingtype.schema.js');
 const { createRoleBody } = require('../../app/schemas/role.schema.js');
 const { createJobBody } = require('../../app/schemas/job.schema.js');
+const { createExpenseBody } = require('../../app/schemas/expense.schema.js');
 
 const OVER = 1e13; // > NUMERIC(14,2) max (999,999,999,999.99)
 
@@ -30,5 +31,12 @@ describe('rate/amount fields reject out-of-range values (NUMERIC(14,2) overflow 
         expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobFlatRate: 5000 }).success).toBe(true);
         expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobFlatRate: OVER }).success).toBe(false);
         expect(createJobBody.safeParse({ jobCustId: 1, jobDesc: 'x', jobBudgetAmount: OVER }).success).toBe(false);
+    });
+
+    test('expense expMarkupPct: a fraction incl. >100% accepted; DECIMAL(6,4) overflow rejected', () => {
+        const base = { expDate: '2026-01-01', expAmount: 100 };
+        expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 0.15 }).success).toBe(true); // 15%
+        expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 1.5 }).success).toBe(true);  // 150% intentional
+        expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 100 }).success).toBe(false); // > 99.9999 → 400, not a 500
     });
 });


### PR DESCRIPTION
## Summary

The expenses + receipt-upload review found the subsystem **essentially sound**, with one **LOW** money footgun.

## Fixed — markup out-of-range → 400, not 500

`expMarkupPct` is a fraction (`0.15` = +15%), applied as `cost × (1 + markup)` and stored in a `DECIMAL(6,4)` column (max `99.9999`). Its schema had only `.min(0)` — **no upper bound** — so:
- a markup `≥ 100` overflowed the column → a **500** at write, and
- a fraction-vs-percent typo (sending `15` meaning "15%") silently bills a **1500%** markup (`$100 → $1600`).

Added `.max(99.9999)` to create + update → a clean **400**, while `>100%` (`>1.0`) markup — intentional per the service tests — still validates.

## Verified sound (not changed)

- **Markup math exact** via `money.js` (single cent-round at the boundary, half-away-from-zero; every drift probe matched the exact cent). No leak on non-billable expenses.
- **Roll-up** is billable-only + un-invoiced + tenant-scoped, and stamps `expInvId` inside a transaction so expenses can't double-bill (`expInvId` isn't in any whitelist).
- **Receipts stored in Postgres `bytea`** — no disk write, no path traversal; a `../` filename is only a DB text column, echoed on download after CRLF/quote stripping.
- **Upload triple-bounded**: `express.json` 100kb → schema `.max(10_000_000)` chars before decode → controller 5 MB decoded cap.
- **Content-type** is a strict enum (png/jpeg/gif/webp/pdf) — `svg+xml`/`text/html` rejected (no stored XSS) — served `Content-Disposition: attachment` with `nosniff`.
- **Cross-tenant**: create is FK-scoped to the expense's company; get/download/list/delete are secure-404.

## Verification

`npm test` → **1717 passing** (+ expMarkupPct bound test: `0.15` and `1.5` accepted, `100` rejected); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/