### PR TITLE
feat(rbac): block self-approval via a Worker→User link (#440/#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel), and `attachAuth` maps them to **503 Service Unavailable**.
 
 ### Security
+- **Separation of duties on approval — no self-approval (#440/#448).** Adds a
+  nullable `workerUserId` link (Worker → User; tenant-checked on
+  create/update/bulk like every other FK) so the approval action can reject a
+  signed-in user approving their **own** logged time (the entry's worker
+  resolves to the acting user) with a 403. Completes the approver-authorization
+  item — the role check (`time:approve`, manager+) plus separation of duties.
+  API-key path unchanged.
 - **RBAC on the approval action (#440/#448).** The timesheet-approval endpoint
   now enforces a new `time:approve` permission (granted to **manager and up**)
   for a signed-in (JWT) actor, scoped to the actor's own company (secure-404);

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -486,14 +486,26 @@ exports.approval = async (req, res) => {
 
     if (req.user) {
         // A signed-in user acts within its own company (secure-404) and needs
-        // the `time:approve` permission (manager+). NOTE: self-approval (the
-        // actor being the worker who logged the time) is NOT yet blocked —
-        // that needs a User↔Worker link the model doesn't have (see item 8).
+        // the `time:approve` permission (manager+).
         if (entry.teCompId !== req.user.userCompId) {
             return res.status(404).json({ message: "Not found." });
         }
         if (!rbac.hasPermission(req.user.userRole, 'time:approve')) {
             return res.status(403).json({ message: "Insufficient role to approve time entries." });
+        }
+        // Separation of duties: a user may not approve their OWN logged time
+        // (the worker the entry belongs to is linked to this user, #448).
+        if (entry.teWorkerId != null) {
+            let worker;
+            try {
+                worker = await db.Worker.findByPk(entry.teWorkerId, { attributes: ['workerUserId'] });
+            } catch (error) {
+                log.error({ err: error }, 'approval: Worker lookup failed');
+                return res.status(500).json({ message: "Error!" });
+            }
+            if (worker && worker.workerUserId === req.user.userId) {
+                return res.status(403).json({ message: "You cannot approve your own time entry." });
+            }
         }
     } else {
         const authKey = req.get('authKey');

--- a/app/controllers/workercontroller.js
+++ b/app/controllers/workercontroller.js
@@ -19,10 +19,10 @@ const CompanyIdFromReq = auth.companyIdFromReq;
 
 const ALLOWED_FIELDS_CREATE = [
     'workerFName', 'workerLName', 'workerTitle',
-    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId',
+    'workerDefaultBillType', 'workerCompId', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId', 'workerUserId',
 ];
 const ALLOWED_FIELDS_UPDATE = [
-    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId',
+    'workerFName', 'workerLName', 'workerTitle', 'workerDefaultBillType', 'workerTargetMinsPerWeek', 'workerCostRate', 'workerRoleId', 'workerUserId',
 ];
 
 /**
@@ -78,6 +78,9 @@ exports.create = async (req, res) => {
         }
         if (!(await auth.roleFkBelongsTo(payload.workerRoleId, authKeyCompanyId))) {
             return res.status(400).json({ message: "Invalid role." });
+        }
+        if (!(await auth.userFkBelongsTo(payload.workerUserId, authKeyCompanyId))) {
+            return res.status(400).json({ message: "Invalid user." });
         }
     } else {
         if (payload.workerCompId === undefined || Number(payload.workerCompId) <= 0) {
@@ -244,6 +247,10 @@ exports.update = async (req, res) => {
             && !(await auth.roleFkBelongsTo(updates.workerRoleId, companyId))) {
             return res.status(400).json({ message: "Invalid role." });
         }
+        if (updates.workerUserId !== undefined
+            && !(await auth.userFkBelongsTo(updates.workerUserId, companyId))) {
+            return res.status(400).json({ message: "Invalid user." });
+        }
     }
 
     try {
@@ -306,6 +313,7 @@ exports.bulkCreate = makeBulkCreate({
     secondaryFk: [
         { field: 'workerDefaultBillType', belongsTo: auth.billingTypeFkBelongsTo, label: 'billing type' },
         { field: 'workerRoleId', belongsTo: auth.roleFkBelongsTo, label: 'role' },
+        { field: 'workerUserId', belongsTo: auth.userFkBelongsTo, label: 'user' },
     ],
 });
 

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -431,6 +431,32 @@ async function roleFkBelongsTo(roleIdValue, companyId) {
 }
 
 /**
+ * Resolve a User id to its owning company (userCompId). Used to tenant-check
+ * the `workerUserId` FK on a Worker (the User ↔ Worker link, #448) — a worker
+ * can only be linked to a user in the same company. Returns -1 for
+ * missing/archived.
+ */
+async function getCompanyIdByUserId(userId) {
+    const idStr = userId == null ? '' : String(userId);
+    if (idStr.length === 0 || idStr === '0') return -1;
+    try {
+        const row = await getDb().User.findByPk(userId, { attributes: ['userCompId'] });
+        if (!row) return -1;
+        const cid = row.userCompId;
+        return typeof cid === 'number' && cid > 0 ? cid : -1;
+    } catch (error) {
+        log.error({ err: error }, 'auth.getCompanyIdByUserId query failed');
+        return -1;
+    }
+}
+
+/** True if the (optional) User FK is absent/null or belongs to `companyId`. */
+async function userFkBelongsTo(userIdValue, companyId) {
+    if (userIdValue == null) return true;
+    return (await getCompanyIdByUserId(userIdValue)) === companyId;
+}
+
+/**
  * Express middleware: ensures the authKey header is present and
  * stashes it on req.authKey. Does NOT validate the key against the
  * database — leaves that to controllers that may have different
@@ -564,6 +590,8 @@ module.exports = {
     getCompanyIdByRoleId,
     billingTypeFkBelongsTo,
     roleFkBelongsTo,
+    getCompanyIdByUserId,
+    userFkBelongsTo,
     requireAuthKey,
     attachAuth,
     attachUser,

--- a/app/migrations/20260706000000-worker-user-link.js
+++ b/app/migrations/20260706000000-worker-user-link.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// User ↔ Worker link (#448 — separation of duties). Adds a nullable
+// workerUserId column on Worker pointing at the User (sign-in account) that
+// the worker corresponds to, so the approval action can block a signed-in
+// user from approving their OWN logged time. Nullable + additive: no data
+// change, no FK constraint (increment layer). setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Worker', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            TABLE, 'workerUserId',
+            { type: Sequelize.INTEGER, allowNull: true },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(TABLE, 'workerUserId');
+    },
+};

--- a/app/models/worker.model.js
+++ b/app/models/worker.model.js
@@ -73,6 +73,13 @@ module.exports = (sequelize, Sequelize) => {
             // between the client rate and the worker's own default.
             type: Sequelize.INTEGER,
         },
+        workerUserId: {
+            field: 'workerUserId',
+            // Nullable link to a User (sign-in account, #448). Used to block
+            // a signed-in user from approving their OWN logged time
+            // (separation of duties). Must belong to the same company.
+            type: Sequelize.INTEGER,
+        },
     }, {
         tableName: 'Worker',
         timestamps: true,

--- a/app/schemas/worker.schema.js
+++ b/app/schemas/worker.schema.js
@@ -25,8 +25,9 @@ const createWorkerBody = z.object({
     workerTargetMinsPerWeek: z.coerce.number().int().positive().optional(),
     workerCostRate: z.coerce.number().positive().max(999999999.99).optional(),
     workerRoleId: z.coerce.number().int().positive().optional(),
+    workerUserId: z.coerce.number().int().positive().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerCompId, workerTargetMinsPerWeek, workerCostRate, workerRoleId, workerUserId.',
 });
 
 /**
@@ -43,8 +44,9 @@ const updateWorkerBody = z.object({
     workerTargetMinsPerWeek: z.coerce.number().int().positive().nullable().optional(),
     workerCostRate: z.coerce.number().positive().max(999999999.99).nullable().optional(),
     workerRoleId: z.coerce.number().int().positive().nullable().optional(),
+    workerUserId: z.coerce.number().int().positive().nullable().optional(),
 }).strict({
-    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate, workerRoleId.',
+    message: 'Unexpected field in body. Whitelist: workerFName, workerLName, workerTitle, workerDefaultBillType, workerTargetMinsPerWeek, workerCostRate, workerRoleId, workerUserId.',
 });
 
 const listByCompanyQuery = z.object({

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -158,16 +158,16 @@ deliberately **not** implemented autonomously.
    *requires* approval before billing has no such gate. Requiring
    `approved` would break the default (approval-less) flow, so which
    policy applies is a per-tenant product decision.
-8. **Approver authorization — role check WIRED (#585); self-approval still
-   open.** The approval action now enforces a `time:approve` permission
-   (granted to **manager and up**) for a signed-in-user (JWT) actor, scoped
-   to the actor's own company (secure-404) — using the same `attachUser`
-   mechanism as item 1. The API-key path is unchanged (full authority). What
-   remains: **separation of duties** — an actor should not approve their own
-   logged time — which needs a **User↔Worker link** the model lacks today
-   (JWT actors are `User`s; time entries reference `Worker`s). Decide whether
-   to add that link (e.g. `worker.userId`) before self-approval can be
-   blocked; and confirm `manager+` is the right approve tier.
+8. **Approver authorization — RESOLVED (#585, #586).** The approval action
+   enforces a `time:approve` permission (granted to **manager and up**) for a
+   signed-in-user (JWT) actor, scoped to the actor's own company (secure-404),
+   using the same `attachUser` mechanism as item 1. **Separation of duties is
+   now enforced too (#586):** a nullable `workerUserId` link (Worker → User,
+   tenant-checked like every other FK) lets the approval action reject a user
+   approving their **own** logged time (the entry's worker resolves to the
+   acting user) with a 403. The API-key path stays full-authority. Remaining
+   product knob: the approve tier defaults to `manager+` (adjustable), and
+   the `workerUserId` link is populated by whoever provisions workers.
 9. **Process-level `unhandledRejection` net.** There is no global
    `unhandledRejection` / `uncaughtException` handler, so an async rejection
    that escaped a handler would crash the process on Node ≥ 15. Both the

--- a/tests/api/timeentry-approval.test.js
+++ b/tests/api/timeentry-approval.test.js
@@ -46,9 +46,12 @@ describe('approval — RBAC for a JWT actor (time:approve)', () => {
     const ACTOR = 100; const ENTRY = 7;
 
     function token() { process.env.JWT_SECRET = SECRET; return jwt.sign({ sub: ACTOR, userCompId: 1 }, SECRET, 3600); }
-    function mock(actorRole, entryComp = 1, status = 'submitted') {
+    // workerUserId = the User the entry's worker is linked to (defaults to a
+    // DIFFERENT user, so it's not self-approval unless overridden to ACTOR).
+    function mock(actorRole, entryComp = 1, status = 'submitted', workerUserId = 999) {
         db.User = { findByPk: vi.fn().mockResolvedValue({ userId: ACTOR, userCompId: 1, userRole: actorRole, userArch: false }) };
-        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: entryComp, teArch: false, teApprovalStatus: status, update: vi.fn().mockResolvedValue(undefined) });
+        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: entryComp, teArch: false, teApprovalStatus: status, teWorkerId: 50, update: vi.fn().mockResolvedValue(undefined) });
+        db.Worker = { findByPk: vi.fn().mockResolvedValue({ workerUserId }) };
     }
     afterEach(() => { delete process.env.JWT_SECRET; });
     const post = () => request(app).post(`/v1/timeentry/${ENTRY}/approval`).set('authorization', `Bearer ${token()}`).send({ action: 'approve' });
@@ -64,5 +67,16 @@ describe('approval — RBAC for a JWT actor (time:approve)', () => {
     test('a cross-company entry → secure-404', async () => {
         mock('manager', 2); // entry in company 2, actor in company 1
         expect((await post()).status).toBe(404);
+    });
+
+    test('separation of duties: a manager cannot approve their OWN logged time → 403', async () => {
+        // The entry's worker is linked to the acting user (workerUserId == ACTOR).
+        mock('manager', 1, 'submitted', ACTOR);
+        expect((await post()).status).toBe(403);
+    });
+
+    test('a manager CAN approve another worker\'s time (worker linked to a different user) → 200', async () => {
+        mock('manager', 1, 'submitted', 777); // worker's user != actor
+        expect((await post()).status).toBe(200);
     });
 });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -245,6 +245,30 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('Worker.workerUserId column + getCompanyIdByUserId resolve against the real schema', async () => {
+        if (!connected) return;
+        const auth = require('../../app/middleware/auth.js');
+        const company = await db.Company.create({ compName: `${SENTINEL}-uwco`, compArch: false });
+        const user = await db.User.create({
+            userCompId: company.compId, userEmail: `${SENTINEL}@x.co`, userName: 'U', userPasswordHash: 'x', userArch: false,
+        });
+        // The migration added workerUserId; a worker can carry it.
+        const worker = await db.Worker.create({
+            workerFName: 'W', workerLName: 'K', workerTitle: 'Dev', workerDefaultBillType: 1,
+            workerCompId: company.compId, workerUserId: user.userId, workerArch: false,
+        });
+        try {
+            expect(await auth.getCompanyIdByUserId(user.userId)).toBe(company.compId);
+            expect(await auth.userFkBelongsTo(user.userId, company.compId)).toBe(true);
+            expect(await auth.userFkBelongsTo(user.userId, company.compId + 99999)).toBe(false);
+            expect(worker.workerUserId).toBe(user.userId); // column round-trips
+        } finally {
+            await worker.destroy();
+            await user.destroy();
+            await company.destroy();
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -290,6 +290,21 @@ describe('auth.getCompanyIdByRoleId / roleFkBelongsTo (Worker rate-source guard)
     });
 });
 
+describe('auth.getCompanyIdByUserId / userFkBelongsTo (Worker→User link guard)', () => {
+    test('resolves a user to its company; belongsTo enforces it', async () => {
+        stub.User.findByPk.mockResolvedValueOnce({ userCompId: 4 });
+        expect(await auth.getCompanyIdByUserId(1)).toBe(4);
+        stub.User.findByPk.mockResolvedValueOnce({ userCompId: 5 });
+        expect(await auth.userFkBelongsTo(1, 4)).toBe(false); // cross-tenant
+        expect(await auth.userFkBelongsTo(null, 4)).toBe(true); // absent optional
+    });
+    test('missing user → -1; non-positive id → -1 without a query', async () => {
+        stub.User.findByPk.mockResolvedValueOnce(null);
+        expect(await auth.getCompanyIdByUserId(9)).toBe(-1);
+        expect(await auth.getCompanyIdByUserId(0)).toBe(-1);
+    });
+});
+
 describe('auth.attachUser middleware (RBAC actor from a Bearer JWT)', () => {
     const jwt = require('../../app/services/jwt.js');
     const SECRET = 'test-jwt-secret';


### PR DESCRIPTION
## Summary

Completes the approver-authorization item (review-log #8): a signed-in user may no longer approve their **own** logged time (separation of duties). This was the one piece that needed a model change — a `User`↔`Worker` link.

- **Migration + model**: a **nullable `workerUserId`** column on `Worker` links a worker to the `User` (sign-in account) it corresponds to. Additive, nullable, no data change, no FK constraint (increment layer); `setup/*.sql` untouched.
- **Tenant-checked** like every other secondary FK: `auth.getCompanyIdByUserId` + `userFkBelongsTo`; `workercontroller` enforces it on create/update/bulk (a worker's user must be same-company) via the `secondaryFk` array. Added to the whitelists + schema.
- **Approval action**: for a JWT actor, after the company + `time:approve` checks, if the entry's `teWorkerId` resolves to a worker whose `workerUserId == the acting user`, reject with **403** "You cannot approve your own time entry." A null `teWorkerId` or an unlinked worker → no self-approval concern. The API-key path is unchanged.

## Verification

- Unit: `getCompanyIdByUserId` / `userFkBelongsTo` (same-co / cross-tenant / missing).
- API: manager approving **own** time → 403; approving **another** worker's time → 200.
- Integration (real PG): the resolver + the `workerUserId` column round-trip against the actual schema (also exercises the new migration).
- `npm test` → **1759 passing**; worker/approval/auth tests green; `npm run lint` clean.

**Resolves review-log item 8** (approver authorization: role check `time:approve` at manager+, plus separation of duties). The approve tier remains an adjustable product knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/