### PR TITLE
feat(approval): enforce multi-level approval chains (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Multi-level approval chains are now enforced (#591).** Previously an
+  `ApprovalChain` was advisory — the first `approve` fully approved a
+  timesheet, skipping every configured level. A new `TimeEntry.teApprovalLevel`
+  counter tracks cleared levels: for a signed-in (JWT) actor each `approve`
+  checks their role against the next required level (`canApproveAt`) and
+  advances one step; the entry stays `submitted` until the final level clears,
+  only then `approved`. submit/reject reset the counter. An API key keeps full
+  authority (single approve), and a company with no active chain is unchanged.
+  Resolves review-log item 6.
+
 ### Security
 - **Per-link share-link revocation (#590).** Shareable invoice links are
   stateless JWTs, so an individual link couldn't be killed before its `exp`

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -11,6 +11,7 @@ const rate = require('../services/rate.js');
 const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
 const rbac = require('../services/rbac.js');
+const { nextStep, canApproveAt } = require('../services/approval-chain.js');
 const { buildApprovalDigest } = require('../services/approval-reminders.js');
 const { sendMail } = require('../services/mailer.js');
 const { createTimeEntryBody } = require('../schemas/timeentry.schema.js');
@@ -524,8 +525,45 @@ exports.approval = async (req, res) => {
         return res.status(409).json({ message: result.error });
     }
 
+    const updates = { teApprovalStatus: result.status };
+
+    if (action === 'approve') {
+        // Multi-level approval-chain enforcement (#443/#6). A signed-in user
+        // must clear each configured level IN ORDER — one `approve` advances
+        // the entry by a single level, and it only becomes 'approved' once the
+        // final level is cleared. An API key keeps full authority (one approve
+        // → approved, marking the chain fully cleared).
+        let chain = null;
+        try {
+            chain = await db.ApprovalChain.findOne({
+                where: { apchCompId: entry.teCompId, apchActive: true },
+                order: [['apchId', 'ASC']],
+            });
+        } catch (error) {
+            log.error({ err: error }, 'approval: ApprovalChain lookup failed');
+            return res.status(500).json({ message: "Error!" });
+        }
+        if (chain && req.user) {
+            if (!canApproveAt(chain.apchLevels, entry.teApprovalLevel, req.user.userRole)) {
+                return res.status(403).json({
+                    message: "Your role cannot approve the next required level of this timesheet.",
+                });
+            }
+            const newLevel = entry.teApprovalLevel + 1;
+            updates.teApprovalLevel = newLevel;
+            // Stay 'submitted' until every level is cleared.
+            updates.teApprovalStatus = nextStep(chain.apchLevels, newLevel).done ? 'approved' : 'submitted';
+        } else if (chain) {
+            // API key / master: full authority — record the chain as fully cleared.
+            updates.teApprovalLevel = chain.apchLevels.length;
+        }
+    } else if (action === 'submit' || action === 'reject') {
+        // Restart the chain: the next review begins at level 0.
+        updates.teApprovalLevel = 0;
+    }
+
     try {
-        await entry.update({ teApprovalStatus: result.status });
+        await entry.update(updates);
         return res.status(200).json({ message: "Approval updated.", timeEntry: entry });
     } catch (error) {
         log.error({ err: error }, 'approval: TimeEntry.update failed');

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -533,7 +533,7 @@ exports.approval = async (req, res) => {
         // the entry by a single level, and it only becomes 'approved' once the
         // final level is cleared. An API key keeps full authority (one approve
         // → approved, marking the chain fully cleared).
-        let chain = null;
+        let chain;
         try {
             chain = await db.ApprovalChain.findOne({
                 where: { apchCompId: entry.teCompId, apchActive: true },

--- a/app/migrations/20260706040000-timeentry-approval-level.js
+++ b/app/migrations/20260706040000-timeentry-approval-level.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Multi-level approval-chain enforcement (#443 / audit item #6). teApprovalLevel
+// records how many of a company's approval-chain levels a timesheet has
+// cleared; the entry becomes 'approved' only once it reaches the chain's level
+// count. NOT NULL default 0 — Postgres backfills existing rows to 0 (unstarted)
+// when the column is added. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'TimeEntry', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            TABLE, 'teApprovalLevel',
+            { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(TABLE, 'teApprovalLevel');
+    },
+};

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -107,6 +107,16 @@ module.exports = (sequelize, Sequelize) => {
             type: Sequelize.TEXT,
             defaultValue: 'open',
         },
+        teApprovalLevel: {
+            field: 'teApprovalLevel',
+            // How many approval-chain levels have been cleared (#443/#6). 0
+            // until the first level is approved; when it reaches the chain's
+            // level count the entry becomes 'approved'. Reset to 0 on
+            // submit/reject. Irrelevant when the company has no active chain.
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+        },
         teArch: {
             field: 'teArch',
             type: Sequelize.BOOLEAN,

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -161,12 +161,16 @@ deliberately **not** implemented autonomously.
 5. **Master actions in the tenant audit trail** (informational). A master
    key's mutations set `alogCompId = null`, so they don't appear in the
    affected company's audit view — a completeness gap, not a leak.
-6. **Multi-level approval chain is not enforced.** `ApprovalChain` is a
-   standalone advisory calculator; the time-entry approval action calls
-   only `applyAction` (a single `teApprovalStatus` enum) and marks an entry
-   fully approved on the **first** `approve`, skipping every configured
-   level. Enforcing a chain needs per-level approval tracking on the entry
-   (a new counter/table), not just the enum.
+6. **Multi-level approval chain — ENFORCED (#591).** A new
+   `TimeEntry.teApprovalLevel` counter tracks how many of the company's
+   active chain's levels an entry has cleared. For a signed-in (JWT) actor,
+   each `approve` now runs `approval-chain.canApproveAt` (their role must
+   satisfy the next required level) and advances one level via `nextStep`;
+   the entry stays `submitted` until the final level clears, only then
+   `approved`. submit/reject reset the counter to 0. An API key keeps full
+   authority (one approve → approved, chain marked cleared); a company with
+   no active chain is unchanged. The company's active chain (lowest `apchId`
+   if several) governs.
 7. **Should approval gate billing?** After the rejected-exclusion fix,
    `open` / `submitted` time still rolls into invoices — correct for
    companies that don't use the approval feature, but a company that

--- a/tests/api/timeentry-approval.test.js
+++ b/tests/api/timeentry-approval.test.js
@@ -50,8 +50,10 @@ describe('approval — RBAC for a JWT actor (time:approve)', () => {
     // DIFFERENT user, so it's not self-approval unless overridden to ACTOR).
     function mock(actorRole, entryComp = 1, status = 'submitted', workerUserId = 999) {
         db.User = { findByPk: vi.fn().mockResolvedValue({ userId: ACTOR, userCompId: 1, userRole: actorRole, userArch: false }) };
-        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: entryComp, teArch: false, teApprovalStatus: status, teWorkerId: 50, update: vi.fn().mockResolvedValue(undefined) });
+        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: entryComp, teArch: false, teApprovalStatus: status, teApprovalLevel: 0, teWorkerId: 50, update: vi.fn().mockResolvedValue(undefined) });
         db.Worker = { findByPk: vi.fn().mockResolvedValue({ workerUserId }) };
+        // No active approval chain by default → single approve → approved.
+        db.ApprovalChain = { findOne: vi.fn().mockResolvedValue(null) };
     }
     afterEach(() => { delete process.env.JWT_SECRET; });
     const post = () => request(app).post(`/v1/timeentry/${ENTRY}/approval`).set('authorization', `Bearer ${token()}`).send({ action: 'approve' });
@@ -78,5 +80,36 @@ describe('approval — RBAC for a JWT actor (time:approve)', () => {
     test('a manager CAN approve another worker\'s time (worker linked to a different user) → 200', async () => {
         mock('manager', 1, 'submitted', 777); // worker's user != actor
         expect((await post()).status).toBe(200);
+    });
+
+    // Multi-level approval-chain enforcement (#6). A 2-level chain: level 1
+    // manager, level 2 admin. Each approve advances one level; 'approved' only
+    // once the final level clears.
+    const LEVELS = [{ level: 1, approverRole: 'manager' }, { level: 2, approverRole: 'admin' }];
+    function mockChain(actorRole, levels, currentLevel) {
+        const update = vi.fn().mockResolvedValue(undefined);
+        db.User = { findByPk: vi.fn().mockResolvedValue({ userId: ACTOR, userCompId: 1, userRole: actorRole, userArch: false }) };
+        db.TimeEntry.findByPk = vi.fn().mockResolvedValue({ teId: ENTRY, teCompId: 1, teArch: false, teApprovalStatus: 'submitted', teApprovalLevel: currentLevel, teWorkerId: 50, update });
+        db.Worker = { findByPk: vi.fn().mockResolvedValue({ workerUserId: 999 }) };
+        db.ApprovalChain = { findOne: vi.fn().mockResolvedValue({ apchLevels: levels, apchActive: true }) };
+        return update;
+    }
+
+    test('level 1: a manager advances the entry one level but it stays submitted', async () => {
+        const update = mockChain('manager', LEVELS, 0);
+        expect((await post()).status).toBe(200);
+        expect(update).toHaveBeenCalledWith(expect.objectContaining({ teApprovalLevel: 1, teApprovalStatus: 'submitted' }));
+    });
+
+    test('final level: an admin clears level 2 → approved', async () => {
+        const update = mockChain('admin', LEVELS, 1);
+        expect((await post()).status).toBe(200);
+        expect(update).toHaveBeenCalledWith(expect.objectContaining({ teApprovalLevel: 2, teApprovalStatus: 'approved' }));
+    });
+
+    test('a manager cannot approve the admin-required level 2 → 403, no update', async () => {
+        const update = mockChain('manager', LEVELS, 1); // next required level = admin
+        expect((await post()).status).toBe(403);
+        expect(update).not.toHaveBeenCalled();
     });
 });

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -320,6 +320,19 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('TimeEntry.teApprovalLevel column exists with default 0 (approval-chain enforcement)', async () => {
+        if (!connected) return;
+        const rows = await db.sequelize.query(
+            `SELECT data_type, column_default
+               FROM information_schema.columns
+              WHERE table_schema = 'dbo' AND table_name = 'TimeEntry' AND column_name = 'teApprovalLevel'`,
+            { type: db.Sequelize.QueryTypes.SELECT },
+        );
+        expect(rows.length).toBe(1);
+        expect(rows[0].data_type).toBe('integer');
+        expect(String(rows[0].column_default)).toContain('0');
+    });
+
     test('RevokedShareLink round-trips + enforces a unique jti (share revocation)', async () => {
         if (!connected) return;
         const jti = `${SENTINEL}-jti`;

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -355,7 +355,7 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
             let dup = false;
             try {
                 await db.RevokedShareLink.create({ rslJti: jti, rslCompId: company.compId, rslExpiresAt: new Date(Date.now() + 60000) });
-            } catch (e) { dup = true; }
+            } catch (_e) { dup = true; }
             expect(dup).toBe(true);
         } finally {
             await db.RevokedShareLink.destroy({ where: { rslJti: jti } });


### PR DESCRIPTION
## Summary

An `ApprovalChain` defines an ordered list of approver levels a timesheet must clear, but the approval action **ignored it** — the first `approve` marked an entry fully approved, skipping every configured level (review-log item 6). This enforces the chain.

- New **`TimeEntry.teApprovalLevel`** counter (migration + model, NOT NULL default 0): how many of the company's active chain's levels have been cleared.
- On `approve` for a **signed-in (JWT) actor** when the company has an active chain:
  - `approval-chain.canApproveAt(levels, teApprovalLevel, actorRole)` — the actor's role must satisfy the next required level, else **403**;
  - advance one level; the entry stays **`submitted`** until `nextStep` reports the chain done, only then **`approved`**.
- **submit / reject reset** `teApprovalLevel` to 0 (the next review restarts).
- An **API key keeps full authority** (one approve → approved, chain marked cleared); a company with **no active chain is unchanged**.
- The company's active chain (lowest `apchId` if several) governs.

The pure resolver (`approval-chain.js` `nextStep`/`canApproveAt`) already existed and was unit-tested; this wires it into the state machine.

## Verification

- A manager advances level 1 (entry stays `submitted`); an admin clears the final level (`approved`); a manager **cannot** approve an admin-required level (403, no update).
- Existing single-approve JWT (`time:approve`, self-approval) + API-key paths still pass.
- Integration test pins the `teApprovalLevel` column/default against real Postgres.
- `npm test` → **1783 passing**; `npm run lint` clean. Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/