### PR TITLE
fix(bounds): cap expAmount + phaseBudgetAmount — completes the FK-audit follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`expAmount` and `phaseBudgetAmount` reject out-of-range values (400, not
+  500).** The last two money fields lacking an upper bound — `expAmount`
+  (overflows `money.toCents()` → `Infinity` → a 500 in the expense billing
+  view / rollup) and `phaseBudgetAmount` (DB overflow) — now cap at
+  `999,999,999.99`, completing `.max()` coverage across **every** money
+  field. Found by the systematic FK audit (the remaining unchecked FK, a
+  BillableRule match-id, is inert — never dereferenced, company-scoped
+  evaluation — so left as-is).
 - **Dunning no longer over-dunns.** Two bugs in the payment-reminder digest
   made it email customers wrong "overdue" amounts, both from diverging from
   the authoritative `invoice-status` engine: (1) a **write-off was ignored**,

--- a/app/schemas/expense.schema.js
+++ b/app/schemas/expense.schema.js
@@ -15,7 +15,11 @@ const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
 // A finite, positive amount. Zero/negative expenses are operator error.
 const expAmountField = z.coerce.number().finite({
     message: 'expAmount must be a finite number.',
-}).positive({ message: 'expAmount must be greater than zero.' });
+}).positive({ message: 'expAmount must be greater than zero.' })
+    // Bound the magnitude so an out-of-range value returns a clean 400
+    // instead of overflowing money.toCents() to Infinity in the billing view
+    // / rollup (a 500), matching every other money field.
+    .max(999999999.99);
 
 /**
  * POST /v1/expense body. expCompId is optional for non-master keys

--- a/app/schemas/phase.schema.js
+++ b/app/schemas/phase.schema.js
@@ -17,7 +17,7 @@ const createPhaseBody = z.object({
     phaseName: z.string().min(1).max(255),
     phaseStartDate: isoDate.optional(),
     phaseEndDate: isoDate.optional(),
-    phaseBudgetAmount: z.coerce.number().positive().optional(),
+    phaseBudgetAmount: z.coerce.number().positive().max(999999999.99).optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: phaseJobId, phaseName, phaseStartDate, phaseEndDate, phaseBudgetAmount.',
 }).refine(
@@ -30,7 +30,7 @@ const updatePhaseBody = z.object({
     phaseName: z.string().min(1).max(255).optional(),
     phaseStartDate: isoDate.nullable().optional(),
     phaseEndDate: isoDate.nullable().optional(),
-    phaseBudgetAmount: z.coerce.number().positive().nullable().optional(),
+    phaseBudgetAmount: z.coerce.number().positive().max(999999999.99).nullable().optional(),
 }).strict({
     message: 'Unexpected field in body. Whitelist: phaseName, phaseStartDate, phaseEndDate, phaseBudgetAmount.',
 }).refine(

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -81,6 +81,14 @@ plausible-but-unproven finding as not-a-finding.
   a Postgres `bytea` (no disk write → no path traversal); the upload is
   triple-bounded (100kb body → 10M-char schema → 5MB decoded); content-type
   is an enum served as an `attachment` with `nosniff` (SVG/HTML rejected).
+- **Cross-tenant FK scoping (systematic audit)** — every controller's
+  create/update/bulk FKs were audited: each foreign key is either the
+  scoping parent or validated against the caller's company (or same-customer,
+  for payment→invoice). The three secondary-FK gaps found are fixed
+  (inventory #571, invoice-line #578, worker rate-source #579) plus the
+  CustomerPayment-bulk same-customer gap (#580); the one remaining unchecked
+  FK — a BillableRule match-id — is **inert** (never dereferenced; rules are
+  evaluated company-scoped), and every money field now carries a `.max()`.
 - **Reporting aggregations** — profitability / utilization / budget / hours /
   unbilled / timesheet / targets / capacity / revenue all sum through
   `money.js`, derive hours from **exact minutes** (never pre-rounded display

--- a/tests/unit/rate-bounds.test.js
+++ b/tests/unit/rate-bounds.test.js
@@ -14,6 +14,7 @@ const { createJobBody } = require('../../app/schemas/job.schema.js');
 const { createExpenseBody } = require('../../app/schemas/expense.schema.js');
 const { createCustomerPaymentBody } = require('../../app/schemas/customerpayment.schema.js');
 const { createInvoiceJobBody } = require('../../app/schemas/invoicejob.schema.js');
+const { createPhaseBody } = require('../../app/schemas/phase.schema.js');
 
 const OVER = 1e13; // > NUMERIC(14,2) max (999,999,999,999.99)
 const HUGE = 1e308; // finite but overflows money.toCents() → Infinity
@@ -41,6 +42,13 @@ describe('rate/amount fields reject out-of-range values (NUMERIC(14,2) overflow 
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 0.15 }).success).toBe(true); // 15%
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 1.5 }).success).toBe(true);  // 150% intentional
         expect(createExpenseBody.safeParse({ ...base, expMarkupPct: 100 }).success).toBe(false); // > 99.9999 → 400, not a 500
+    });
+
+    test('expAmount / phaseBudgetAmount: out-of-range rejected (money.toCents overflow guard)', () => {
+        expect(createExpenseBody.safeParse({ expDate: '2026-01-01', expAmount: 250.5 }).success).toBe(true);
+        expect(createExpenseBody.safeParse({ expDate: '2026-01-01', expAmount: OVER }).success).toBe(false);
+        expect(createPhaseBody.safeParse({ phaseJobId: 1, phaseName: 'P', phaseBudgetAmount: 5000 }).success).toBe(true);
+        expect(createPhaseBody.safeParse({ phaseJobId: 1, phaseName: 'P', phaseBudgetAmount: OVER }).success).toBe(false);
     });
 
     test('cpayAmount / injbAmount: negatives allowed but a money.toCents-overflowing magnitude is rejected', () => {


### PR DESCRIPTION
## Summary

Closes the systematic cross-tenant FK audit's remaining LOW findings.

- **`expAmount`** and **`phaseBudgetAmount`** were the only money fields still without a `.max()`. A finite-but-huge `expAmount` (`1e308`) overflows `money.toCents()` → `Infinity` in the expense billing view / rollup (a **500**); `phaseBudgetAmount` overflows its `DECIMAL(14,2)` column at write. Both now cap at `999,999,999.99` → a clean **400**, matching every other money field.
- The audit's **last unchecked FK** — BillableRule `bruMatchJobId`/`bruMatchTaskId` — is left as-is: it's **never dereferenced** (`billable-rules.js` does pure integer equality) and rules are evaluated scoped to the caller's own company, so a foreign/dangling id simply never matches. Inert, not exploitable — recorded in the review log.

**This closes the FK audit**: every controller's FKs are scoped or fixed, and every money field is bounded.

## Verification

`npm test` → **1734 passing** (+ `expAmount`/`phaseBudgetAmount` bound cases); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/