### PR TITLE
feat(rbac): gate the approval action with a time:approve permission (#440/#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **RBAC on the approval action (#440/#448).** The timesheet-approval endpoint
+  now enforces a new `time:approve` permission (granted to **manager and up**)
+  for a signed-in (JWT) actor, scoped to the actor's own company (secure-404);
+  a `member`/`viewer` gets a 403. The API-key path is unchanged (full
+  authority). Separation-of-duties (blocking self-approval) remains open — it
+  needs a `User`↔`Worker` link the model doesn't have yet (documented in
+  `docs/SECURITY-REVIEW-LOG.md` item 8).
 - **RBAC on the full user-management surface (#448).** Extends the initial
   role-write enforcement to the remaining user endpoints for a signed-in
   (JWT) actor: `GET /v1/user/:id` + `bycompany` require `user:read` and are

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -10,6 +10,7 @@ const { buildCsv } = require('./_csv-escape.js');
 const rate = require('../services/rate.js');
 const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
+const rbac = require('../services/rbac.js');
 const { buildApprovalDigest } = require('../services/approval-reminders.js');
 const { sendMail } = require('../services/mailer.js');
 const { createTimeEntryBody } = require('../schemas/timeentry.schema.js');
@@ -468,9 +469,8 @@ exports.stop = async (req, res) => {
  * Secure-404 scoped; 409 on an illegal transition from the current state.
  */
 exports.approval = async (req, res) => {
-    const authKey = req.get('authKey');
-    if (!authKey) {
-        return res.status(403).json({ message: "Authorization key not sent." });
+    if (!req.user && !req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization required." });
     }
 
     let entry;
@@ -484,11 +484,25 @@ exports.approval = async (req, res) => {
         return res.status(404).json({ message: "Not found." });
     }
 
-    const isMaster = await MasterFromReq(req, authKey);
-    if (!isMaster) {
-        const companyId = await CompanyIdFromReq(req, authKey);
-        if (companyId === -1 || entry.teCompId !== companyId) {
+    if (req.user) {
+        // A signed-in user acts within its own company (secure-404) and needs
+        // the `time:approve` permission (manager+). NOTE: self-approval (the
+        // actor being the worker who logged the time) is NOT yet blocked —
+        // that needs a User↔Worker link the model doesn't have (see item 8).
+        if (entry.teCompId !== req.user.userCompId) {
             return res.status(404).json({ message: "Not found." });
+        }
+        if (!rbac.hasPermission(req.user.userRole, 'time:approve')) {
+            return res.status(403).json({ message: "Insufficient role to approve time entries." });
+        }
+    } else {
+        const authKey = req.get('authKey');
+        const isMaster = await MasterFromReq(req, authKey);
+        if (!isMaster) {
+            const companyId = await CompanyIdFromReq(req, authKey);
+            if (companyId === -1 || entry.teCompId !== companyId) {
+                return res.status(404).json({ message: "Not found." });
+            }
         }
     }
 

--- a/app/services/rbac.js
+++ b/app/services/rbac.js
@@ -18,7 +18,7 @@ const DEFAULT_ROLE = 'member';
 // Cumulative capability tiers.
 const VIEWER = ['invoice:read', 'billing:read', 'time:read', 'report:read', 'user:read'];
 const MEMBER = VIEWER.concat(['time:write']);
-const MANAGER = MEMBER.concat(['invoice:write', 'invoice:send', 'billing:write']);
+const MANAGER = MEMBER.concat(['invoice:write', 'invoice:send', 'billing:write', 'time:approve']);
 const ADMIN = MANAGER.concat(['user:write', 'user:manage-roles']);
 const OWNER = ADMIN.concat(['company:manage']);
 

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -158,11 +158,16 @@ deliberately **not** implemented autonomously.
    *requires* approval before billing has no such gate. Requiring
    `approved` would break the default (approval-less) flow, so which
    policy applies is a per-tenant product decision.
-8. **Approver authorization / separation of duties.** The approval action
-   requires only a valid company key (no role check, no "not the logged-time
-   worker" check) — the same root cause as item 1 (RBAC is not enforced;
-   API keys resolve to a company, not a user). Self-approval is currently
-   unpreventable.
+8. **Approver authorization — role check WIRED (#585); self-approval still
+   open.** The approval action now enforces a `time:approve` permission
+   (granted to **manager and up**) for a signed-in-user (JWT) actor, scoped
+   to the actor's own company (secure-404) — using the same `attachUser`
+   mechanism as item 1. The API-key path is unchanged (full authority). What
+   remains: **separation of duties** — an actor should not approve their own
+   logged time — which needs a **User↔Worker link** the model lacks today
+   (JWT actors are `User`s; time entries reference `Worker`s). Decide whether
+   to add that link (e.g. `worker.userId`) before self-approval can be
+   blocked; and confirm `manager+` is the right approve tier.
 9. **Process-level `unhandledRejection` net.** There is no global
    `unhandledRejection` / `uncaughtException` handler, so an async rejection
    that escaped a handler would crash the process on Node ≥ 15. Both the

--- a/tests/api/timeentry-approval.test.js
+++ b/tests/api/timeentry-approval.test.js
@@ -3,7 +3,7 @@
 //
 // HTTP contract tests for the approval endpoint (#440) — auth + schema.
 
-import { describe, test, expect, vi, beforeAll } from 'vitest';
+import { describe, test, expect, vi, beforeAll, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
@@ -34,5 +34,35 @@ describe('Timesheet approval contract', () => {
     });
     test('POST /v1/timeentry/:id/approval 400 on a missing action (schema)', async () => {
         expect((await request(app).post('/v1/timeentry/1/approval').set('authKey', 'k').send({})).status).toBe(400);
+    });
+});
+
+// RBAC on the approval action for a signed-in USER (Bearer JWT): the actor
+// needs the `time:approve` permission (manager+) and its own company.
+describe('approval — RBAC for a JWT actor (time:approve)', () => {
+    const jwt = require('../../app/services/jwt.js');
+    const db = require('../../app/config/db.config.js');
+    const SECRET = 'test-secret';
+    const ACTOR = 100; const ENTRY = 7;
+
+    function token() { process.env.JWT_SECRET = SECRET; return jwt.sign({ sub: ACTOR, userCompId: 1 }, SECRET, 3600); }
+    function mock(actorRole, entryComp = 1, status = 'submitted') {
+        db.User = { findByPk: vi.fn().mockResolvedValue({ userId: ACTOR, userCompId: 1, userRole: actorRole, userArch: false }) };
+        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: entryComp, teArch: false, teApprovalStatus: status, update: vi.fn().mockResolvedValue(undefined) });
+    }
+    afterEach(() => { delete process.env.JWT_SECRET; });
+    const post = () => request(app).post(`/v1/timeentry/${ENTRY}/approval`).set('authorization', `Bearer ${token()}`).send({ action: 'approve' });
+
+    test('a manager can approve a submitted entry → 200', async () => {
+        mock('manager');
+        expect((await post()).status).toBe(200);
+    });
+    test('a member (no time:approve) → 403', async () => {
+        mock('member');
+        expect((await post()).status).toBe(403);
+    });
+    test('a cross-company entry → secure-404', async () => {
+        mock('manager', 2); // entry in company 2, actor in company 1
+        expect((await post()).status).toBe(404);
     });
 });

--- a/tests/unit/rbac.test.js
+++ b/tests/unit/rbac.test.js
@@ -79,6 +79,14 @@ describe('rbac (#448)', () => {
         expect(canChangeRole('manager', 'member', 'viewer')).toBe(false);
     });
 
+    test('time:approve is granted to manager and up, not to member/viewer', () => {
+        expect(hasPermission('viewer', 'time:approve')).toBe(false);
+        expect(hasPermission('member', 'time:approve')).toBe(false);
+        expect(hasPermission('manager', 'time:approve')).toBe(true);
+        expect(hasPermission('admin', 'time:approve')).toBe(true);
+        expect(hasPermission('owner', 'time:approve')).toBe(true);
+    });
+
     test('canManageUsers / canReadUsers map to user:write / user:read', () => {
         expect(canManageUsers('admin')).toBe(true);
         expect(canManageUsers('owner')).toBe(true);


### PR DESCRIPTION
## Summary

Continues the RBAC enforcement to the **approval action** (review-log open item 8). The timesheet-approval endpoint (`POST /v1/timeentry/:id/approval`) previously required only a company key with no role check; it now enforces RBAC for a signed-in user (Bearer JWT) via the `attachUser` mechanism from #583.

- New permission **`time:approve`**, granted to the **manager tier and up** (managers approve their team's billable time). A `member`/`viewer` gets **403**.
- The JWT actor is scoped to its own company (**secure-404** on a cross-company entry).
- The **API-key path is unchanged** (a company/master key keeps full authority).

## Deliberately still open (documented)

**Separation of duties** — an actor should not approve their *own* logged time — is **not** yet enforced: it needs a `User`↔`Worker` link the model lacks (JWT actors are `User`s; time entries reference `Worker`s). Item 8 in the review log records the decision (add e.g. `worker.userId`?) and notes `manager+` as my recommended, adjustable approve tier.

## Verification

`npm test` → **1754 passing** (+ rbac: `time:approve` on manager+ only; approval enforcement: manager approves 200, member 403, cross-company secure-404); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

Advances review-log item 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/