### PR TITLE
docs(security-review-log): record the clean route-guarding audit (225 routes)

### DIFF
--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -81,6 +81,19 @@ plausible-but-unproven finding as not-a-finding.
   a Postgres `bytea` (no disk write → no path traversal); the upload is
   triple-bounded (100kb body → 10M-char schema → 5MB decoded); content-type
   is an enum served as an `attachment` with `nosniff` (SVG/HTML rejected).
+- **Route guarding (systematic audit)** — all **225** route registrations in
+  `router.js` audited: `attachAuth` is on `/v1` (and nothing is registered
+  outside `router.js`), every scoped handler self-enforces the `authKey` +
+  company scope (inline or via `findScoped` / `resolveCompany` / the bulk
+  factories), every `:id` route carries `v.params(intIdParam)` (no NaN id
+  reaches `findByPk`), every create/update/bulk a `.strict()` `v.body` (or
+  reads no body), and every list/report a `v.query`. The deliberately-public
+  routes (health / metrics / openapi, `whoami`, `login` / password-reset /
+  invite-accept / signed share-link read) leak nothing sensitive
+  (`safeUser` / `safeView` projections, anti-enumeration 401/200). No
+  unauthenticated path, missing/wrong validation, or wrong-schema wiring.
+  (`user.setRole` being company-scoped rather than master-only ties to the
+  RBAC-enforcement decision, open item 1.)
 - **Cross-tenant FK scoping (systematic audit)** — every controller's
   create/update/bulk FKs were audited: each foreign key is either the
   scoping parent or validated against the caller's company (or same-customer,


### PR DESCRIPTION
## Summary

Records a systematic audit of **every route registration** in `router.js` (225 routes) — after the FK audit found real cross-tenant bugs, the same rigor was applied to route guarding. **Result: airtight, no security gaps.**

Verified (not assumed):
- `attachAuth` on `/v1`; nothing registered outside `router.js` (nothing bypasses the auth layer).
- Every scoped handler self-enforces the `authKey` + company scope (inline, or via `findScoped` / `resolveCompany` / the bulk factories).
- Every `:id` route carries `v.params(intIdParam)` → no NaN/uncoerced id reaches `findByPk`.
- Every create/update/bulk carries a `.strict()` `v.body` (or provably reads no body); every list/report/search/export a `v.query`.
- The intended-public routes (health/metrics/openapi, `whoami`, `login` / password-reset / invite-accept / signed share-link read) leak nothing sensitive — `safeUser`/`safeView` projections exclude the key/secret/password hashes; anti-enumeration 401/200.

No unauthenticated path, missing/wrong validation, NaN-id, or wrong-schema wiring.

The one product observation — `user.setRole` is company-scoped, not master-only — ties to the already-open **RBAC-enforcement decision** (review-log item 1). The rest are cosmetic (403-vs-404 deny code on list vs single-entity).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/