### PR TITLE
chore(models): make the last three money columns NUMERIC(14,2) (items 3/11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default.
 
 ### Changed
+- **All money columns are now `NUMERIC(14,2)`.** `btHourlyRate`, `cpayAmount`,
+  and `injbAmount` — the last three money columns stored as `DOUBLE` — are
+  converted to `NUMERIC(14,2)` with a Number getter, matching every other
+  money column (exact-decimal at rest). Behaviour-preserving: `money.js`
+  already rounds to cents and the schemas bound the magnitude, so the cast
+  only pins existing values to 2 dp. Closes the storage-consistency note in
+  `docs/SECURITY-REVIEW-LOG.md` (items 3 / 11).
 - **Consolidate CSV export assembly into a shared `buildCsv` helper.** The
   customer and time-entry `export.csv` builders duplicated the same inline
   header + escaped-rows loop; both now call `buildCsv(fields, records,

--- a/app/migrations/20260706010000-money-columns-numeric.js
+++ b/app/migrations/20260706010000-money-columns-numeric.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Storage consistency (review-log items 3/11): btHourlyRate, cpayAmount, and
+// injbAmount were the last three money columns stored as DOUBLE (float) while
+// every other money column is NUMERIC(14,2). Convert them so the whole money
+// model is exact-decimal at rest. Behaviour-preserving: money.js already
+// rounds to cents in computation and the schemas bound the magnitude
+// (<= 999,999,999.99), so the `::numeric(14,2)` cast only pins existing values
+// to 2 dp — which is how they were already computed. setup/*.sql untouched;
+// the migration converts on both fresh (post-setup) and existing databases.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const COLS = [
+    ['BillingType', 'btHourlyRate'],
+    ['CustomerPayment', 'cpayAmount'],
+    ['InvoiceJob', 'injbAmount'],
+];
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            for (const [table, col] of COLS) {
+                await queryInterface.sequelize.query(
+                    `ALTER TABLE "${SCHEMA}"."${table}" ALTER COLUMN "${col}" TYPE numeric(14,2) USING "${col}"::numeric(14,2);`,
+                    { transaction: t },
+                );
+            }
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            for (const [table, col] of COLS) {
+                await queryInterface.sequelize.query(
+                    `ALTER TABLE "${SCHEMA}"."${table}" ALTER COLUMN "${col}" TYPE double precision USING "${col}"::double precision;`,
+                    { transaction: t },
+                );
+            }
+        });
+    },
+};

--- a/app/models/billingtype.model.js
+++ b/app/models/billingtype.model.js
@@ -22,8 +22,14 @@ module.exports = (sequelize, Sequelize) => {
         },
         btHourlyRate: {
             field: 'btHourlyRate',
-            type: Sequelize.DOUBLE,
+            // NUMERIC(14,2) with a Number getter (pg NUMERIC→string), matching
+            // every other money column — exact-decimal at rest.
+            type: Sequelize.DECIMAL(14, 2),
             allowNull: false,
+            get() {
+                const v = this.getDataValue('btHourlyRate');
+                return v == null ? null : Number(v);
+            },
         },
         btArch: {
             field: 'btArch',

--- a/app/models/customerpayment.model.js
+++ b/app/models/customerpayment.model.js
@@ -37,8 +37,14 @@ module.exports = (sequelize, Sequelize) => {
         },
         cpayAmount: {
             field: 'cpayAmount',
-            type: Sequelize.DOUBLE,
+            // NUMERIC(14,2) with a Number getter (pg NUMERIC→string), matching
+            // every other money column — exact-decimal at rest.
+            type: Sequelize.DECIMAL(14, 2),
             allowNull: false,
+            get() {
+                const v = this.getDataValue('cpayAmount');
+                return v == null ? null : Number(v);
+            },
         },
         cpayArch: {
             field: 'cpayArch',

--- a/app/models/invoicejob.model.js
+++ b/app/models/invoicejob.model.js
@@ -31,8 +31,14 @@ module.exports = (sequelize, Sequelize) => {
         },
         injbAmount: {
             field: 'injbAmount',
-            type: Sequelize.DOUBLE,
+            // NUMERIC(14,2) with a Number getter (pg NUMERIC→string), matching
+            // every other money column — exact-decimal at rest.
+            type: Sequelize.DECIMAL(14, 2),
             allowNull: false,
+            get() {
+                const v = this.getDataValue('injbAmount');
+                return v == null ? null : Number(v);
+            },
         },
         injbArch: {
             field: 'injbArch',

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -190,10 +190,12 @@ deliberately **not** implemented autonomously.
     `defaultScope` join return `null`, so `resolveHourlyRate` falls through
     to the next tier instead of flagging — a silent under-bill. The right
     behavior (fall through vs. flag `unresolvedRate` vs. block the archive)
-    is a billing-policy choice, so it was not changed autonomously. (Minor,
-    same review: `btHourlyRate` is a `DOUBLE` while every other rate column
-    is `NUMERIC(14,2)` — a consistency migration; and `$0` is only settable
-    at the BillingType tier — a validation-symmetry choice.)
+    is a billing-policy choice, so it was not changed autonomously. (The
+    `DOUBLE`-vs-`NUMERIC` storage inconsistency — `btHourlyRate`, `cpayAmount`,
+    `injbAmount` — was **resolved in #587**: all three are now `NUMERIC(14,2)`
+    with a Number getter, so every money column is exact-decimal at rest.
+    Remaining minor: `$0` is only settable at the BillingType tier — a
+    validation-symmetry choice.)
 12. **Team utilization mixes numerator/denominator populations** (reporting
     review, LOW / by-design). Team `utilizationPct = teamBillable /
     teamCapacity`, but the numerator sums **all** workers' billable minutes

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -269,6 +269,25 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('btHourlyRate / cpayAmount / injbAmount are NUMERIC(14,2) after the migration', async () => {
+        if (!connected) return;
+        const rows = await db.sequelize.query(
+            `SELECT table_name, column_name, data_type, numeric_precision, numeric_scale
+             FROM information_schema.columns
+             WHERE table_schema = 'dbo'
+               AND ( (table_name = 'BillingType'     AND column_name = 'btHourlyRate')
+                  OR (table_name = 'CustomerPayment' AND column_name = 'cpayAmount')
+                  OR (table_name = 'InvoiceJob'      AND column_name = 'injbAmount') )`,
+            { type: db.Sequelize.QueryTypes.SELECT },
+        );
+        expect(rows.length).toBe(3);
+        for (const r of rows) {
+            expect(r.data_type).toBe('numeric');
+            expect(Number(r.numeric_precision)).toBe(14);
+            expect(Number(r.numeric_scale)).toBe(2);
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration


### PR DESCRIPTION
## Summary

`btHourlyRate`, `cpayAmount`, and `injbAmount` were the last money columns stored as `DOUBLE` (float) while every other money column is `NUMERIC(14,2)` with a Number getter. This converges them so the whole money model is exact-decimal at rest — closing the storage-consistency note in the review log (items 3/11).

- **Migration** ALTERs the three columns `DOUBLE → numeric(14,2)` (`USING col::numeric(14,2)`, in a transaction; `down` reverts). `setup/*.sql` untouched — the migration converts on both fresh (post-setup) and existing DBs.
- **Models**: `DECIMAL(14,2)` + a Number getter (pg `NUMERIC`→string), matching `jobFlatRate` et al.

**Behaviour-preserving**: `money.js` already rounds to cents in computation and the zod schemas bound the magnitude (≤ `999,999,999.99`), so the cast only pins existing values to 2 dp — which is how they were already computed. No product decision.

## Verification

`npm test` → **1762 passing** (the 66 billingtype/customerpayment/invoicejob + money/rollup tests stay green); a new **integration test** asserts the three columns are `numeric(14,2)` via `information_schema` after the migration (real Postgres, CI — also exercises the migration itself); `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/