### PR TITLE
security(share): per-link revocation via jti deny-list (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Per-link share-link revocation (#590).** Shareable invoice links are
+  stateless JWTs, so an individual link couldn't be killed before its `exp`
+  (≤90 days) without rotating `SHARE_SECRET` (which kills every link). Each
+  minted link now carries a random `jti`; a new tenant-scoped
+  `POST /v1/share/revoke` deny-lists a token's `jti` (in the new
+  `RevokedShareLink` table) after verifying the caller owns the invoice, and
+  the public view rejects a revoked link with a 401 (same message as an
+  invalid token — no revocation-status leak). Idempotent. Resolves review-log
+  item 4.
 - **GDPR export streams instead of buffering (#589).** `GET
   /v1/gdpr/customer/:id/export` previously ran seven un-`limit`ed parallel
   `findAll`s and held the entire result set in memory — an OOM/DoS vector for

--- a/app/config/db.config.js
+++ b/app/config/db.config.js
@@ -82,6 +82,7 @@ db.ApprovalChain = require('../models/approvalchain.model.js')(sequelize, Sequel
 db.Invitation = require('../models/invitation.model.js')(sequelize, Sequelize);
 db.CustomFieldDef = require('../models/customfielddef.model.js')(sequelize, Sequelize);
 db.BillableRule = require('../models/billablerule.model.js')(sequelize, Sequelize);
+db.RevokedShareLink = require('../models/revokedsharelink.model.js')(sequelize, Sequelize);
 
 // ----------------------------------------------------------------------
 // Associations — centralized so the relationship graph is visible

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -1867,8 +1867,22 @@ const spec = {
                 parameters: [{ name: 'token', in: 'query', required: true, schema: { type: 'string' } }],
                 responses: {
                     200: { description: 'Read-only invoice projection (totals, balance, customer name)' },
-                    401: { description: 'Invalid or expired link' },
+                    401: { description: 'Invalid, expired, or revoked link' },
                     404: { description: 'Invoice not found' },
+                    503: { description: 'SHARE_SECRET not configured' },
+                },
+            },
+        },
+        '/v1/share/revoke': {
+            post: {
+                summary: 'Revoke a previously-minted share link before its exp (#4)',
+                security: [{ authKey: [] }],
+                requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { token: { type: 'string', description: 'The share token to revoke.' } }, required: ['token'] } } } },
+                responses: {
+                    200: { description: 'Link revoked (idempotent)' },
+                    400: { description: 'Invalid, expired, or non-revocable (legacy, no jti) token' },
+                    403: { description: 'Auth failure' },
+                    404: { description: 'Not found / cross-tenant' },
                     503: { description: 'SHARE_SECRET not configured' },
                 },
             },

--- a/app/controllers/sharecontroller.js
+++ b/app/controllers/sharecontroller.js
@@ -8,6 +8,7 @@
 // are HS256 JWTs (jwt.js) keyed by SHARE_SECRET — when it's unset, both
 // endpoints return 503.
 
+const crypto = require('crypto');
 const db = require('../config/db.config.js');
 const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
@@ -56,13 +57,76 @@ exports.createInvoiceShare = async (req, res) => {
     }
 
     const ttl = resolveTtl((req.body || {}).expiresInSec);
-    const token = jwt.sign({ kind: 'invoice', id: invoice.invId }, s, ttl);
+    // A per-link `jti` makes the token individually revocable (#4): revoking
+    // records this jti in RevokedShareLink and the view rejects it.
+    const jti = crypto.randomBytes(16).toString('hex');
+    const token = jwt.sign({ kind: 'invoice', id: invoice.invId, jti }, s, ttl);
     return res.status(201).json({
         message: "Share link created.",
         token,
         path: `/v1/share/invoice?token=${encodeURIComponent(token)}`,
         expiresIn: ttl,
     });
+};
+
+/**
+ * POST /v1/share/revoke — revoke a previously-minted share link before its
+ * `exp` (#4). The caller presents the token; we verify it, confirm the caller
+ * owns the invoice it points at (secure-404), then deny-list its `jti`.
+ * Idempotent: revoking an already-revoked link succeeds.
+ */
+exports.revokeInvoiceShare = async (req, res) => {
+    const authKey = req.get('authKey');
+    if (!authKey) {
+        return res.status(403).json({ message: "Authorization key not sent." });
+    }
+    const s = secret();
+    if (!s) {
+        return res.status(503).json({ message: "Link sharing is not configured." });
+    }
+
+    const payload = jwt.verify(String((req.body || {}).token || ''), s);
+    if (!payload || payload.kind !== 'invoice' || !payload.id || !payload.jti) {
+        // Invalid, already expired, or a legacy token minted without a jti
+        // (those aren't individually revocable — rotate SHARE_SECRET instead).
+        return res.status(400).json({ message: "Invalid, expired, or non-revocable link." });
+    }
+
+    let invoice;
+    try {
+        invoice = await db.Invoice.findByPk(payload.id, { attributes: ['invId', 'invCustId', 'invArch'] });
+    } catch (error) {
+        log.error({ err: error }, 'share revoke: Invoice.findByPk failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+    if (!invoice || invoice.invArch) {
+        return res.status(404).json({ message: "Not found." });
+    }
+
+    const invCompanyId = await GetCompanyIdByCustomerId(invoice.invCustId);
+    const isMaster = await MasterFromReq(req, authKey);
+    let companyId = invCompanyId;
+    if (!isMaster) {
+        companyId = await CompanyIdFromReq(req, authKey);
+        if (companyId === -1 || invCompanyId !== companyId) {
+            return res.status(404).json({ message: "Not found." });
+        }
+    }
+
+    try {
+        await db.RevokedShareLink.findOrCreate({
+            where: { rslJti: payload.jti },
+            defaults: {
+                rslJti: payload.jti,
+                rslCompId: companyId,
+                rslExpiresAt: new Date(payload.exp * 1000),
+            },
+        });
+        return res.status(200).json({ message: "Share link revoked." });
+    } catch (error) {
+        log.error({ err: error }, 'share revoke: deny-list insert failed');
+        return res.status(500).json({ message: "Error!" });
+    }
 };
 
 /** GET /v1/share/invoice?token=... — PUBLIC read-only invoice view. */
@@ -75,6 +139,21 @@ exports.viewInvoice = async (req, res) => {
     const payload = jwt.verify(String(req.query.token || ''), s);
     if (!payload || payload.kind !== 'invoice' || !payload.id) {
         return res.status(401).json({ message: "Invalid or expired link." });
+    }
+
+    // Per-link revocation (#4): a deny-listed jti is dead even though the JWT
+    // still verifies. Same 401 as an invalid token — don't leak revocation.
+    if (payload.jti) {
+        let revoked;
+        try {
+            revoked = await db.RevokedShareLink.findOne({ where: { rslJti: payload.jti }, attributes: ['rslId'] });
+        } catch (error) {
+            log.error({ err: error }, 'share: revocation check failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (revoked) {
+            return res.status(401).json({ message: "Invalid or expired link." });
+        }
     }
 
     let invoice;

--- a/app/migrations/20260706030000-revoked-share-link.js
+++ b/app/migrations/20260706030000-revoked-share-link.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Per-link share-link revocation (#438 / audit item #4). A deny-list of
+// revoked share-token `jti`s: the public invoice view rejects any token whose
+// jti is listed, so a leaked link can be killed before its exp without
+// rotating SHARE_SECRET (which would kill every link). New table in the
+// increment layer; no FK constraints. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'RevokedShareLink', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.createTable(
+                TABLE,
+                {
+                    rslId: { type: Sequelize.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
+                    rslJti: { type: Sequelize.TEXT, allowNull: false },
+                    rslCompId: { type: Sequelize.INTEGER, allowNull: false },
+                    rslExpiresAt: { type: Sequelize.DATE, allowNull: false },
+                    createdAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                    updatedAt: { type: 'timestamp(3) without time zone', allowNull: false, defaultValue: Sequelize.fn('now') },
+                },
+                { transaction: t },
+            );
+            await queryInterface.addIndex(TABLE, { name: 'RevokedShareLink_jti_uidx', unique: true, fields: ['rslJti'], transaction: t });
+            await queryInterface.addIndex(TABLE, { name: 'RevokedShareLink_expires_idx', fields: ['rslExpiresAt'], transaction: t });
+        });
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.dropTable(TABLE);
+    },
+};

--- a/app/models/revokedsharelink.model.js
+++ b/app/models/revokedsharelink.model.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * RevokedShareLink — the deny-list backing per-link share revocation (#438
+ * / audit item #4). Share links are stateless HS256 JWTs, so before this an
+ * individual link could not be killed before its `exp` (≤90 days). Each
+ * minted link now carries a random `jti`; revoking a link records its `jti`
+ * here, and the public view rejects any token whose `jti` is listed.
+ *
+ * rslCompId records the revoking tenant (scope/audit); rslExpiresAt is the
+ * underlying token's expiry so rows can be pruned once the token would have
+ * died on its own anyway.
+ */
+module.exports = (sequelize, Sequelize) => {
+    const RevokedShareLink = sequelize.define('RevokedShareLink', {
+        rslId: {
+            field: 'rslId',
+            type: Sequelize.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        rslJti: {
+            field: 'rslJti',
+            type: Sequelize.TEXT,
+            allowNull: false,
+            unique: true,
+        },
+        rslCompId: {
+            field: 'rslCompId',
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+        rslExpiresAt: {
+            field: 'rslExpiresAt',
+            type: Sequelize.DATE,
+            allowNull: false,
+        },
+    }, {
+        tableName: 'RevokedShareLink',
+        timestamps: true,
+    });
+
+    return RevokedShareLink;
+};

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -989,6 +989,13 @@ router.get(
     v.query(shareSchemas.shareViewQuery),
     share.viewInvoice,
 );
+// Revoke a minted link before its exp (#4). Distinct path (not
+// /invoice/:id) so it never collides with the mint route's :id param.
+router.post(
+    '/v1/share/revoke',
+    v.body(shareSchemas.shareRevokeBody),
+    share.revokeInvoiceShare,
+);
 
 // v1 approval-chain routes (multi-level approval routing, #443).
 // GET /:id/next resolves the next required level/role.

--- a/app/schemas/share.schema.js
+++ b/app/schemas/share.schema.js
@@ -22,4 +22,11 @@ const shareViewQuery = z.object({
     message: 'Unexpected query parameter. Allowed: token.',
 });
 
-module.exports = { intIdParam, shareCreateBody, shareViewQuery };
+/** POST /v1/share/revoke body (#4) — the token to revoke. */
+const shareRevokeBody = z.object({
+    token: z.string().min(1).max(4096),
+}).strict({
+    message: 'Unexpected field in body. Whitelist: token.',
+});
+
+module.exports = { intIdParam, shareCreateBody, shareViewQuery, shareRevokeBody };

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -149,10 +149,15 @@ deliberately **not** implemented autonomously.
    `gdpr.streamRelationArray`) so peak memory is O(batch), not O(total rows) —
    no truncation, so GDPR completeness is preserved. A mid-stream DB error
    truncates the (already-started) response, which the client detects.
-4. **Per-link share revocation.** Share links are stateless JWTs, so an
-   individual link can't be revoked before its `exp` (≤90 days); the only
-   levers are archiving the invoice or rotating `SHARE_SECRET`. Add a
-   `jti` + denylist if individual revocation is required.
+4. **Per-link share revocation — RESOLVED (#590).** Share links are stateless
+   JWTs, so an individual link previously couldn't be revoked before its `exp`
+   (≤90 days) short of archiving the invoice or rotating `SHARE_SECRET` (which
+   kills *every* link). Each minted link now carries a random `jti`; a new
+   tenant-scoped `POST /v1/share/revoke` (present the token → verify invoice
+   ownership → deny-list the jti in the `RevokedShareLink` table), and the
+   public view rejects a deny-listed jti with the same 401 as an invalid token
+   (no revocation-status leak). Revoke is idempotent; legacy pre-`jti` tokens
+   aren't individually revocable (400) — rotate the secret for those.
 5. **Master actions in the tenant audit trail** (informational). A master
    key's mutations set `alogCompId = null`, so they don't appear in the
    affected company's audit view — a completeness gap, not a leak.

--- a/tests/api/openapi.test.js
+++ b/tests/api/openapi.test.js
@@ -59,6 +59,7 @@ describe('OpenAPI spec', () => {
         expect(paths).toContain('/v1/timeentry');
         expect(paths).toContain('/v1/timeentry/{id}');
         expect(paths).toContain('/v1/timeentry/bycompany/{id}');
+        expect(paths).toContain('/v1/share/revoke');
     });
 
     test('spec declares the authKey security scheme', async () => {

--- a/tests/api/share.test.js
+++ b/tests/api/share.test.js
@@ -4,7 +4,7 @@
 // HTTP contract tests for shareable invoice links (#438) — auth, schema,
 // and the SHARE_SECRET gate.
 
-import { describe, test, expect, vi, beforeAll } from 'vitest';
+import { describe, test, expect, vi, beforeAll, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
@@ -12,6 +12,7 @@ vi.mock('../../app/config/db.config.js', () => ({
     sequelize: { query: vi.fn().mockResolvedValue([]), QueryTypes: { SELECT: 'SELECT' } },
     Sequelize: { Op: {} },
     Customer: {}, Worker: {}, BillingType: {}, InventoryItem: {}, Company: {}, Job: {}, Invoice: {}, CustomerPayment: {}, Expense: {}, AuditLog: {}, Task: {}, Retainer: {}, Phase: {}, Role: {}, RecurringInvoice: {}, Webhook: {}, TimeEntry: {}, RateSchedule: {}, Receipt: {}, ReportSchedule: {}, User: {},
+    RevokedShareLink: {},
     ApiKey: {}, ApiMaster: {},
 }));
 
@@ -49,5 +50,42 @@ describe('Shareable invoice links (#438)', () => {
         } finally {
             delete process.env.SHARE_SECRET;
         }
+    });
+});
+
+// Per-link revocation (#4).
+describe('Share-link revocation (#4)', () => {
+    const jwt = require('../../app/services/jwt.js');
+    const db = require('../../app/config/db.config.js');
+    const SECRET = 'unit-test-share-secret';
+    afterEach(() => { delete process.env.SHARE_SECRET; });
+
+    test('POST /v1/share/revoke 403 without authKey', async () => {
+        expect((await request(app).post('/v1/share/revoke').send({ token: 'x' })).status).toBe(403);
+    });
+    test('POST /v1/share/revoke 503 when SHARE_SECRET unset', async () => {
+        expect((await request(app).post('/v1/share/revoke').set('authKey', 'k').send({ token: 'x' })).status).toBe(503);
+    });
+    test('POST /v1/share/revoke 400 on a missing token (schema)', async () => {
+        expect((await request(app).post('/v1/share/revoke').set('authKey', 'k').send({})).status).toBe(400);
+    });
+    test('POST /v1/share/revoke 400 on an invalid/expired token', async () => {
+        process.env.SHARE_SECRET = SECRET;
+        expect((await request(app).post('/v1/share/revoke').set('authKey', 'k').send({ token: 'not.a.jwt' })).status).toBe(400);
+    });
+    test('POST /v1/share/revoke 400 on a legacy token without a jti', async () => {
+        process.env.SHARE_SECRET = SECRET;
+        const legacy = jwt.sign({ kind: 'invoice', id: 1 }, SECRET, 3600); // no jti
+        expect((await request(app).post('/v1/share/revoke').set('authKey', 'k').send({ token: legacy })).status).toBe(400);
+    });
+
+    test('GET view returns 401 when the token jti is deny-listed', async () => {
+        process.env.SHARE_SECRET = SECRET;
+        db.RevokedShareLink.findOne = vi.fn().mockResolvedValue({ rslId: 1 }); // revoked
+        db.Invoice.findByPk = vi.fn(); // must NOT be reached
+        const token = jwt.sign({ kind: 'invoice', id: 1, jti: 'deadbeef' }, SECRET, 3600);
+        const res = await request(app).get(`/v1/share/invoice?token=${encodeURIComponent(token)}`);
+        expect(res.status).toBe(401);
+        expect(db.Invoice.findByPk).not.toHaveBeenCalled();
     });
 });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -320,6 +320,36 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('RevokedShareLink round-trips + enforces a unique jti (share revocation)', async () => {
+        if (!connected) return;
+        const jti = `${SENTINEL}-jti`;
+        const company = await db.Company.create({ compName: `${SENTINEL}-rsl`, compArch: false });
+        try {
+            const [, created] = await db.RevokedShareLink.findOrCreate({
+                where: { rslJti: jti },
+                defaults: { rslJti: jti, rslCompId: company.compId, rslExpiresAt: new Date(Date.now() + 60000) },
+            });
+            expect(created).toBe(true);
+            // The view's revocation check finds it.
+            expect(await db.RevokedShareLink.findOne({ where: { rslJti: jti } })).not.toBeNull();
+            // Revoking again is idempotent — no duplicate.
+            const [, created2] = await db.RevokedShareLink.findOrCreate({
+                where: { rslJti: jti },
+                defaults: { rslJti: jti, rslCompId: company.compId, rslExpiresAt: new Date(Date.now() + 60000) },
+            });
+            expect(created2).toBe(false);
+            // The unique index rejects a raw duplicate insert.
+            let dup = false;
+            try {
+                await db.RevokedShareLink.create({ rslJti: jti, rslCompId: company.compId, rslExpiresAt: new Date(Date.now() + 60000) });
+            } catch (e) { dup = true; }
+            expect(dup).toBe(true);
+        } finally {
+            await db.RevokedShareLink.destroy({ where: { rslJti: jti } });
+            await company.destroy({ force: true });
+        }
+    });
+
     test('IdempotencyKey pending-claim protocol works against the real schema', async () => {
         if (!connected) return;
         const scope = `${SENTINEL}-ik-scope`;


### PR DESCRIPTION
## Summary

Shareable invoice links are stateless HS256 JWTs, so an individual link couldn't be killed before its `exp` (≤90 days) short of archiving the invoice or rotating `SHARE_SECRET` — which kills **every** link. This adds **per-link revocation** (review-log item 4).

- Each minted link now carries a random **`jti`** (`crypto.randomBytes(16)`).
- New **`RevokedShareLink`** table (model + migration): a deny-list of revoked jtis, unique on `rslJti`, with `rslCompId` (revoking tenant) + `rslExpiresAt` (the token's own expiry, for pruning). Increment layer; `setup/*.sql` untouched.
- New **`POST /v1/share/revoke`** (tenant-scoped): present the token → verify it → confirm the caller owns the invoice it points at (**secure-404**) → deny-list its jti. **Idempotent** (`findOrCreate`). Legacy pre-`jti` tokens aren't individually revocable → 400.
- The public view rejects a deny-listed jti with the **same 401** as an invalid token — no revocation-status leak.

## Verification

- **Contract**: revoke 403 (no authKey) / 503 (no secret) / 400 (missing token / invalid / legacy-no-jti).
- **Behavior**: view returns **401 when the jti is deny-listed** and never loads the invoice.
- **Integration** (real Postgres): `RevokedShareLink` round-trips — `findOrCreate` idempotency + the unique-`jti` constraint rejecting a duplicate.
- **OpenAPI** documents `/v1/share/revoke`; the spec-paths test pins it.
- `npm test` → **1779 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/