### PR TITLE
security(gdpr): stream the customer export instead of buffering it (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **GDPR export streams instead of buffering (#589).** `GET
+  /v1/gdpr/customer/:id/export` previously ran seven un-`limit`ed parallel
+  `findAll`s and held the entire result set in memory — an OOM/DoS vector for
+  a customer with a large history. It now streams the same JSON object,
+  keyset-paginating each relation (`pk > lastId` batches of 500) so peak
+  memory is bounded regardless of total rows. No truncation — GDPR
+  completeness is preserved. Resolves review-log item 3.
 - **Idempotency now prevents concurrent double-execution (#588).** The
   `Idempotency-Key` middleware previously wrote its cache row *after* the
   handler, so two simultaneous same-key requests both executed the side

--- a/app/controllers/gdprcontroller.js
+++ b/app/controllers/gdprcontroller.js
@@ -5,7 +5,7 @@
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
-const { anonymizedValues } = require('../services/gdpr.js');
+const { anonymizedValues, streamRelationArray } = require('../services/gdpr.js');
 
 // #374: reuse attachAuth's resolved context (req.isMaster / req.companyId)
 // instead of a second DB lookup; falls back to a live lookup if absent.
@@ -40,6 +40,12 @@ async function findScopedCustomer(req, res) {
 /**
  * GET /v1/gdpr/customer/:id/export — a portable JSON export of everything
  * held about a customer (data-portability). Company-scoped, secure-404.
+ *
+ * The related sets are STREAMED in keyset-paginated batches rather than
+ * loaded whole (audit item #3): a customer with a very large history would
+ * otherwise blow the heap on the parallel un-`limit`ed `findAll`s. The
+ * response is the same single JSON object; it is just assembled incrementally
+ * so peak memory stays O(batch), not O(total rows).
  */
 exports.exportCustomer = async (req, res) => {
     if (!req.get('authKey')) {
@@ -49,33 +55,42 @@ exports.exportCustomer = async (req, res) => {
     if (!customer) return undefined;
 
     const custId = customer.custId;
-    let bundle;
+    const Op = db.Sequelize.Op;
+    // Same set + order as before; each entry streams as its own JSON array.
+    const RELATIONS = [
+        { key: 'invoices', model: db.Invoice, fk: 'invCustId' },
+        { key: 'jobs', model: db.Job, fk: 'jobCustId' },
+        { key: 'expenses', model: db.Expense, fk: 'expCustId' },
+        { key: 'timeEntries', model: db.TimeEntry, fk: 'teCustId' },
+        { key: 'payments', model: db.CustomerPayment, fk: 'cpayCustId' },
+        { key: 'retainers', model: db.Retainer, fk: 'retCustId' },
+        { key: 'recurringInvoices', model: db.RecurringInvoice, fk: 'recinvCustId' },
+    ];
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
     try {
-        const [invoices, jobs, expenses, timeEntries, payments, retainers, recurringInvoices] = await Promise.all([
-            db.Invoice.findAll({ where: { invCustId: custId } }),
-            db.Job.findAll({ where: { jobCustId: custId } }),
-            db.Expense.findAll({ where: { expCustId: custId } }),
-            db.TimeEntry.findAll({ where: { teCustId: custId } }),
-            db.CustomerPayment.findAll({ where: { cpayCustId: custId } }),
-            db.Retainer.findAll({ where: { retCustId: custId } }),
-            db.RecurringInvoice.findAll({ where: { recinvCustId: custId } }),
-        ]);
-        bundle = { invoices, jobs, expenses, timeEntries, payments, retainers, recurringInvoices };
+        res.write('{"message":"GDPR data export."'
+            + ',"exportedAt":' + JSON.stringify(new Date().toISOString())
+            + ',"customer":' + JSON.stringify(customer)
+            + ',');
+        const counts = {};
+        for (const rel of RELATIONS) {
+            res.write(JSON.stringify(rel.key) + ':[');
+            counts[rel.key] = await streamRelationArray(
+                rel.model, { [rel.fk]: custId }, Op, (chunk) => res.write(chunk),
+            );
+            res.write('],');
+        }
+        res.write('"counts":' + JSON.stringify(counts) + '}');
+        return res.end();
     } catch (error) {
-        log.error({ err: error }, 'gdpr export: aggregation failed');
-        return res.status(500).json({ message: "Error!" });
+        log.error({ err: error }, 'gdpr export: streaming failed');
+        // If nothing was flushed yet we can still send a clean 500; once the
+        // stream has started the client detects the truncated JSON.
+        if (!res.headersSent) return res.status(500).json({ message: "Error!" });
+        return res.end();
     }
-
-    const counts = {};
-    for (const [k, v] of Object.entries(bundle)) counts[k] = v.length;
-
-    return res.status(200).json({
-        message: "GDPR data export.",
-        exportedAt: new Date().toISOString(),
-        customer,
-        ...bundle,
-        counts,
-    });
 };
 
 /**

--- a/app/services/gdpr.js
+++ b/app/services/gdpr.js
@@ -31,4 +31,46 @@ function anonymizedValues() {
     return out;
 }
 
-module.exports = { PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues };
+// Default rows-per-batch for the streamed GDPR export. Large enough to keep
+// round-trips low, small enough that peak memory is bounded regardless of a
+// customer's total history (audit item #3 — the pre-stream findAll loaded the
+// whole relation into memory, an OOM/DoS vector).
+const EXPORT_BATCH_SIZE = 500;
+
+/**
+ * Stream one relation as a comma-separated run of JSON objects (no enclosing
+ * brackets — the caller writes those). Keyset pagination over the model's
+ * primary key means peak memory is O(batchSize), not O(total rows), and the
+ * `pk > lastId` cursor can neither skip nor duplicate rows the way OFFSET can.
+ *
+ * Pure-ish + injectable for tests: `model` need only expose
+ * `primaryKeyAttribute` + `findAll({where, order, limit})`, `Op` supplies the
+ * `gt` operator, and `write(str)` receives each chunk. Returns the row count.
+ */
+async function streamRelationArray(model, baseWhere, Op, write, batchSize = EXPORT_BATCH_SIZE) {
+    const pk = model.primaryKeyAttribute;
+    let lastId = 0;
+    let first = true;
+    let total = 0;
+    for (;;) {
+        const rows = await model.findAll({
+            where: { ...baseWhere, [pk]: { [Op.gt]: lastId } },
+            order: [[pk, 'ASC']],
+            limit: batchSize,
+        });
+        if (!rows || rows.length === 0) break;
+        for (const row of rows) {
+            write((first ? '' : ',') + JSON.stringify(row));
+            first = false;
+            lastId = typeof row.get === 'function' ? row.get(pk) : row[pk];
+        }
+        total += rows.length;
+        if (rows.length < batchSize) break;
+    }
+    return total;
+}
+
+module.exports = {
+    PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues,
+    EXPORT_BATCH_SIZE, streamRelationArray,
+};

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -142,10 +142,13 @@ deliberately **not** implemented autonomously.
    replays once it completes, or `409 idempotency_key_reused` on a body
    mismatch. Nullable `ikResponseStatus`/`ikResponseBody` migration backs the
    pending state.
-3. **Streamed GDPR export.** `exportCustomer` issues un-`limit`ed
-   `findAll`s — an OOM/DoS vector for a very large customer. A cap conflicts
-   with GDPR's completeness requirement, so it wants a **streamed** export
-   rather than a truncating limit.
+3. **Streamed GDPR export — RESOLVED (#589).** `exportCustomer` previously
+   issued seven un-`limit`ed parallel `findAll`s and buffered the lot — an
+   OOM/DoS vector for a very large customer. It now **streams** the same JSON
+   object, keyset-paginating each relation (`pk > lastId` batches of 500 via
+   `gdpr.streamRelationArray`) so peak memory is O(batch), not O(total rows) —
+   no truncation, so GDPR completeness is preserved. A mid-stream DB error
+   truncates the (already-started) response, which the client detects.
 4. **Per-link share revocation.** Share links are stateless JWTs, so an
    individual link can't be revoked before its `exp` (≤90 days); the only
    levers are archiving the invoice or rotating `SHARE_SECRET`. Add a

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -293,7 +293,8 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         const { streamRelationArray } = require('../../app/services/gdpr.js');
         const company = await db.Company.create({ compName: `${SENTINEL}-gdpr`, compArch: false });
         const customer = await db.Customer.create({
-            custCompanyName: `${SENTINEL}-cust`, custCompId: company.compId, custArch: false,
+            custCompanyName: `${SENTINEL}-cust`, custFName: 'Ex', custLName: 'Port',
+            custCompId: company.compId, custArch: false,
         });
         const made = [];
         for (let i = 0; i < 5; i++) {

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -288,6 +288,37 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('streamRelationArray keyset-paginates a real relation in PK order (GDPR export)', async () => {
+        if (!connected) return;
+        const { streamRelationArray } = require('../../app/services/gdpr.js');
+        const company = await db.Company.create({ compName: `${SENTINEL}-gdpr`, compArch: false });
+        const customer = await db.Customer.create({
+            custCompanyName: `${SENTINEL}-cust`, custCompId: company.compId, custArch: false,
+        });
+        const made = [];
+        for (let i = 0; i < 5; i++) {
+            made.push(await db.Invoice.create({
+                invCustId: customer.custId, invDate: '2026-01-01', invDueDate: '2026-02-01',
+            }));
+        }
+        try {
+            const chunks = [];
+            // batchSize 2 → forces multiple keyset pages against real Postgres.
+            const total = await streamRelationArray(
+                db.Invoice, { invCustId: customer.custId }, db.Sequelize.Op, (c) => chunks.push(c), 2,
+            );
+            expect(total).toBe(5);
+            const parsed = JSON.parse('[' + chunks.join('') + ']');
+            const ids = parsed.map((r) => r.invId);
+            expect(ids).toEqual([...ids].sort((a, b) => a - b)); // ascending PK order
+            expect(new Set(ids).size).toBe(5);                    // no dup / skip across pages
+        } finally {
+            for (const inv of made) await inv.destroy({ force: true });
+            await customer.destroy({ force: true });
+            await company.destroy({ force: true });
+        }
+    });
+
     test('IdempotencyKey pending-claim protocol works against the real schema', async () => {
         if (!connected) return;
         const scope = `${SENTINEL}-ik-scope`;

--- a/tests/unit/gdpr.test.js
+++ b/tests/unit/gdpr.test.js
@@ -2,7 +2,7 @@
 // Copyright 2026 Aaron K. Clark
 
 import { describe, test, expect } from 'vitest';
-import { PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues } from '../../app/services/gdpr.js';
+import { PII_FIELDS, NON_NULL_PII, PLACEHOLDER, anonymizedValues, streamRelationArray } from '../../app/services/gdpr.js';
 
 describe('gdpr (#461)', () => {
     test('anonymizedValues covers every PII field and nothing else', () => {
@@ -21,6 +21,64 @@ describe('gdpr (#461)', () => {
         expect(v.custPhone).toBeNull();
         expect(v.custAddress1).toBeNull();
         expect(v.custZip).toBeNull();
+    });
+});
+
+// streamRelationArray: keyset-paginated streaming (audit item #3). A fake
+// model returns rows in PK order past the `pk > lastId` cursor, capped at the
+// batch limit — the same contract Sequelize's findAll honours.
+describe('streamRelationArray — bounded, keyset-paginated streaming', () => {
+    const OP_GT = Symbol('gt');
+    const Op = { gt: OP_GT };
+    // rows: [{id, v}, ...] sorted by id. Records the largest `limit` requested
+    // so we can assert peak batch size is bounded.
+    function fakeModel(pk, rows, seenLimits) {
+        return {
+            primaryKeyAttribute: pk,
+            findAll: async ({ where, order, limit }) => {
+                if (seenLimits) seenLimits.push(limit);
+                // ORDER BY pk ASC, WHERE pk > cursor, LIMIT.
+                expect(order).toEqual([[pk, 'ASC']]);
+                const cursor = where[pk][OP_GT];
+                return rows.filter((r) => r[pk] > cursor).slice(0, limit)
+                    .map((r) => ({ ...r, get: (k) => r[k] }));
+            },
+        };
+    }
+    function collect(rows, batchSize) {
+        const chunks = [];
+        const seenLimits = [];
+        const model = fakeModel('id', rows, seenLimits);
+        return streamRelationArray(model, { fk: 1 }, Op, (c) => chunks.push(c), batchSize)
+            .then((total) => ({ total, chunks, seenLimits }));
+    }
+
+    test('streams every row across multiple batches, comma-joined + parseable', async () => {
+        const rows = [1, 2, 3, 4, 5].map((id) => ({ id, v: `r${id}` }));
+        const { total, chunks, seenLimits } = await collect(rows, 2);
+        expect(total).toBe(5);
+        // Reassembling the chunks inside [] yields the ordered rows.
+        const parsed = JSON.parse('[' + chunks.join('') + ']');
+        expect(parsed.map((r) => r.id)).toEqual([1, 2, 3, 4, 5]);
+        // Never requested more than the batch size (bounded memory).
+        expect(Math.max(...seenLimits)).toBe(2);
+        // 3 batches for 5 rows @ 2: [1,2],[3,4],[5].
+        expect(seenLimits.length).toBe(3);
+    });
+
+    test('empty relation → 0 rows, one empty batch, no chunks', async () => {
+        const { total, chunks, seenLimits } = await collect([], 500);
+        expect(total).toBe(0);
+        expect(chunks).toEqual([]);
+        expect(seenLimits).toEqual([500]);
+    });
+
+    test('a full final batch triggers one more (empty) probe, then stops', async () => {
+        // Exactly batchSize rows: first batch is full → loop again → empty → stop.
+        const rows = [1, 2].map((id) => ({ id, v: id }));
+        const { total, seenLimits } = await collect(rows, 2);
+        expect(total).toBe(2);
+        expect(seenLimits.length).toBe(2); // [1,2] then the empty probe
     });
 });
 


### PR DESCRIPTION
## Summary

`GET /v1/gdpr/customer/:id/export` ran **seven un-`limit`ed parallel `findAll`s** (invoices, jobs, expenses, time entries, payments, retainers, recurring invoices) and buffered the entire result set before `res.json` — an **OOM/DoS vector** for a customer with a large history. A cap would violate GDPR's completeness requirement, so the fix is to **stream, not truncate** (review-log item 3).

- **New `gdpr.streamRelationArray(model, baseWhere, Op, write, batchSize=500)`** — keyset pagination over the model's primary key (`pk > lastId`, `ORDER BY pk`, `LIMIT batch`). Peak memory is **O(batch), not O(total rows)**; the cursor can neither skip nor duplicate rows the way `OFFSET` can. Pure-ish + injectable (needs only `primaryKeyAttribute` + `findAll`) so it unit-tests without a DB.
- **`exportCustomer`** now writes the **same single JSON object** incrementally: header + `customer`, then each relation as a streamed array, then `counts`. A mid-stream error truncates the already-started response (client detects); a pre-stream failure still returns a clean 500.

## Verification

- **Unit** (`streamRelationArray`): multi-batch streaming (comma-joined + parseable, ordered), bounded batch size, empty relation, full-final-batch probe.
- **Integration** (real Postgres): keyset-paginates real `Invoice`s across pages in ascending PK order with no dup/skip.
- The existing auth/validation contract tests still pass.
- `npm test` → **1770 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/