### PR TITLE
feat(rate): snapshot the billing rate on time entries at creation (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Time entries snapshot their billing rate at creation (#593).** A new
+  nullable `TimeEntry.teRateSnapshot` freezes the hourly rate resolved when an
+  entry is created (also on timer-start and copy); `rate.js#resolveHourlyRate`
+  now prefers the snapshot over walking the live rate sources. Editing a rate
+  (billing type, job flat rate, client rate card, role rate, task rate) no
+  longer retroactively re-prices a not-yet-invoiced backlog. An entry with no
+  resolvable rate at creation stores `null` and falls through to live
+  resolution. Resolves review-log item 10.
+
 ## [1.1.0] - 2026-07-06
 
 The first feature release on top of the 1.0.0 backend baseline: a complete

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -7,6 +7,7 @@ const log = require('../config/logger.js');
 const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const { makeBulkCreateIndirect } = require('./_bulk-helpers.js');
+const { rateSourceInclude } = require('../services/rate-source-include.js');
 const money = require('../services/money.js');
 const { buildRollup } = require('../services/invoice-rollup.js');
 const invoiceStatus = require('../services/invoice-status.js');
@@ -340,19 +341,10 @@ exports.rollup = async (req, res) => {
     try {
         entries = await db.TimeEntry.findAll({
             where,
-            include: [
-                { model: db.BillingType, as: 'billingType', required: false },
-                // Job flat rate (#410) — resolveHourlyRate reads entry.job.
-                { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
-                {
-                    model: db.Worker, as: 'worker', required: false,
-                    include: [{ model: db.BillingType, as: 'defaultBillingType', required: false }, { model: db.Role, as: 'role', required: false }],
-                },
-                // Client rate card (#413) — resolveHourlyRate reads entry.customer.
-                { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
-                // Task rate (#411) — the most-specific rate tier.
-                { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
-            ],
+            // The rate sources resolveHourlyRate reads (shared with the
+            // create-time snapshot, #10). teRateSnapshot loads by default, so
+            // a snapshotted entry re-prices from the frozen rate, not live.
+            include: rateSourceInclude(db),
         });
     } catch (error) {
         log.error({ err: error }, 'rollup: TimeEntry.findAll failed');

--- a/app/controllers/timeentrycontroller.js
+++ b/app/controllers/timeentrycontroller.js
@@ -8,6 +8,7 @@ const auth = require('../middleware/auth.js');
 const { buildLinkHeader } = require('../middleware/pagination.js');
 const { buildCsv } = require('./_csv-escape.js');
 const rate = require('../services/rate.js');
+const { rateSourceInclude } = require('../services/rate-source-include.js');
 const { applyAction } = require('../services/approval.js');
 const { lockReason } = require('../services/time-lock.js');
 const rbac = require('../services/rbac.js');
@@ -174,6 +175,26 @@ async function checkEntryLinks({ teWorkerId, teJobId, teBillTypeId, teTaskId }, 
  * Shared by the single-create handler and the bulk importer so both apply
  * identical validation, link checks, and the locked-period guard.
  */
+/**
+ * Best-effort: freeze the entry's resolved hourly rate onto teRateSnapshot
+ * (#10) so a later rate-source edit can't retroactively re-price it. Reloads
+ * the entry with its rate associations, resolves live (the fresh row has a
+ * null snapshot, so no chicken-and-egg), and stores the rate when non-null.
+ * Never throws into the create path — on any failure the entry simply falls
+ * through to live resolution later.
+ */
+async function snapshotEntryRate(entry) {
+    if (!entry) return;
+    try {
+        const withAssoc = await db.TimeEntry.findByPk(entry.teId, { include: rateSourceInclude(db) });
+        if (!withAssoc) return;
+        const resolved = rate.resolveHourlyRate(withAssoc);
+        if (resolved != null) await entry.update({ teRateSnapshot: resolved });
+    } catch (error) {
+        log.warn({ err: error }, 'timeentry: rate snapshot failed');
+    }
+}
+
 async function createOneEntry(companyId, body) {
     const src = body || {};
     const payload = {};
@@ -212,6 +233,7 @@ async function createOneEntry(companyId, body) {
     }
 
     const created = await TimeEntry.create(payload);
+    await snapshotEntryRate(created);
     return { created };
 }
 
@@ -410,6 +432,7 @@ exports.start = async (req, res) => {
 
     try {
         const created = await TimeEntry.create(payload);
+        await snapshotEntryRate(created); // freeze the rate when the timer starts (#10)
         return res.status(201).json({ message: "Timer started.", timeEntry: created });
     } catch (error) {
         log.error({ err: error }, 'timer start: TimeEntry.create failed');
@@ -640,6 +663,7 @@ exports.copy = async (req, res) => {
     };
     try {
         const created = await TimeEntry.create(payload);
+        await snapshotEntryRate(created); // freeze the copy's rate at copy time (#10)
         return res.status(201).json({ message: "Time entry copied.", timeEntry: created });
     } catch (error) {
         log.error({ err: error }, 'copy: TimeEntry.create failed');

--- a/app/migrations/20260706050000-timeentry-rate-snapshot.js
+++ b/app/migrations/20260706050000-timeentry-rate-snapshot.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Rate snapshot on time entries (rate review / audit item #10). teRateSnapshot
+// freezes the hourly rate resolved when the entry was created, so editing a
+// rate source afterwards can't retroactively re-price a not-yet-invoiced
+// backlog. NULLABLE — an entry created before any rate source is resolvable
+// stays null and falls through to live resolution. setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'TimeEntry', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            TABLE, 'teRateSnapshot',
+            { type: Sequelize.DECIMAL(14, 2), allowNull: true },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(TABLE, 'teRateSnapshot');
+    },
+};

--- a/app/models/timeentry.model.js
+++ b/app/models/timeentry.model.js
@@ -117,6 +117,19 @@ module.exports = (sequelize, Sequelize) => {
             allowNull: false,
             defaultValue: 0,
         },
+        teRateSnapshot: {
+            field: 'teRateSnapshot',
+            // The hourly rate frozen when the entry was created (#10). When
+            // set, resolveHourlyRate uses it instead of walking the live rate
+            // sources, so a later rate edit can't re-price the entry. NULL =
+            // no rate was resolvable at creation → fall through to live.
+            type: Sequelize.DECIMAL(14, 2),
+            allowNull: true,
+            get() {
+                const v = this.getDataValue('teRateSnapshot');
+                return v == null ? null : Number(v);
+            },
+        },
         teArch: {
             field: 'teArch',
             type: Sequelize.BOOLEAN,

--- a/app/services/rate-source-include.js
+++ b/app/services/rate-source-include.js
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * rate-source-include.js — the Sequelize `include` that eager-loads exactly
+ * the associations `rate.js#resolveHourlyRate` reads (billingType, task, job,
+ * customer, worker + its defaultBillingType/role). Shared by the invoice
+ * rollup and the create-time rate snapshot (#10) so both resolve a rate from
+ * an identical source set. Takes `db` as an argument to avoid importing the
+ * model registry here (keeps it dependency-light + testable).
+ */
+function rateSourceInclude(db) {
+    return [
+        { model: db.BillingType, as: 'billingType', required: false },
+        { model: db.Job, as: 'job', required: false, attributes: ['jobId', 'jobFlatRate'] },
+        {
+            model: db.Worker, as: 'worker', required: false,
+            include: [
+                { model: db.BillingType, as: 'defaultBillingType', required: false },
+                { model: db.Role, as: 'role', required: false },
+            ],
+        },
+        { model: db.Customer, as: 'customer', required: false, attributes: ['custId', 'custDefaultRate'] },
+        { model: db.Task, as: 'task', required: false, attributes: ['taskId', 'taskRate'] },
+    ];
+}
+
+module.exports = { rateSourceInclude };

--- a/app/services/rate.js
+++ b/app/services/rate.js
@@ -63,6 +63,10 @@ function roleRateOf(worker) {
  */
 function resolveHourlyRate(entry) {
     if (!entry) return null;
+    // A rate frozen at creation (#10) wins over live resolution, so editing a
+    // rate source later cannot retroactively re-price this entry.
+    const snapshot = numOrNull(entry.teRateSnapshot);
+    if (snapshot != null) return snapshot;
     const own = rateOf(entry.billingType);
     if (own != null) return own;
     const taskR = taskRateOf(entry.task);

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -194,15 +194,17 @@ deliberately **not** implemented autonomously.
    call site catches), so this is defense-in-depth — but whether an escaped
    rejection should crash-and-restart or log-and-continue is a deliberate
    operational policy choice, so no global handler was added autonomously.
-10. **No rate snapshot; effective-dating is unwired from billing** (rate
-    review, MED-HIGH). `resolveHourlyRate` reads the *current* rate sources
-    at invoice/report time — nothing is captured on the `TimeEntry` at entry
-    time, and `rate.js` never calls `rate-schedule.js`, so the shipped
-    effective-dating feature influences **no** invoice line and editing a
-    rate retroactively re-prices a not-yet-invoiced backlog. Fixing it is a
-    product+schema decision: snapshot the resolved rate onto the entry at
-    creation, and/or drive resolution through `rateOnDate(entryDate)`. The
-    arithmetic and precedence themselves were verified sound.
+10. **Rate snapshot — RESOLVED (#593).** `resolveHourlyRate` read the
+    *current* rate sources at invoice/report time, so editing a rate
+    retroactively re-priced a not-yet-invoiced backlog. A new nullable
+    `TimeEntry.teRateSnapshot` freezes the rate resolved when the entry is
+    created (via `snapshotEntryRate` on create / timer-start / copy, using the
+    shared `rateSourceInclude`), and `resolveHourlyRate` now prefers the
+    snapshot over live resolution — so a later rate-source edit can no longer
+    re-price the entry. A null snapshot (no rate resolvable at creation) still
+    falls through to live. **Follow-up still open**: full effective-dating
+    driven through `rate-schedule.js#rateOnDate(entryDate)` — the snapshot
+    covers the retroactive-re-pricing risk without the schedule wiring.
 11. **Archiving a rate source silently re-rates entries to a lower tier**
     (rate review, MED). Soft-deleting a referenced rate source (e.g. a
     per-entry `BillingType` override) makes the `required:false` +

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -320,6 +320,38 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('a rate snapshot freezes billing against a later rate-source edit (#10)', async () => {
+        if (!connected) return;
+        const rate = require('../../app/services/rate.js');
+        const { rateSourceInclude } = require('../../app/services/rate-source-include.js');
+        const company = await db.Company.create({ compName: `${SENTINEL}-rate`, compArch: false });
+        const customer = await db.Customer.create({
+            custCompanyName: `${SENTINEL}-rc`, custFName: 'R', custLName: 'S',
+            custCompId: company.compId, custDefaultRate: 100, custArch: false,
+        });
+        const entry = await db.TimeEntry.create({
+            teCompId: company.compId, teCustId: customer.custId, teStartedAt: new Date(),
+            teMinutes: 60, teBillable: true, teArch: false,
+        });
+        try {
+            // Simulate the controller's create-time snapshot: resolve live (client
+            // rate 100), then freeze it onto the entry.
+            const withAssoc = await db.TimeEntry.findByPk(entry.teId, { include: rateSourceInclude(db) });
+            expect(rate.resolveHourlyRate(withAssoc)).toBe(100);
+            await entry.update({ teRateSnapshot: rate.resolveHourlyRate(withAssoc) });
+            // The client rate later changes...
+            await customer.update({ custDefaultRate: 200 });
+            // ...but the entry re-prices from the FROZEN 100, not the live 200.
+            const reloaded = await db.TimeEntry.findByPk(entry.teId, { include: rateSourceInclude(db) });
+            expect(reloaded.teRateSnapshot).toBe(100);
+            expect(rate.resolveHourlyRate(reloaded)).toBe(100);
+        } finally {
+            await entry.destroy({ force: true });
+            await customer.destroy({ force: true });
+            await company.destroy({ force: true });
+        }
+    });
+
     test('TimeEntry.teApprovalLevel column exists with default 0 (approval-chain enforcement)', async () => {
         if (!connected) return;
         const rows = await db.sequelize.query(

--- a/tests/unit/rate.test.js
+++ b/tests/unit/rate.test.js
@@ -11,6 +11,17 @@ const rate = require('../../app/services/rate.js');
 const bt = (r) => ({ btHourlyRate: r });
 
 describe('rate.resolveHourlyRate — precedence', () => {
+    test('a frozen teRateSnapshot wins over every live source (#10)', () => {
+        // Live sources would resolve to 99, but the snapshot (150) freezes it.
+        const entry = { teRateSnapshot: 150, billingType: bt(99), worker: { defaultBillingType: bt(50) } };
+        expect(rate.resolveHourlyRate(entry)).toBe(150);
+    });
+
+    test('a null teRateSnapshot falls through to live resolution', () => {
+        const entry = { teRateSnapshot: null, billingType: bt(99) };
+        expect(rate.resolveHourlyRate(entry)).toBe(99);
+    });
+
     test("entry's own BillingType wins over the worker default", () => {
         const entry = { billingType: bt(150), worker: { defaultBillingType: bt(100) } };
         expect(rate.resolveHourlyRate(entry)).toBe(150);


### PR DESCRIPTION
## Summary

`resolveHourlyRate` read the **current** rate sources at invoice/report time, so editing a rate (billing type, job flat rate, client rate card, role rate, task rate) **retroactively re-priced a not-yet-invoiced backlog** (review-log item 10, MED-HIGH).

- New nullable **`TimeEntry.teRateSnapshot`** (migration + model, `DECIMAL(14,2)` + Number getter) freezes the rate resolved when the entry is created.
- **`snapshotEntryRate()`** reloads the new entry with its rate associations, resolves live, and stores the result — wired into **every creation path** (single create, bulk via `createOneEntry`, timer start, copy). **Best-effort**: a snapshot failure never fails the create; a null result (no rate resolvable yet) leaves the entry to live resolution.
- **`resolveHourlyRate` now prefers `teRateSnapshot`** over live resolution, so a later rate-source edit can't re-price the entry. All callers (rollup, reports) benefit automatically.
- Extracted the rate-source `include` into **`services/rate-source-include.js`**, shared by the snapshot and the invoice rollup (de-dupes + guarantees both resolve from an identical source set).

## Verification

- **Unit**: snapshot wins over live sources; a null snapshot falls through to live.
- **Integration** (real Postgres): freeze 100, edit the client rate to 200 → the entry still prices at **100**, not 200.
- Existing rate / rollup / timeentry / timer / copy suites pass.
- `npm test` → **1789 passing**; `npm run lint` clean (CI-style, `--max-warnings 0`). Lone failure is the pre-existing `Sequelize authenticates` check.

Full effective-dating via `rate-schedule.js#rateOnDate(entryDate)` remains an open follow-up; the snapshot covers the retroactive-re-pricing risk without the schedule wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/