### PR TITLE
feat(rbac): extend JWT-actor RBAC to the read/update/remove user endpoints (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **RBAC on the full user-management surface (#448).** Extends the initial
+  role-write enforcement to the remaining user endpoints for a signed-in
+  (JWT) actor: `GET /v1/user/:id` + `bycompany` require `user:read` and are
+  scoped to the actor's own company (secure-404 / 403); `PATCH /v1/user/:id`
+  allows a user to edit **its own** profile but requires `user:write` to edit
+  another; `DELETE /v1/user/:id` requires `user:write`. The API-key path is
+  unchanged (full authority).
 - **RBAC enforcement for signed-in users (#448).** `rbac.canAssignRole` was
   defined but had no call sites. A new `attachUser` middleware resolves the
   Bearer-JWT sign-in path into `req.user = { userId, userCompId, userRole }`

--- a/app/controllers/usercontroller.js
+++ b/app/controllers/usercontroller.js
@@ -158,9 +158,8 @@ exports.create = async (req, res) => {
 
 /** GET /v1/user/:id — fetch one (metadata only). Secure-404 scoped. */
 exports.getById = async (req, res) => {
-    const authKey = req.get('authKey');
-    if (!authKey) {
-        return res.status(403).json({ message: "Authorization key not sent." });
+    if (!req.user && !req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization required." });
     }
 
     let user;
@@ -173,11 +172,18 @@ exports.getById = async (req, res) => {
     if (!user || user.userArch) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await MasterFromReq(req, authKey);
-    if (!isMaster) {
-        const companyId = await CompanyIdFromReq(req, authKey);
-        if (companyId === -1 || user.userCompId !== companyId) {
+    if (req.user) {
+        // Signed-in user: needs read permission + own company (secure-404).
+        if (!rbac.canReadUsers(req.user.userRole) || user.userCompId !== req.user.userCompId) {
             return res.status(404).json({ message: "Not found." });
+        }
+    } else {
+        const isMaster = await MasterFromReq(req, req.get('authKey'));
+        if (!isMaster) {
+            const companyId = await CompanyIdFromReq(req, req.get('authKey'));
+            if (companyId === -1 || user.userCompId !== companyId) {
+                return res.status(404).json({ message: "Not found." });
+            }
         }
     }
     return res.status(200).json({ message: "Found.", user });
@@ -185,9 +191,8 @@ exports.getById = async (req, res) => {
 
 /** GET /v1/user/bycompany/:id — list a company's users (metadata only, paginated). */
 exports.listByCompany = async (req, res) => {
-    const authKey = req.get('authKey');
-    if (!authKey) {
-        return res.status(403).json({ message: "Authorization key not sent." });
+    if (!req.user && !req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization required." });
     }
 
     const targetCompanyId = Number(req.params.id);
@@ -195,11 +200,18 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await MasterFromReq(req, authKey);
-    if (!isMaster) {
-        const companyId = await CompanyIdFromReq(req, authKey);
-        if (companyId === -1 || companyId !== targetCompanyId) {
+    if (req.user) {
+        // Signed-in user: needs read permission + can only list its OWN company.
+        if (!rbac.canReadUsers(req.user.userRole) || targetCompanyId !== req.user.userCompId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    } else {
+        const isMaster = await MasterFromReq(req, req.get('authKey'));
+        if (!isMaster) {
+            const companyId = await CompanyIdFromReq(req, req.get('authKey'));
+            if (companyId === -1 || companyId !== targetCompanyId) {
+                return res.status(403).json({ message: "Invalid Authorization Key." });
+            }
         }
     }
 
@@ -227,11 +239,14 @@ exports.listByCompany = async (req, res) => {
 
 /** PATCH /v1/user/:id — update email / name / password. userCompId not settable here. */
 exports.update = async (req, res) => {
-    if (!req.get('authKey')) {
-        return res.status(403).json({ message: "Authorization key not sent." });
-    }
     const user = await findScoped(req, res);
     if (!user) return undefined;
+
+    // A signed-in user may edit its OWN profile; editing another user needs
+    // the manage-users permission. (An API key keeps full authority.)
+    if (req.user && user.userId !== req.user.userId && !rbac.canManageUsers(req.user.userRole)) {
+        return res.status(403).json({ message: "Insufficient role to update another user." });
+    }
 
     const body = req.body || {};
     const updates = {};
@@ -253,11 +268,12 @@ exports.update = async (req, res) => {
 
 /** DELETE /v1/user/:id — soft-delete (sets userArch = true). */
 exports.remove = async (req, res) => {
-    if (!req.get('authKey')) {
-        return res.status(403).json({ message: "Authorization key not sent." });
-    }
     const user = await findScoped(req, res);
     if (!user) return undefined;
+
+    if (req.user && !rbac.canManageUsers(req.user.userRole)) {
+        return res.status(403).json({ message: "Insufficient role to remove users." });
+    }
 
     try {
         await user.update({ userArch: true });
@@ -298,11 +314,12 @@ exports.setRole = async (req, res) => {
 
 /** GET /v1/user/:id/permissions — a user's role + effective permissions (#448). */
 exports.permissions = async (req, res) => {
-    if (!req.get('authKey')) {
-        return res.status(403).json({ message: "Authorization key not sent." });
-    }
     const user = await findScoped(req, res);
     if (!user) return undefined;
+
+    if (req.user && !rbac.canReadUsers(req.user.userRole)) {
+        return res.status(404).json({ message: "Not found." });
+    }
 
     return res.status(200).json({
         message: "Found.",

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -125,9 +125,10 @@ deliberately **not** implemented autonomously.
    out-ranks you), scoped to the actor's own company (secure-404). The
    **API-key path is unchanged** — a company/master key remains the tenant's
    full-authority credential (that's the deliberate model; a signed-in user
-   is the constrained actor). Follow-up (optional): extend JWT-actor auth to
-   the user read/update/remove endpoints for full self-service, and gate the
-   approval action the same way (open item 8).
+   is the constrained actor). The full user surface is now JWT-actor aware
+   (#584): read (`user:read`), update (self-edit or `user:write`), remove
+   (`user:write`), and `listByCompany` (own company). Remaining follow-up:
+   gate the approval action the same way (open item 8).
 2. **Idempotency concurrent double-execution.** The cache row is written
    *after* the handler, so two simultaneous same-key requests both execute
    the side effect (a double-charge risk); sequential retries are correctly

--- a/tests/api/user.test.js
+++ b/tests/api/user.test.js
@@ -110,3 +110,60 @@ describe('setRole — RBAC enforced for a JWT actor', () => {
         expect((await patchRole('manager')).status).toBe(404);
     });
 });
+
+// JWT-actor RBAC on the read / update / remove user endpoints.
+describe('user read/update/remove — RBAC for a JWT actor', () => {
+    const jwt = require('../../app/services/jwt.js');
+    const db = require('../../app/config/db.config.js');
+    const SECRET = 'test-secret';
+    const ACTOR = 100; const TARGET = 200;
+
+    function actorToken() {
+        process.env.JWT_SECRET = SECRET;
+        return jwt.sign({ sub: ACTOR, userCompId: 1 }, SECRET, 3600);
+    }
+    function row(id, comp, role) {
+        return { userId: id, userCompId: comp, userRole: role, userArch: false, userEmail: 'x@y.co', userName: 'X', update: vi.fn().mockResolvedValue(undefined) };
+    }
+    // targetComp/targetId let a test point the target at another company or at
+    // the actor itself (self-edit). The ACTOR row always carries update().
+    function mockUsers(actorRole, targetComp = 1, targetId = TARGET) {
+        db.User.findByPk = vi.fn().mockImplementation((id) => {
+            if (Number(id) === ACTOR) return Promise.resolve(row(ACTOR, 1, actorRole));
+            if (Number(id) === targetId) return Promise.resolve(row(targetId, targetComp, 'member'));
+            return Promise.resolve(null);
+        });
+    }
+    afterEach(() => { delete process.env.JWT_SECRET; });
+    const bearer = () => ({ authorization: `Bearer ${actorToken()}` });
+
+    test('GET a user in own company → 200; cross-company → secure-404', async () => {
+        mockUsers('member');
+        expect((await request(app).get(`/v1/user/${TARGET}`).set(bearer())).status).toBe(200);
+        mockUsers('member', 2);
+        expect((await request(app).get(`/v1/user/${TARGET}`).set(bearer())).status).toBe(404);
+    });
+
+    test('listByCompany: own company 200, other company 403', async () => {
+        mockUsers('member');
+        db.User.findAndCountAll = vi.fn().mockResolvedValue({ count: 0, rows: [] });
+        expect((await request(app).get('/v1/user/bycompany/1').set(bearer())).status).toBe(200);
+        expect((await request(app).get('/v1/user/bycompany/2').set(bearer())).status).toBe(403);
+    });
+
+    test('member updates its OWN profile (200) but not another user (403); admin can (200)', async () => {
+        mockUsers('member', 1, ACTOR); // target == actor (self)
+        expect((await request(app).patch(`/v1/user/${ACTOR}`).set(bearer()).send({ userName: 'New' })).status).toBe(200);
+        mockUsers('member'); // another user, member lacks user:write
+        expect((await request(app).patch(`/v1/user/${TARGET}`).set(bearer()).send({ userName: 'New' })).status).toBe(403);
+        mockUsers('admin');
+        expect((await request(app).patch(`/v1/user/${TARGET}`).set(bearer()).send({ userName: 'New' })).status).toBe(200);
+    });
+
+    test('remove: member 403, admin 200', async () => {
+        mockUsers('member');
+        expect((await request(app).delete(`/v1/user/${TARGET}`).set(bearer())).status).toBe(403);
+        mockUsers('admin');
+        expect((await request(app).delete(`/v1/user/${TARGET}`).set(bearer())).status).toBe(200);
+    });
+});


### PR DESCRIPTION
## Summary

Completes the RBAC enforcement started in #583. The remaining user endpoints now accept a signed-in user (Bearer JWT) as well as an API key, with RBAC enforced for the JWT actor — so a signed-in admin has a **complete RBAC-gated user-management surface** (list/get → set roles / create / invite / update / remove).

- **`GET /v1/user/:id`** + **`GET /v1/user/bycompany/:id`** — require `user:read`, scoped to the actor's own company (secure-404 on a single user, 403 on a foreign-company list).
- **`PATCH /v1/user/:id`** — a user may edit its **own** profile (email/name/password); editing **another** user requires `user:write`.
- **`DELETE /v1/user/:id`** — requires `user:write`.

`findScoped` already accepted a JWT actor (#583); these endpoints just drop the API-key-only top guard and add the per-endpoint permission check. The **API-key path is unchanged** (full authority).

## Verification

`npm test` → **1750 passing** (+ JWT-actor tests: GET own 200 / cross-company 404; `listByCompany` own 200 / other 403; update self 200 / other-as-member 403 / other-as-admin 200; remove member 403 / admin 200); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

Advances review-log item 1 (the remaining follow-up is gating the approval action, item 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/