### PR TITLE
fix(dunning): stop over-dunning — honor write-offs + strict overdue boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Dunning no longer over-dunns.** Two bugs in the payment-reminder digest
+  made it email customers wrong "overdue" amounts, both from diverging from
+  the authoritative `invoice-status` engine: (1) a **write-off was ignored**,
+  so a fully-forgiven invoice was dunned for its full balance — the digest
+  now settles `total − collected − writeOff`; and (2) the default
+  (`olderThanDays=0`) run flagged an invoice **due today** as overdue (a #556
+  side effect) — it now requires the reference date to be **strictly** before
+  today (`dueDate < today`, matching `deriveStatus`), while preserving #556's
+  inclusive cutoff for `olderThanDays > 0`. Found by the remaining-services
+  review.
 - **Expense markup is bounded (400, not 500).** `expMarkupPct` (a fraction,
   `0.15` = +15%) had no upper bound, so a value ≥ 100 overflowed its
   `DECIMAL(6,4)` column → a **500** at write (and a fraction-vs-percent typo

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -722,6 +722,9 @@ exports.paymentReminders = async (req, res) => {
             dueDate: inv.invDueDate ? String(inv.invDueDate).slice(0, 10) : null,
             total: inv.invTotal,
             collected: money.sum((inv.payments || []).map((p) => p.cpayAmount)),
+            // A write-off settles the balance like a payment — without it a
+            // forgiven invoice would be dunned for its full amount.
+            writeOff: inv.invWriteOff,
         };
     });
 

--- a/app/services/payment-reminders.js
+++ b/app/services/payment-reminders.js
@@ -5,9 +5,10 @@
 /**
  * payment-reminders.js — build a dunning digest of overdue invoices with
  * a balance outstanding (#10). An invoice counts when its reference date
- * (due date, else invoice date) is at least `olderThanDays` days in the
- * past AND total − collected > 0. Pure: the caller loads invoices with
- * their payment totals and passes `today`; exact money via money.js.
+ * (due date, else invoice date) is strictly before `today` (overdue) AND at
+ * least `olderThanDays` days in the past AND total − collected − writeOff >
+ * 0. Pure: the caller loads invoices with their payment totals and passes
+ * `today`; exact money via money.js.
  */
 
 const money = require('./money.js');
@@ -22,7 +23,7 @@ function minusDays(iso, days) {
 }
 
 /**
- * @param invoices [{ invId, invNumber, custName, date, dueDate, total, collected }]
+ * @param invoices [{ invId, invNumber, custName, date, dueDate, total, collected, writeOff }]
  * @param opts { today: 'YYYY-MM-DD', olderThanDays?: number }
  * @returns { count, totalOutstanding, invoices: [...], subject, text }
  */
@@ -35,14 +36,20 @@ function buildDunningDigest(invoices, opts = {}) {
     for (const inv of invoices || []) {
         const total = inv.total == null ? 0 : Number(inv.total);
         const collected = inv.collected == null ? 0 : Number(inv.collected);
-        const outstanding = money.subtract(total, collected);
+        // A write-off settles a balance the same as a payment (matching
+        // invoice-status.summarize) — otherwise a fully-forgiven invoice is
+        // dunned for its full amount.
+        const writeOff = inv.writeOff == null ? 0 : Number(inv.writeOff);
+        const outstanding = money.subtract(money.subtract(total, collected), writeOff);
         if (outstanding <= 0) continue;
         const refDate = inv.dueDate || inv.date || null;
-        // Flag when the reference date is on OR before the cutoff — i.e. the
-        // invoice is *at least* olderThanDays days in the past, matching the
-        // module contract. An invoice due exactly olderThanDays ago counts
-        // (previously a strict `>= cutoff` skip excluded that boundary day).
-        if (!refDate || !cutoff || refDate > cutoff) continue;
+        // Dun only invoices that are STRICTLY overdue — the reference date is
+        // before today, matching invoice-status.deriveStatus's `dueDate <
+        // today`; an invoice due *today* is current, never dunned, regardless
+        // of olderThanDays. AND it must be at least olderThanDays in the past
+        // (cutoff inclusive, #556) — an invoice due exactly olderThanDays ago
+        // still counts.
+        if (!refDate || !today || !cutoff || refDate >= today || refDate > cutoff) continue;
         rows.push({
             invId: inv.invId,
             invNumber: inv.invNumber || null,

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -27,6 +27,7 @@ plausible-but-unproven finding as not-a-finding.
 | Invoice PDF | Unbounded line count × long unbroken `jobDesc` → pdfkit superlinear word-fit **froze the event loop** (~6 s/req) — one authed request stalled the whole server; descriptions/notes clipped, line count capped | **High** | #568 |
 | Report PDF | Same pdfkit **event-loop-stall DoS** in `report-pdf.js` `drawTable` (uncapped rows × caller-controlled `custName`, ~9 s/req); cells clipped, rows capped | **High** | #569 |
 | Time-lock | Closed-period lock **bypass** via a timezone offset in `teStartedAt` (string bucketed to wall-clock day, `Date` to UTC) | High | #555 |
+| Dunning | Over-dunning: a **write-off** was ignored (forgiven invoice dunned in full) and the default run flagged **due-today** as overdue (a #556 side effect); now settles `total−collected−writeOff` and requires `dueDate < today` | Med | #577 |
 | Billing gate | Invoice rollup ignored approval status → a reviewer-**rejected** entry still billed the client; rollup now excludes `teApprovalStatus = 'rejected'` | Med | #566 |
 | Mailer | `subject` / `from` not CR/LF-checked → **email header injection** once an SMTP transport is wired (defense-in-depth) | Med/latent | #564 |
 | RBAC | `permissionsFor` threw on prototype-named roles (`__proto__`) instead of failing closed to `[]` | Low | #561 |

--- a/tests/unit/payment-reminders.test.js
+++ b/tests/unit/payment-reminders.test.js
@@ -51,6 +51,31 @@ describe('buildDunningDigest (#10)', () => {
             { today: TODAY, olderThanDays: 30 }).count).toBe(0);
     });
 
+    test('a write-off settles the balance — a fully written-off invoice is not dunned', () => {
+        // Write-offs count as settlement (matching invoice-status.summarize);
+        // otherwise a forgiven invoice would be dunned for its full amount.
+        expect(buildDunningDigest([
+            { invId: 1, dueDate: '2026-02-01', total: 1000, collected: 0, writeOff: 1000 },
+        ], { today: TODAY }).count).toBe(0);
+        // Partial write-off reduces the outstanding shown.
+        const d = buildDunningDigest([
+            { invId: 2, dueDate: '2026-02-01', total: 1000, collected: 100, writeOff: 300 },
+        ], { today: TODAY });
+        expect(d.count).toBe(1);
+        expect(d.invoices[0].outstanding).toBe(600); // 1000 − 100 − 300
+    });
+
+    test('an invoice due TODAY is not overdue — not dunned even at olderThanDays 0', () => {
+        // Matches invoice-status.deriveStatus (`dueDate < today`, strict).
+        expect(buildDunningDigest([
+            { invId: 1, dueDate: TODAY, total: 500, collected: 0 },
+        ], { today: TODAY, olderThanDays: 0 }).count).toBe(0);
+        // Due yesterday IS overdue.
+        expect(buildDunningDigest([
+            { invId: 2, dueDate: '2026-02-28', total: 500, collected: 0 },
+        ], { today: TODAY, olderThanDays: 0 }).count).toBe(1);
+    });
+
     test('falls back to invoice date when no due date', () => {
         const d = buildDunningDigest([
             { invId: 1, date: '2026-01-01', total: 200, collected: 0 },


### PR DESCRIPTION
## Summary

The final service sweep (billable-rules, payment-reminders, recurring-schedule, notifier, custom-field) found the last services mostly sound, but surfaced **two real MEDIUM money bugs — both over-dunning**, both from the dunning path diverging from `invoice-status.js` (the authoritative overdue/settlement engine).

## Fixed

**1. Write-offs were ignored.** The dunning controller passed `collected = sum(payments)` only, and the digest computed `outstanding = total − collected` — so a fully written-off invoice (`invWriteOff = invTotal`) was dunned for its **full** balance, even though `invoice-status.summarize` treats a write-off as settlement. Now threads `invWriteOff` through and settles `total − collected − writeOff`.

- Proof: `{total:1000, writeOff:1000, payments:[]}` → digest count **1 → 0**.

**2. Due-today flagged overdue by default.** With the default `olderThanDays=0`, `cutoff = today` and the skip test `refDate > cutoff` **included** invoices due *today* — but `deriveStatus` defines overdue strictly as `dueDate < today`. This was a side effect of #556 flipping the cutoff inclusive. Now also requires `refDate < today` (strictly overdue), which **keeps #556's inclusive boundary** for `olderThanDays > 0` while excluding due-today.

- Proof: due today, default → count **1 → 0**; due exactly 30 days ago with `olderThanDays=30` → still **1** (#556 preserved).

## Verification

`npm test` → **1719 passing** (+ unit tests for write-off settlement and the due-today boundary); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` connectivity check.

## Verified sound (not changed)

- **billable-rules** — deterministic precedence, `=== true` (no `!x` trap), archived rules filtered; and it's advisory-only (not wired to `teBillable`), so it can't silently mis-set stored revenue.
- **notifier** — tenant `text` is JSON-encoded (`{text: String(text)}`); can't inject sibling keys; `channel` is a transport enum, URL is env-fixed (no SSRF).
- **recurring-schedule** — `advanceDate` TZ-stable; the run handler generates no invoice yet, so no double-generation today (flagged: add a guarded cursor update before generation is wired).
- **custom-field** `__proto__` swallow is neutralized at the boundary by zod (`z.record` strips it), so it's a latent, unreachable service-level note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/