### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-06
+
+The first feature release on top of the 1.0.0 backend baseline: a complete
+track → bill → get-paid platform (invoicing, payments, expenses, retainers,
+reporting), self-service auth with RBAC, an approval workflow, and a
+sustained security-hardening pass. All changes are backward-compatible — the
+API-key path is unchanged; new behavior is additive or gated on the new
+signed-in-user (JWT) actor.
+
 ### Added
 - **Multi-level approval chains are now enforced (#591).** Previously an
   `ApprovalChain` was advisory — the first `approve` fully approved a

--- a/app/config/openapi.js
+++ b/app/config/openapi.js
@@ -435,7 +435,7 @@ const spec = {
     openapi: '3.0.3',
     info: {
         title: 'TimeTrackerAPI',
-        version: pkg.version || '1.0.0',
+        version: pkg.version || '1.1.0',
         description:
             'Open-source Node.js + PostgreSQL TimeTrackerAPI. 16 ' +
             'company-scoped entities (Customer, TimeEntry, Worker, ' +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "TimeTrackerAPI",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "TimeTrackerAPI",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TimeTrackerAPI",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Open-source Node.js + PostgreSQL time-tracking REST API with customer/company-scoped auth, OpenAPI spec, idempotency, and CSV export.",
   "main": "server.js",
   "keywords": [


### PR DESCRIPTION
## Release 1.1.0

The first feature release on top of the 1.0.0 backend baseline. All changes are **backward-compatible** (SemVer **minor**) — the API-key path is unchanged; new behavior is additive or gated on the new signed-in-user (JWT) actor.

### What's in it (highlights)
- **Billing platform**: invoicing (rollup, numbering, PDF, tax/discount/write-off), payments + allocation + AR aging, expenses, retainers, recurring invoices.
- **Auth & RBAC**: self-service signup/login (JWT), password reset, invitations, and RBAC enforcement across the user-management surface + the approval action (with separation-of-duties).
- **Approval workflow**: submit → review → approve, now with **multi-level approval-chain enforcement** (#591).
- **Security hardening** (this arc): idempotency pre-handler claim (no concurrent double-execution), streamed GDPR export (no OOM), per-link share revocation, SSRF/DoS/cross-tenant fixes, all money columns exact-decimal `NUMERIC(14,2)`.

### Mechanics
- `package.json` + `package-lock.json`: `1.0.0` → `1.1.0` (only the project version — no dependency versions touched). `openapi.info.version` reads `pkg.version`, so `/openapi.json` + Swagger report `1.1.0` automatically.
- `CHANGELOG.md`: `[Unreleased]` rolled into `[1.1.0] - 2026-07-06` with a summary.

`npm test` → **1784 passing**; `npm run lint` clean (CI-style, `--max-warnings 0`). Lone failure is the pre-existing `Sequelize authenticates` check. A `v1.1.0` tag + GitHub release follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/