### PR TITLE
security(tenant): tenant-check injbInvId on invoice lines + bound cpay/injb amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Tenant-check the invoice FK on invoice lines (cross-tenant injection).**
+  `InvoiceJob` create/bulk tenant-checked only the parent `injbJobId` (the
+  job's company), leaving `injbInvId` — the **invoice** the line attaches to
+  — unchecked. So a company-scoped caller could attach a line, with an
+  arbitrary `injbAmount`, to **another tenant's invoice**: it renders on the
+  victim's customer-facing invoice PDF (leaking the attacker's `jobDesc` +
+  amount) and makes sum-of-lines diverge from the stored total — and because
+  line management scopes via the job, the victim gets a 404 on the injected
+  line and **can't remove it**. New `auth.getCompanyIdByInvId` +
+  `invoiceFkBelongsTo` reject a cross-tenant or missing `injbInvId` with a
+  generic 400 on create **and** bulk (the same secondary-FK class as the
+  inventory fix). Found by the payment-allocation / invoice-line review.
+- **Bound `cpayAmount` / `injbAmount` to stop an AR-report DoS.** Both money
+  fields were `.finite()` but **unbounded**, so a finite-but-huge value
+  (e.g. `1e308`) overflowed `money.toCents()` to `Infinity` and threw
+  uncaught in the invoice / AR-aging / PDF consumers — one poisoned payment
+  500'd the **whole company's aging report** (`summarize` is mapped over
+  every invoice). Both now bound the magnitude (negatives still allowed for
+  reversals / credit lines).
 - **Block SSRF in outbound webhook delivery.** A tenant registers its own
   `whkUrl` and the server POSTs to it, previously with only a **structural**
   URL check — so a webhook (or its `POST /v1/webhook/:id/ping`) pointed at

--- a/app/controllers/invoicejobcontroller.js
+++ b/app/controllers/invoicejobcontroller.js
@@ -50,6 +50,13 @@ exports.create = async (req, res) => {
                 message: "Cannot create an invoice line for a job in a company you do not belong to.",
             });
         }
+        // The secondary FK — the invoice the line attaches to — must ALSO
+        // belong to the caller's company. It was previously unchecked, so a
+        // scoped caller could attach a line (and its amount) to another
+        // tenant's invoice. Generic 400 so it can't probe foreign invoice ids.
+        if (!(await auth.invoiceFkBelongsTo(payload.injbInvId, authCompanyId))) {
+            return res.status(400).json({ message: "Invalid invoice." });
+        }
     }
 
     payload.injbArch = false;
@@ -250,6 +257,7 @@ exports.bulkCreate = makeBulkCreateIndirect({
     archField: 'injbArch',
     bodyKey: 'invoiceJobs',
     createdKey: 'invoiceJobs',
+    secondaryFk: { field: 'injbInvId', belongsTo: auth.invoiceFkBelongsTo },
 });
 
 exports._internals = { IsMaster, GetCompanyId, GetCompanyIdByJobId };

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -339,6 +339,50 @@ async function inventoryFkBelongsTo(invitIdValue, companyId) {
 }
 
 /**
+ * Resolve an invoice id to its owning company id (via invCustId →
+ * Customer.custCompId). Used to tenant-check the SECONDARY `injbInvId` FK on
+ * an InvoiceJob line: the line already scopes on its parent `injbJobId`, but
+ * `injbInvId` (the invoice the line attaches to) was unchecked, so a scoped
+ * caller could attach a line to another tenant's invoice. Returns -1 for
+ * missing/archived (defaultScope filters archived customers).
+ */
+async function getCompanyIdByInvId(invId) {
+    const idStr = invId == null ? '' : String(invId);
+    if (idStr.length === 0 || idStr === '0') return -1;
+    try {
+        const row = await getDb().Invoice.findByPk(invId, {
+            attributes: ['invId'],
+            include: [{
+                model: getDb().Customer,
+                as: 'customer',
+                attributes: ['custCompId'],
+                required: true,
+            }],
+        });
+        if (!row) return -1;
+        const customer = row.customer;
+        if (!customer) return -1;
+        const cid = customer.custCompId;
+        return typeof cid === 'number' && cid > 0 ? cid : -1;
+    } catch (error) {
+        log.error({ err: error }, 'auth.getCompanyIdByInvId query failed');
+        return -1;
+    }
+}
+
+/**
+ * Companion to inventoryFkBelongsTo for the InvoiceJob `injbInvId` FK: for a
+ * scoped caller the referenced invoice must belong to their company. True
+ * when the FK is absent/null or same-company; false for missing/cross-tenant
+ * (one boolean → a single generic 400, no invoice-id enumeration oracle).
+ */
+async function invoiceFkBelongsTo(invIdValue, companyId) {
+    if (invIdValue == null) return true;
+    const owner = await getCompanyIdByInvId(invIdValue);
+    return owner === companyId;
+}
+
+/**
  * Express middleware: ensures the authKey header is present and
  * stashes it on req.authKey. Does NOT validate the key against the
  * database — leaves that to controllers that may have different
@@ -434,6 +478,8 @@ module.exports = {
     getCompanyIdByPohId,
     getCompanyIdByInvitId,
     inventoryFkBelongsTo,
+    getCompanyIdByInvId,
+    invoiceFkBelongsTo,
     requireAuthKey,
     attachAuth,
     requireAuth,

--- a/app/schemas/customerpayment.schema.js
+++ b/app/schemas/customerpayment.schema.js
@@ -18,9 +18,13 @@ const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
 // pathological clients — `z.number()` rejects NaN but allows the
 // infinities by default, and a DOUBLE column will happily store them.
 // Negative values pass — some operators model refunds that way.
+// Bound the magnitude (negatives allowed — a reversal/credit): an unbounded
+// but finite value (e.g. 1e308) survives `.finite()` and later overflows
+// money.toCents() to Infinity, which throws uncaught in the AR/status
+// consumers (a 500 that can take down the whole company's aging report).
 const cpayAmountField = z.coerce.number().finite({
     message: 'cpayAmount must be a finite number.',
-}).refine((n) => n !== 0, {
+}).min(-999999999.99).max(999999999.99).refine((n) => n !== 0, {
     message: 'cpayAmount must not be zero.',
 });
 

--- a/app/schemas/invoicejob.schema.js
+++ b/app/schemas/invoicejob.schema.js
@@ -16,9 +16,13 @@ const intIdParam = z.object({
 // numbers at the boundary. Zero and negative values still pass (a
 // $0 reference line and a credit/discount line are both real
 // accounting uses).
+// Bound the magnitude (negatives allowed — a credit/discount line): an
+// unbounded but finite value (e.g. 1e308) survives `.finite()` and later
+// overflows money.toCents() to Infinity, throwing uncaught in the invoice
+// total / aging / PDF consumers (a 500).
 const injbAmountField = z.coerce.number().finite({
     message: 'injbAmount must be a finite number.',
-});
+}).min(-999999999.99).max(999999999.99);
 
 const createInvoiceJobBody = z.object({
     injbInvId: z.coerce.number().int().positive(),

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -23,6 +23,8 @@ plausible-but-unproven finding as not-a-finding.
 | Subsystem | Finding | Severity | PR |
 |---|---|---|---|
 | Webhooks (SSRF) | Tenant `whkUrl` fetched with only a structural check → **SSRF** to cloud metadata / loopback / private hosts (redirect-following bypass; `ping` status oracle); added a resolved-IP denylist + scheme pin + per-hop redirect re-validation (`ssrf-guard.js`) | **High** | #573 |
+| Invoice lines (cross-tenant) | `injbInvId` unchecked on InvoiceJob create/bulk → a scoped caller attaches a line + amount to **another tenant's invoice** (renders on their PDF; victim can't delete it); added `getCompanyIdByInvId` / `invoiceFkBelongsTo` (secondary-FK class, cf. inventory #571) | **High** | #578 |
+| Payment / line amounts (DoS) | Unbounded `cpayAmount` / `injbAmount` → a finite-huge value overflows `money.toCents()` to **Infinity** → uncaught throw → 500 across a company's whole AR aging; magnitude-bounded (negatives still allowed) | Med | #578 |
 | Idempotency | Unbounded `canonicalJson` → **pre-auth process-crash DoS** (the author's fix `580109b` had never been merged to `main`); depth-bounded → 400, async mount hardened | **High** | #558 |
 | Invoice PDF | Unbounded line count × long unbroken `jobDesc` → pdfkit superlinear word-fit **froze the event loop** (~6 s/req) — one authed request stalled the whole server; descriptions/notes clipped, line count capped | **High** | #568 |
 | Report PDF | Same pdfkit **event-loop-stall DoS** in `report-pdf.js` `drawTable` (uncapped rows × caller-controlled `custName`, ~9 s/req); cells clipped, rows capped | **High** | #569 |

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -202,6 +202,30 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('getCompanyIdByInvId / invoiceFkBelongsTo resolve against the real Invoice→Customer schema', async () => {
+        if (!connected) return;
+        const auth = require('../../app/middleware/auth.js');
+        const company = await db.Company.create({ compName: `${SENTINEL}-invco`, compArch: false });
+        const customer = await db.Customer.create({
+            custCompanyName: `${SENTINEL}-invcust`, custFName: 'In', custLName: 'Voice',
+            custCompId: company.compId, custArch: false,
+        });
+        const invoice = await db.Invoice.create({
+            invCustId: customer.custId, invDate: '2026-02-01', invDueDate: '2026-03-01',
+        });
+        try {
+            // Catches a wrong association alias / column that a stub can't.
+            expect(await auth.getCompanyIdByInvId(invoice.invId)).toBe(company.compId);
+            expect(await auth.invoiceFkBelongsTo(invoice.invId, company.compId)).toBe(true);
+            expect(await auth.invoiceFkBelongsTo(invoice.invId, company.compId + 99999)).toBe(false);
+            expect(await auth.getCompanyIdByInvId(999999999)).toBe(-1);
+        } finally {
+            await invoice.destroy();
+            await customer.destroy();
+            await company.destroy();
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -31,6 +31,7 @@ beforeEach(async () => {
         PurchaseOrderHeader: { findByPk: vi.fn() },
         Job: { findByPk: vi.fn() },
         InventoryItem: { findByPk: vi.fn() },
+        Invoice: { findByPk: vi.fn() },
     };
     auth._setDbForTesting(stub);
 });
@@ -222,6 +223,38 @@ describe('auth.inventoryFkBelongsTo (secondary-FK tenant guard)', () => {
     test('missing / dangling item id is rejected', async () => {
         stub.InventoryItem.findByPk.mockResolvedValueOnce(null);
         expect(await auth.inventoryFkBelongsTo(999999999, 7)).toBe(false);
+    });
+});
+
+describe('auth.getCompanyIdByInvId', () => {
+    test('resolves an invoice to its company via the customer', async () => {
+        stub.Invoice.findByPk.mockResolvedValueOnce({ invId: 1, customer: { custCompId: 8 } });
+        expect(await auth.getCompanyIdByInvId(1)).toBe(8);
+    });
+    test('missing invoice / no customer → -1', async () => {
+        stub.Invoice.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByInvId(1)).toBe(-1);
+        stub.Invoice.findByPk.mockResolvedValueOnce({ invId: 1, customer: null });
+        expect(await auth.getCompanyIdByInvId(1)).toBe(-1);
+    });
+    test('non-positive id → -1 without a query', async () => {
+        expect(await auth.getCompanyIdByInvId(0)).toBe(-1);
+        expect(stub.Invoice.findByPk).not.toHaveBeenCalled();
+    });
+});
+
+describe('auth.invoiceFkBelongsTo (InvoiceJob injbInvId guard)', () => {
+    test('absent FK allowed with no query', async () => {
+        expect(await auth.invoiceFkBelongsTo(null, 8)).toBe(true);
+        expect(stub.Invoice.findByPk).not.toHaveBeenCalled();
+    });
+    test('same-company invoice allowed; cross-tenant / missing rejected', async () => {
+        stub.Invoice.findByPk.mockResolvedValueOnce({ customer: { custCompId: 8 } });
+        expect(await auth.invoiceFkBelongsTo(5, 8)).toBe(true);
+        stub.Invoice.findByPk.mockResolvedValueOnce({ customer: { custCompId: 9 } });
+        expect(await auth.invoiceFkBelongsTo(5, 8)).toBe(false);
+        stub.Invoice.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.invoiceFkBelongsTo(999, 8)).toBe(false);
     });
 });
 

--- a/tests/unit/rate-bounds.test.js
+++ b/tests/unit/rate-bounds.test.js
@@ -12,8 +12,11 @@ const { createBillingTypeBody } = require('../../app/schemas/billingtype.schema.
 const { createRoleBody } = require('../../app/schemas/role.schema.js');
 const { createJobBody } = require('../../app/schemas/job.schema.js');
 const { createExpenseBody } = require('../../app/schemas/expense.schema.js');
+const { createCustomerPaymentBody } = require('../../app/schemas/customerpayment.schema.js');
+const { createInvoiceJobBody } = require('../../app/schemas/invoicejob.schema.js');
 
 const OVER = 1e13; // > NUMERIC(14,2) max (999,999,999,999.99)
+const HUGE = 1e308; // finite but overflows money.toCents() → Infinity
 
 describe('rate/amount fields reject out-of-range values (NUMERIC(14,2) overflow guard)', () => {
     test('billingtype btHourlyRate: normal accepted, out-of-range rejected', () => {
@@ -38,5 +41,14 @@ describe('rate/amount fields reject out-of-range values (NUMERIC(14,2) overflow 
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 0.15 }).success).toBe(true); // 15%
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 1.5 }).success).toBe(true);  // 150% intentional
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 100 }).success).toBe(false); // > 99.9999 → 400, not a 500
+    });
+
+    test('cpayAmount / injbAmount: negatives allowed but a money.toCents-overflowing magnitude is rejected', () => {
+        // Negatives are legitimate (payment reversal / credit line) and stay valid.
+        expect(createCustomerPaymentBody.safeParse({ cpayCustId: 1, cpayDate: '2026-01-01', cpayAmount: -250 }).success).toBe(true);
+        expect(createInvoiceJobBody.safeParse({ injbInvId: 1, injbJobId: 1, injbAmount: -100 }).success).toBe(true);
+        // A finite-but-huge value (would overflow money.sum → 500) is rejected with a 400.
+        expect(createCustomerPaymentBody.safeParse({ cpayCustId: 1, cpayDate: '2026-01-01', cpayAmount: HUGE }).success).toBe(false);
+        expect(createInvoiceJobBody.safeParse({ injbInvId: 1, injbJobId: 1, injbAmount: HUGE }).success).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

The payment-allocation / invoice-line review found CustomerPayment allocation **sound** (company-scoped before the invoice check, no TOCTOU, over-allocation handled) but surfaced two real bugs on the invoice-line path.

## HIGH — cross-tenant invoice-line injection

`InvoiceJob` create + bulk tenant-checked only the parent `injbJobId` (the job's company); the second FK **`injbInvId`** — the invoice the line attaches to — was accepted verbatim. So a company-scoped caller can attach a line, with an arbitrary `injbAmount`, to **another tenant's invoice**:

- it renders on the victim's **customer-facing invoice PDF** (leaking the attacker's `jobDesc` + amount) and makes sum-of-lines diverge from the stored `invSubtotal`;
- because `getById`/`update`/`remove` scope via `injbJobId`, the **victim gets a 404 on the injected line and can't delete it** — only the attacker can.

This is the exact **secondary-FK class already fixed for inventory (#571)** — the `_bulk-helpers` `secondaryFk` option just wasn't wired for `injbInvId`.

**Fix:** `auth.getCompanyIdByInvId` (invoice → `invCustId` → `Customer.custCompId`) + `invoiceFkBelongsTo`; create and bulk now reject a cross-tenant/missing `injbInvId` with a generic **400** ("Invalid invoice", no enumeration oracle). Master keys skip it, per the existing pattern.

## MEDIUM — unbounded amounts → AR-report DoS

`cpayAmount` / `injbAmount` were `.finite()` but **unbounded**, so `1e308` stored fine but overflowed `money.toCents()` to `Infinity`, throwing uncaught in the invoice / AR-aging / PDF consumers. Since AR aging maps `summarize()` over **every** company invoice, one poisoned allocated payment **500s the whole company's aging report**. Fix: bound both to `[-999999999.99, 999999999.99]` (negatives stay valid — reversal / credit line).

## Verification

- Unit: `getCompanyIdByInvId` + `invoiceFkBelongsTo` (same-co / cross-tenant / missing) via `_setDbForTesting`; amount bounds (negative accepted, `1e308` rejected).
- Integration (real PG): resolver proven against the actual `Invoice→Customer` association (catches a wrong alias/column a stub can't).
- `npm test` → **1725 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

## Flagged, not fixed

`cpayAmount`/`injbAmount` are `DOUBLE` columns while `Invoice` totals are `DECIMAL(14,2)` — the same storage-consistency migration already noted for `btHourlyRate` (review-log item 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/