### PR TITLE
feat(ops): process-level safety net for escaped async errors (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Process-level safety net for escaped async errors (#594).** `server.js`
+  installs global handlers: an `unhandledRejection` is logged and the process
+  continues (a stray missed `.catch` shouldn't drop in-flight connections),
+  while an `uncaughtException` is logged then triggers `exit(1)` so a
+  supervisor (systemd/k8s/docker) restarts a clean process. Defense-in-depth —
+  no known live escape path. Resolves review-log item 9.
 - **Time entries snapshot their billing rate at creation (#593).** A new
   nullable `TimeEntry.teRateSnapshot` freezes the hourly rate resolved when an
   entry is created (also on timer-start and copy); `rate.js#resolveHourlyRate`

--- a/app/config/process-safety.js
+++ b/app/config/process-safety.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+"use strict";
+
+/**
+ * process-safety.js — a process-level net for escaped async errors (audit
+ * item #9). The codebase awaits/catches its async, so neither handler is
+ * expected to fire in practice; this is defense-in-depth so an escaped error
+ * is never silent.
+ *
+ * Policy (adjustable by an operator):
+ *   - unhandledRejection → LOG and continue. A single stray missed `.catch`
+ *     shouldn't drop every in-flight connection; Node's default (crash) is the
+ *     more aggressive alternative if fail-fast is preferred.
+ *   - uncaughtException  → LOG then exit(1). After an uncaught throw the
+ *     process may be in a corrupt state, so hand off to a supervisor
+ *     (systemd / k8s / docker) to restart a clean one rather than resume.
+ */
+
+const log = require('./logger.js');
+
+/** Log an escaped promise rejection. Deliberately does NOT exit. */
+function onUnhandledRejection(reason) {
+    log.error({ err: reason }, 'unhandledRejection (no known live escape path; logged as defense-in-depth)');
+}
+
+/** Log an uncaught exception, then exit non-zero for a clean supervised restart. */
+function onUncaughtException(err, exit) {
+    log.error({ err }, 'uncaughtException — exiting(1) for a clean restart');
+    (typeof exit === 'function' ? exit : process.exit)(1);
+}
+
+/**
+ * Register both handlers on `proc` (defaults to the real process). Call once
+ * at startup. Kept out of module top-level so importing this file for tests
+ * does not mutate the global process.
+ */
+function installProcessSafetyNet(proc) {
+    const p = proc || process;
+    p.on('unhandledRejection', onUnhandledRejection);
+    p.on('uncaughtException', (err) => onUncaughtException(err, p.exit ? p.exit.bind(p) : undefined));
+}
+
+module.exports = { onUnhandledRejection, onUncaughtException, installProcessSafetyNet };

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -187,13 +187,14 @@ deliberately **not** implemented autonomously.
    acting user) with a 403. The API-key path stays full-authority. Remaining
    product knob: the approve tier defaults to `manager+` (adjustable), and
    the `workerUserId` link is populated by whoever provisions workers.
-9. **Process-level `unhandledRejection` net.** There is no global
-   `unhandledRejection` / `uncaughtException` handler, so an async rejection
-   that escaped a handler would crash the process on Node ≥ 15. Both the
-   idempotency and PDF reviews confirmed **no live escape path** (every such
-   call site catches), so this is defense-in-depth — but whether an escaped
-   rejection should crash-and-restart or log-and-continue is a deliberate
-   operational policy choice, so no global handler was added autonomously.
+9. **Process-level safety net — RESOLVED (#594).** `server.js` now installs
+   `app/config/process-safety.js`: an `unhandledRejection` is **logged** (and
+   the process continues — a stray missed `.catch` shouldn't drop every
+   in-flight connection), while an `uncaughtException` is **logged then
+   `exit(1)`** so a supervisor restarts a clean process (state may be corrupt
+   after an uncaught throw). Both reviews confirmed **no live escape path**, so
+   this is defense-in-depth. The policy is documented as adjustable (an
+   operator preferring fail-fast can flip the rejection branch).
 10. **Rate snapshot — RESOLVED (#593).** `resolveHourlyRate` read the
     *current* rate sources at invoice/report time, so editing a rate
     retroactively re-priced a not-yet-invoiced backlog. A new nullable

--- a/server.js
+++ b/server.js
@@ -16,6 +16,13 @@ const router = require('./app/routers/router.js');
 const { errorHandler, notFound } = require('./app/middleware/error-handler.js');
 const { metricsMiddleware } = require('./app/middleware/metrics.js');
 const { redactUrl } = require('./app/middleware/redact-url.js');
+const { installProcessSafetyNet } = require('./app/config/process-safety.js');
+
+// Defense-in-depth net for escaped async errors (#9): log an unhandled
+// rejection (continue) and log-then-exit(1) on an uncaught exception so a
+// supervisor restarts a clean process. Installed first so it also covers
+// errors thrown during the rest of startup.
+installProcessSafetyNet();
 
 const app = express();
 

--- a/tests/unit/process-safety.test.js
+++ b/tests/unit/process-safety.test.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Unit tests for the process-level safety net (#9). The handlers are
+// injectable (exit / proc) so we can assert their effects without actually
+// exiting the test runner.
+
+import { describe, test, expect, vi } from 'vitest';
+
+const { onUnhandledRejection, onUncaughtException, installProcessSafetyNet } = require('../../app/config/process-safety.js');
+const log = require('../../app/config/logger.js');
+
+describe('process-safety net (#9)', () => {
+    test('onUncaughtException logs and exits(1) via the injected exit', () => {
+        const exit = vi.fn();
+        const spy = vi.spyOn(log, 'error').mockImplementation(() => {});
+        onUncaughtException(new Error('boom'), exit);
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(spy).toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    test('onUnhandledRejection logs and does NOT exit or throw', () => {
+        const spy = vi.spyOn(log, 'error').mockImplementation(() => {});
+        expect(() => onUnhandledRejection(new Error('stray'))).not.toThrow();
+        expect(spy).toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    test('installProcessSafetyNet registers both handlers; only uncaught exits', () => {
+        const handlers = {};
+        const proc = { on: (evt, fn) => { handlers[evt] = fn; }, exit: vi.fn() };
+        installProcessSafetyNet(proc);
+        expect(typeof handlers.unhandledRejection).toBe('function');
+        expect(typeof handlers.uncaughtException).toBe('function');
+
+        const spy = vi.spyOn(log, 'error').mockImplementation(() => {});
+        handlers.uncaughtException(new Error('x'));
+        expect(proc.exit).toHaveBeenCalledWith(1);
+        // The rejection handler logs but must not exit.
+        handlers.unhandledRejection(new Error('y'));
+        expect(proc.exit).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary

`server.js` had graceful shutdown for `SIGTERM`/`SIGINT` but **no handler** for an `unhandledRejection` / `uncaughtException` — an escaped async rejection would crash the process on Node ≥ 15. Both the idempotency and PDF reviews confirmed **no live escape path**, so this is defense-in-depth (review-log item 9).

- New **`app/config/process-safety.js`**:
  - `unhandledRejection` → **log and continue** (a stray missed `.catch` shouldn't drop every in-flight connection; fail-fast is the documented, adjustable alternative).
  - `uncaughtException` → **log then `exit(1)`** so a supervisor (systemd/k8s/docker) restarts a clean process (state may be corrupt after an uncaught throw).
  - Handlers take an injectable `exit`/`proc` so they **unit-test without exiting the runner**; `installProcessSafetyNet()` is called from `server.js`, not at module top-level (importing the file for tests doesn't mutate the global process).
- `server.js` installs it **first**, so it also covers errors thrown during the rest of startup.

## Verification

- `onUncaughtException` logs + exits(1) via the injected exit; `onUnhandledRejection` logs + does not exit; `installProcessSafetyNet` registers both handlers and only the uncaught path exits.
- `server-boots` still passes (the net install doesn't break booting).
- `npm test` → **1794 passing**; `npm run lint` clean (CI-style, `--max-warnings 0`). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/