### PR TITLE
security(idempotency): pre-handler claim to stop concurrent double-execution (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Idempotency now prevents concurrent double-execution (#588).** The
+  `Idempotency-Key` middleware previously wrote its cache row *after* the
+  handler, so two simultaneous same-key requests both executed the side
+  effect (a double-charge risk). It now performs a **pre-handler atomic
+  claim** (`INSERT … ON CONFLICT DO UPDATE … WHERE ikExpiresAt < now()
+  RETURNING`): exactly one request wins and runs the handler; a concurrent
+  same-key+body request gets `409 idempotency_in_progress` while it's
+  in-flight and replays the cached response once it completes. The claim is
+  released on a 5xx / non-JSON exit so a genuine retry re-runs, and a
+  crashed holder's claim is re-claimable after a 5-minute `PENDING_TTL`. A
+  migration makes `ikResponseStatus`/`ikResponseBody` nullable for the
+  pending state. Resolves review-log item 2.
+
 ### Fixed
 - **`expAmount` and `phaseBudgetAmount` reject out-of-range values (400, not
   500).** The last two money fields lacking an upper bound — `expAmount`

--- a/app/middleware/idempotency.js
+++ b/app/middleware/idempotency.js
@@ -50,7 +50,12 @@ function _setDbForTesting(db) {
     _dbOverride = db || null;
 }
 
-const TTL_MS = 24 * 60 * 60 * 1000;  // 24 hours
+const TTL_MS = 24 * 60 * 60 * 1000;  // 24 hours — a COMPLETED response is cached this long
+// A PENDING claim not completed within this window is treated as dead (its
+// holder crashed / the connection dropped) and may be re-claimed by a retry.
+// Bounds how long a stuck claim blocks retries; short enough that a client
+// recovers quickly, long enough to cover any realistic handler duration.
+const PENDING_TTL_MS = 5 * 60 * 1000;  // 5 minutes
 // Keys are client-picked; reject anything that looks like garbage.
 // Stripe accepts up to 255 chars; we mirror that and require
 // printable ASCII to avoid `\0` injection into the SQL replacement
@@ -136,12 +141,19 @@ async function pruneExpired(sequelize) {
  * retries. If the request lacks an `Idempotency-Key` header the
  * middleware is a no-op (passes through to the handler).
  *
- * Behavior on header present:
- *   - First time we've seen this (scope, key): proceed to handler,
- *     then write the response to the cache before returning.
- *   - Same (scope, key), same body hash: replay the cached response.
- *   - Same (scope, key), DIFFERENT body hash: 409 Conflict with a
- *     stable `{message, code: "idempotency_key_reused"}` body.
+ * Behavior on header present — a pre-handler CLAIM protocol so two
+ * concurrent requests with the same key can never both execute the
+ * side effect (the double-charge window, audit item #2):
+ *   - We first try to atomically INSERT a PENDING claim row (or
+ *     re-claim one left past PENDING_TTL by a crashed holder). The
+ *     RETURNING clause tells us whether WE won the claim.
+ *   - Won the claim → run the handler; on a 2xx/4xx response COMPLETE
+ *     the row (cache status+body for TTL_MS), on a 5xx / no-JSON exit
+ *     RELEASE it (delete the pending row) so a retry re-runs.
+ *   - Lost the claim (a live row already exists):
+ *       · same key, DIFFERENT body → 409 idempotency_key_reused.
+ *       · same key+body, still PENDING → 409 idempotency_in_progress.
+ *       · same key+body, COMPLETED → replay the cached response.
  *   - Storage failure: log + proceed (the dedup is best-effort; we
  *     never want it to break a write that would otherwise succeed).
  */
@@ -166,9 +178,9 @@ async function idempotency(req, res, next) {
     } catch (error) {
         if (error instanceof CanonicalJsonDepthError) {
             // Don't propagate as 500 via the global error path; emit a
-            // crisp 400 the client can act on. Skips both the cache
-            // lookup AND the handler — pre-bound, this branch would
-            // have stack-overflowed at depth ~5000, surfacing as 500.
+            // crisp 400 the client can act on. Skips both the claim AND
+            // the handler — pre-bound, this branch would have stack-
+            // overflowed at depth ~5000, surfacing as 500.
             //
             // Message is hardcoded (rather than `error.message`) so we
             // match the controller-error-shape policy — middleware
@@ -188,79 +200,140 @@ async function idempotency(req, res, next) {
     // because the index on ikExpiresAt covers it.
     pruneExpired(getDb().sequelize).catch(() => {});
 
-    let existing;
+    // Atomically CLAIM the (scope, key) slot: INSERT a pending row, or
+    // re-claim one whose previous holder left it past PENDING_TTL. A live
+    // row (pending or completed) is left untouched by the WHERE guard, so
+    // RETURNING yields a row ONLY when we actually (re)claimed. This is the
+    // serialization point — Postgres resolves concurrent INSERT…ON CONFLICT
+    // one at a time, so exactly one request wins.
+    let claimed;
     try {
-        const rows = await getDb().sequelize.query(
-            `SELECT "ikRequestHash" AS "requestHash",
-                    "ikResponseStatus" AS "status",
-                    "ikResponseBody" AS "body"
-               FROM "dbo"."IdempotencyKey"
-              WHERE "ikScope" = :scope AND "ikKey" = :key
-                AND "ikExpiresAt" >= now()`,
+        const result = await getDb().sequelize.query(
+            `INSERT INTO "dbo"."IdempotencyKey"
+                ("ikScope", "ikKey", "ikRequestHash",
+                 "ikResponseStatus", "ikResponseBody", "ikExpiresAt")
+             VALUES (:scope, :key, :requestHash, NULL, NULL, :pendingExpiry)
+             ON CONFLICT ("ikScope", "ikKey") DO UPDATE
+                SET "ikRequestHash" = EXCLUDED."ikRequestHash",
+                    "ikResponseStatus" = NULL,
+                    "ikResponseBody" = NULL,
+                    "ikExpiresAt" = EXCLUDED."ikExpiresAt"
+                WHERE "dbo"."IdempotencyKey"."ikExpiresAt" < now()
+             RETURNING "ikId"`,
             {
-                replacements: { scope, key: rawKey },
-                type: getDb().Sequelize.QueryTypes.SELECT,
+                replacements: {
+                    scope,
+                    key: rawKey,
+                    requestHash: bodyHash,
+                    pendingExpiry: new Date(Date.now() + PENDING_TTL_MS),
+                },
             },
         );
-        existing = rows && rows[0];
+        const rows = Array.isArray(result) ? result[0] : null;
+        claimed = Array.isArray(rows) && rows.length > 0;
     } catch (error) {
-        log.warn({ err: error }, 'IdempotencyKey: lookup failed, proceeding without dedup');
+        // Best-effort: a claim failure must never block a write.
+        log.warn({ err: error }, 'IdempotencyKey: claim failed, proceeding without dedup');
         return next();
     }
 
-    if (existing) {
+    if (!claimed) {
+        // A live row already holds this (scope, key). Look it up to decide.
+        let existing;
+        try {
+            const rows = await getDb().sequelize.query(
+                `SELECT "ikRequestHash" AS "requestHash",
+                        "ikResponseStatus" AS "status",
+                        "ikResponseBody" AS "body"
+                   FROM "dbo"."IdempotencyKey"
+                  WHERE "ikScope" = :scope AND "ikKey" = :key
+                    AND "ikExpiresAt" >= now()`,
+                {
+                    replacements: { scope, key: rawKey },
+                    type: getDb().Sequelize.QueryTypes.SELECT,
+                },
+            );
+            existing = rows && rows[0];
+        } catch (error) {
+            log.warn({ err: error }, 'IdempotencyKey: lookup failed, proceeding without dedup');
+            return next();
+        }
+
+        if (!existing) {
+            // The row expired / was pruned between claim and lookup — a rare
+            // race. Proceed without dedup rather than surface a 500.
+            return next();
+        }
         if (existing.requestHash !== bodyHash) {
             return res.status(409).json({
                 message: 'Idempotency-Key was reused with a different request body.',
                 code: 'idempotency_key_reused',
             });
         }
-        // Replay the cached response verbatim. Set a header so
-        // clients can tell a replay apart from a fresh write — useful
-        // for observability and for client-side write counters.
+        if (existing.status == null) {
+            // A concurrent request with the same key+body is still executing.
+            return res.status(409).json({
+                message: 'A request with this Idempotency-Key is already in progress.',
+                code: 'idempotency_in_progress',
+            });
+        }
+        // Completed → replay the cached response verbatim. The header lets
+        // clients tell a replay apart from a fresh write.
         res.setHeader('Idempotency-Replay', 'true');
         return res.status(existing.status).json(existing.body);
     }
 
-    // First time seeing this key. Intercept the handler's response
-    // so we can persist it BEFORE the bytes flush to the client. We
-    // wrap res.json (the controllers' uniform exit) and store there.
+    // WE own the execution. COMPLETE the claim (cache the response) on a
+    // 2xx/4xx, or RELEASE it (delete the still-pending row) on a 5xx or a
+    // no-JSON exit so a retry re-runs. `settled` guards against the finish
+    // safety-net double-acting.
+    let settled = false;
+    const completeClaim = (status, body) => {
+        if (settled) return;
+        settled = true;
+        getDb().sequelize.query(
+            `UPDATE "dbo"."IdempotencyKey"
+                SET "ikResponseStatus" = :status,
+                    "ikResponseBody" = :body::jsonb,
+                    "ikExpiresAt" = :expiresAt
+              WHERE "ikScope" = :scope AND "ikKey" = :key`,
+            {
+                replacements: {
+                    scope,
+                    key: rawKey,
+                    status,
+                    body: JSON.stringify(body),
+                    expiresAt: new Date(Date.now() + TTL_MS),
+                },
+            },
+        ).catch((error) => {
+            log.warn({ err: error }, 'IdempotencyKey: complete failed');
+        });
+    };
+    const releaseClaim = () => {
+        if (settled) return;
+        settled = true;
+        getDb().sequelize.query(
+            `DELETE FROM "dbo"."IdempotencyKey"
+              WHERE "ikScope" = :scope AND "ikKey" = :key
+                AND "ikResponseStatus" IS NULL`,
+            { replacements: { scope, key: rawKey } },
+        ).catch((error) => {
+            log.warn({ err: error }, 'IdempotencyKey: release failed');
+        });
+    };
+
     const originalJson = res.json.bind(res);
     res.json = function patchedJson(body) {
-        // Statuscode could have been set via res.status() prior to
-        // .json(). Default to 200 if nothing explicit.
         const status = res.statusCode || 200;
-        // Only persist successful or client-error writes. 5xx
-        // responses indicate the request never succeeded and we
-        // want the retry to actually re-run.
-        if (status >= 200 && status < 500) {
-            const expiresAt = new Date(Date.now() + TTL_MS);
-            // Fire and forget — the response shouldn't block on the
-            // cache write. If the INSERT loses a race with a
-            // concurrent retry the UNIQUE constraint catches it.
-            getDb().sequelize.query(
-                `INSERT INTO "dbo"."IdempotencyKey"
-                    ("ikScope", "ikKey", "ikRequestHash",
-                     "ikResponseStatus", "ikResponseBody", "ikExpiresAt")
-                 VALUES (:scope, :key, :requestHash,
-                         :status, :body::jsonb, :expiresAt)
-                 ON CONFLICT ("ikScope", "ikKey") DO NOTHING`,
-                {
-                    replacements: {
-                        scope,
-                        key: rawKey,
-                        requestHash: bodyHash,
-                        status,
-                        body: JSON.stringify(body),
-                        expiresAt,
-                    },
-                },
-            ).catch((error) => {
-                log.warn({ err: error }, 'IdempotencyKey: store failed');
-            });
-        }
+        if (status >= 200 && status < 500) completeClaim(status, body);
+        else releaseClaim();  // 5xx → release so a retry re-runs
         return originalJson(body);
     };
+    // If the response finishes WITHOUT going through res.json (a non-JSON
+    // send, a dropped connection, or an error that bypasses res.json),
+    // release the pending claim so the key isn't stuck until PENDING_TTL.
+    res.on('finish', () => { if (!settled) releaseClaim(); });
 
     return next();
 }
@@ -273,6 +346,7 @@ module.exports = {
     buildScope,
     KEY_PATTERN,
     TTL_MS,
+    PENDING_TTL_MS,
     MAX_CANONICAL_DEPTH,
     CanonicalJsonDepthError,
     // Test-only seam: pass a stub `{ sequelize: { query: ... }, Sequelize:

--- a/app/migrations/20260706020000-idempotency-pending-nullable.js
+++ b/app/migrations/20260706020000-idempotency-pending-nullable.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Idempotency pre-handler claim (audit item #2). To close the concurrent
+// double-execution window, the middleware now inserts a PENDING claim row
+// BEFORE running the handler (and completes/releases it after). A pending row
+// has no response yet, so ikResponseStatus / ikResponseBody must be NULLABLE.
+// Additive + reversible; setup/*.sql untouched.
+
+'use strict';
+
+const TABLE = '"dbo"."IdempotencyKey"';
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface) {
+        await queryInterface.sequelize.query(`ALTER TABLE ${TABLE} ALTER COLUMN "ikResponseStatus" DROP NOT NULL;`);
+        await queryInterface.sequelize.query(`ALTER TABLE ${TABLE} ALTER COLUMN "ikResponseBody" DROP NOT NULL;`);
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface) {
+        // Drop any still-pending rows before restoring NOT NULL.
+        await queryInterface.sequelize.query(`DELETE FROM ${TABLE} WHERE "ikResponseStatus" IS NULL OR "ikResponseBody" IS NULL;`);
+        await queryInterface.sequelize.query(`ALTER TABLE ${TABLE} ALTER COLUMN "ikResponseStatus" SET NOT NULL;`);
+        await queryInterface.sequelize.query(`ALTER TABLE ${TABLE} ALTER COLUMN "ikResponseBody" SET NOT NULL;`);
+    },
+};

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -129,12 +129,19 @@ deliberately **not** implemented autonomously.
    (#584): read (`user:read`), update (self-edit or `user:write`), remove
    (`user:write`), and `listByCompany` (own company). Remaining follow-up:
    gate the approval action the same way (open item 8).
-2. **Idempotency concurrent double-execution.** The cache row is written
-   *after* the handler, so two simultaneous same-key requests both execute
-   the side effect (a double-charge risk); sequential retries are correctly
-   deduped. The fix is a **pre-handler claim** (insert a pending row →
-   conflicting request replays or 409s) with release-on-5xx / `res.finish`
-   handling and a nullable-columns migration.
+2. **Idempotency concurrent double-execution — RESOLVED (#588).** Previously
+   the cache row was written *after* the handler, so two simultaneous same-key
+   requests both executed the side effect (a double-charge risk). The
+   middleware now performs a **pre-handler atomic claim**: `INSERT … ON
+   CONFLICT DO UPDATE … WHERE ikExpiresAt < now() RETURNING` inserts a PENDING
+   row (or re-claims one left past a 5-min `PENDING_TTL`); Postgres serializes
+   the conflict so exactly one request wins. The winner runs the handler and
+   COMPLETEs the row on a 2xx/4xx (cached 24 h) or RELEASEs it on a 5xx /
+   `res.finish` with no JSON (so a retry re-runs); a losing request with the
+   same key+body gets `409 idempotency_in_progress` while the holder is live,
+   replays once it completes, or `409 idempotency_key_reused` on a body
+   mismatch. Nullable `ikResponseStatus`/`ikResponseBody` migration backs the
+   pending state.
 3. **Streamed GDPR export.** `exportCustomer` issues un-`limit`ed
    `findAll`s — an OOM/DoS vector for a very large customer. A cap conflicts
    with GDPR's completeness requirement, so it wants a **streamed** export

--- a/tests/api/idempotency.test.js
+++ b/tests/api/idempotency.test.js
@@ -90,35 +90,65 @@ describe('Idempotency middleware: mounted on POST routes', () => {
         expect(res.status).not.toBe(409);
     });
 
-    test('first write + replay round-trip works via the _setDbForTesting seam', async () => {
-        // Walk the full first-write → replay path that vi.mock alone
-        // can't reach. The stub plays both roles of the cache table:
-        // SELECT returns nothing on the first request (cache miss),
-        // INSERT writes a row, SELECT on the second request returns
-        // the stored row.
-        const idem = require('../../app/middleware/idempotency.js');
-        const storedRows = new Map();
-        const stub = {
+    // A stateful in-memory stand-in for the IdempotencyKey table that models
+    // the pre-handler CLAIM protocol (audit item #2): INSERT claims a pending
+    // slot (or re-claims an expired one), UPDATE completes it, DELETE releases
+    // or prunes. All mutations are synchronous so a sequential retry in a test
+    // deterministically sees the completed row (mirrors: the completion UPDATE
+    // is issued before the first response's bytes flush).
+    function makeClaimStub() {
+        const store = new Map();
+        const kf = (r) => `${r.scope}::${r.key}`;
+        return {
+            store,
             sequelize: {
                 query: vi.fn(async (sql, opts) => {
-                    if (/^SELECT/.test(sql)) {
-                        const key = opts && opts.replacements && opts.replacements.key;
-                        const scope = opts && opts.replacements && opts.replacements.scope;
-                        const hit = storedRows.get(`${scope}::${key}`);
-                        return hit ? [hit] : [];
-                    }
+                    const r = (opts && opts.replacements) || {};
                     if (/^INSERT/.test(sql)) {
-                        const { scope, key, requestHash, status, body } = opts.replacements;
-                        storedRows.set(`${scope}::${key}`, {
-                            requestHash, status, body: JSON.parse(body),
-                        });
-                        return [[], 1];
+                        const k = kf(r);
+                        const cur = store.get(k);
+                        const pendMs = r.pendingExpiry && r.pendingExpiry.getTime
+                            ? r.pendingExpiry.getTime() : Date.now() + 300000;
+                        if (!cur || cur.expiresAt < Date.now()) {
+                            store.set(k, { requestHash: r.requestHash, status: null, body: null, expiresAt: pendMs });
+                            return [[{ ikId: 1 }]];  // claimed
+                        }
+                        return [[]];  // conflict — a live row already holds it
                     }
-                    return [];
+                    if (/^SELECT/.test(sql)) {
+                        const cur = store.get(kf(r));
+                        return cur && cur.expiresAt >= Date.now() ? [cur] : [];
+                    }
+                    if (/^UPDATE/.test(sql)) {
+                        const cur = store.get(kf(r));
+                        if (cur) {
+                            cur.status = r.status;
+                            cur.body = JSON.parse(r.body);
+                            cur.expiresAt = r.expiresAt && r.expiresAt.getTime ? r.expiresAt.getTime() : Date.now() + 86400000;
+                        }
+                        return [[], {}];
+                    }
+                    if (/^DELETE/.test(sql)) {
+                        if (/ikResponseStatus" IS NULL/.test(sql)) {          // release
+                            const cur = store.get(kf(r));
+                            if (cur && cur.status == null) store.delete(kf(r));
+                        } else {                                              // prune expired
+                            for (const [k, v] of store) if (v.expiresAt < Date.now()) store.delete(k);
+                        }
+                        return [[], {}];
+                    }
+                    return [[], {}];
                 }),
             },
             Sequelize: { QueryTypes: { SELECT: 'SELECT' } },
         };
+    }
+
+    test('first write + replay round-trip works via the _setDbForTesting seam', async () => {
+        // Walk the full claim → complete → replay path that vi.mock alone
+        // can't reach, driven by the stateful claim stub.
+        const idem = require('../../app/middleware/idempotency.js');
+        const stub = makeClaimStub();
         idem._setDbForTesting(stub);
         try {
             const key = '01HFREPLAY12345';
@@ -152,6 +182,74 @@ describe('Idempotency middleware: mounted on POST routes', () => {
                 .send({ custCompanyName: 'Different' });
             expect(third.status).toBe(409);
             expect(third.body.code).toBe('idempotency_key_reused');
+        } finally {
+            idem._setDbForTesting(null);
+        }
+    });
+
+    test('a concurrent in-flight request (same key+body, still pending) → 409 in_progress', async () => {
+        // This is the double-execution guard (audit item #2): while one
+        // request holds a PENDING claim, a second with the SAME key+body must
+        // NOT run the handler — it gets 409 in_progress. We simulate the
+        // in-flight holder with a stub whose claim always conflicts and whose
+        // lookup returns a pending row carrying the matching request hash.
+        const idem = require('../../app/middleware/idempotency.js');
+        const body = { custCompanyName: 'Acme' };
+        const bodyHash = idem.hashBody(body);
+        const stub = {
+            sequelize: {
+                query: vi.fn(async (sql) => {
+                    if (/^INSERT/.test(sql)) return [[]];                          // claim lost — a live row exists
+                    if (/^SELECT/.test(sql)) return [{ requestHash: bodyHash, status: null, body: null }]; // pending
+                    return [[], {}];
+                }),
+            },
+            Sequelize: { QueryTypes: { SELECT: 'SELECT' } },
+        };
+        idem._setDbForTesting(stub);
+        try {
+            const res = await request(app)
+                .post('/v1/customer')
+                .set('authKey', 'any')
+                .set('Idempotency-Key', '01HFINFLIGHT999')
+                .send(body);
+            expect(res.status).toBe(409);
+            expect(res.body.code).toBe('idempotency_in_progress');
+        } finally {
+            idem._setDbForTesting(null);
+        }
+    });
+
+    test('a pending claim past PENDING_TTL is re-claimable (a stuck holder does not block forever)', async () => {
+        // Seed an EXPIRED pending row; the next request must win the claim
+        // (the INSERT…ON CONFLICT DO UPDATE WHERE expiresAt < now() path) and
+        // reach the handler rather than 409.
+        const idem = require('../../app/middleware/idempotency.js');
+        const stub = makeClaimStub();
+        // Pre-seed an expired pending row for whatever (scope,key) the request
+        // computes — easier to force via the stub: first INSERT sees the
+        // expired row and re-claims. We emulate "expired" by seeding with a
+        // past expiry keyed to the first INSERT's replacements.
+        let seeded = false;
+        const realQuery = stub.sequelize.query;
+        stub.sequelize.query = vi.fn(async (sql, opts) => {
+            if (/^INSERT/.test(sql) && !seeded) {
+                seeded = true;
+                const r = opts.replacements;
+                stub.store.set(`${r.scope}::${r.key}`, { requestHash: 'stale', status: null, body: null, expiresAt: Date.now() - 1000 });
+            }
+            return realQuery(sql, opts);
+        });
+        idem._setDbForTesting(stub);
+        try {
+            const res = await request(app)
+                .post('/v1/customer')
+                .set('authKey', 'any')
+                .set('Idempotency-Key', '01HFSTUCK0001')
+                .send({ custCompanyName: 'Acme' });
+            // Re-claimed + ran the handler → NOT a 409 in_progress / reused.
+            expect(res.status).not.toBe(409);
+            expect(res.headers['idempotency-replay']).toBeUndefined();
         } finally {
             idem._setDbForTesting(null);
         }

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -288,6 +288,45 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('IdempotencyKey pending-claim protocol works against the real schema', async () => {
+        if (!connected) return;
+        const scope = `${SENTINEL}-ik-scope`;
+        const key = `${SENTINEL}-ik-key`;
+        // The exact atomic claim the middleware issues: insert a pending row,
+        // or re-claim one whose ikExpiresAt is in the past.
+        const claimSql =
+            `INSERT INTO "dbo"."IdempotencyKey"
+                ("ikScope","ikKey","ikRequestHash","ikResponseStatus","ikResponseBody","ikExpiresAt")
+             VALUES (:scope,:key,:hash,NULL,NULL,:exp)
+             ON CONFLICT ("ikScope","ikKey") DO UPDATE
+                SET "ikRequestHash"=EXCLUDED."ikRequestHash",
+                    "ikResponseStatus"=NULL, "ikResponseBody"=NULL,
+                    "ikExpiresAt"=EXCLUDED."ikExpiresAt"
+                WHERE "dbo"."IdempotencyKey"."ikExpiresAt" < now()
+             RETURNING "ikId"`;
+        const soon = new Date(Date.now() + 300000);
+        try {
+            // 1) First claim inserts a PENDING row — nullable status/body proves
+            //    the migration ran (pre-migration this INSERT would violate NOT NULL).
+            const [r1] = await db.sequelize.query(claimSql, { replacements: { scope, key, hash: 'h1', exp: soon } });
+            expect(r1.length).toBe(1);
+            // 2) A second claim while the row is live → 0 rows (conflict) — the
+            //    concurrent-double-execution guard.
+            const [r2] = await db.sequelize.query(claimSql, { replacements: { scope, key, hash: 'h1', exp: soon } });
+            expect(r2.length).toBe(0);
+            // 3) Expire the row, then a claim re-claims it → 1 row (a stuck
+            //    holder doesn't block retries forever).
+            await db.sequelize.query(
+                `UPDATE "dbo"."IdempotencyKey" SET "ikExpiresAt" = now() - interval '1 second' WHERE "ikScope"=:scope AND "ikKey"=:key`,
+                { replacements: { scope, key } },
+            );
+            const [r3] = await db.sequelize.query(claimSql, { replacements: { scope, key, hash: 'h2', exp: soon } });
+            expect(r3.length).toBe(1);
+        } finally {
+            await db.sequelize.query(`DELETE FROM "dbo"."IdempotencyKey" WHERE "ikScope"=:scope`, { replacements: { scope } });
+        }
+    });
+
     test('Invoice has invSubtotal / invTax / invTotal money columns', async () => {
         if (!connected) return;
         // Selecting the new attributes proves the 20260522 migration


### PR DESCRIPTION
## Summary

The `Idempotency-Key` middleware wrote its cache row **after** the handler, so two *simultaneous* same-key requests both missed the lookup and both executed the side effect — a **double-charge window** (sequential retries were already deduped). This replaces the cache-after-handler flow with a **pre-handler atomic claim**, closing review-log item 2 (payment-critical).

## Design — atomic claim

```sql
INSERT ... ON CONFLICT ("ikScope","ikKey") DO UPDATE
  SET (reset to pending, new hash/expiry)
  WHERE "IdempotencyKey"."ikExpiresAt" < now()   -- only re-claim an EXPIRED row
RETURNING "ikId"
```

Postgres serializes the `ON CONFLICT`, so **exactly one** request inserts (or re-claims an expired) pending row and gets a `RETURNING` row; concurrent losers get 0 rows. Then:

- **Winner** runs the handler; via a wrapped `res.json` + `res.on('finish')`:
  - `2xx/4xx` → **complete** the row (cache status+body, extend expiry to 24 h)
  - `5xx` / non-JSON exit → **release** it (delete the pending claim) so a genuine retry re-runs
- **Loser** looks the row up:
  - different body → `409 idempotency_key_reused` *(unchanged)*
  - same body, still pending → **`409 idempotency_in_progress`** *(the new guard)*
  - same body, completed → **replay** the cached response *(unchanged)*

A crashed holder's claim is re-claimable after **`PENDING_TTL` (5 min)**, bounding how long a stuck key blocks retries (a handler must finish within that window for the exclusion guarantee — far above any real handler / HTTP timeout). Still **best-effort**: any claim/lookup DB error logs + proceeds so dedup never blocks a write.

**Migration**: `ikResponseStatus` / `ikResponseBody` become **nullable** for the pending state (`down` drops pending rows before restoring `NOT NULL`); `setup/*.sql` untouched.

## Verification

- Rewrote the round-trip test to a **stateful claim stub** (claim → complete → replay → reused-409).
- Added **concurrent `in_progress` 409** and **re-claim-after-`PENDING_TTL`** cases.
- **Integration test** drives the exact claim SQL against **real Postgres**: pending insert (nullable cols prove the migration), live-row conflict (0 rows), expiry re-claim (1 row).
- `npm test` → **1766 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/