### PR TITLE
feat(billing): opt-in approval billing gate (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Opt-in approval billing gate (#595).** A new company flag
+  `compRequireApproval` (default `false`) makes the invoice rollup bill **only
+  `approved` time** — `open`/`submitted`/`rejected` billable time is reported
+  back in `skipped.notApproved` instead of billed. Off by default, so the
+  approval-less flow is unchanged; settable via `PATCH /v1/company/:id`.
+  Resolves review-log item 7.
 - **Process-level safety net for escaped async errors (#594).** `server.js`
   installs global handlers: an `unhandledRejection` is logged and the process
   continues (a stray missed `.catch` shouldn't drop in-flight connections),

--- a/app/controllers/companycontroller.js
+++ b/app/controllers/companycontroller.js
@@ -31,7 +31,7 @@ const CompanyIdFromReq = auth.companyIdFromReq;
 const ALLOWED_FIELDS_CREATE = [
     'compName', 'compAddress1', 'compAddress2', 'compCity',
     'compState', 'compZip', 'compPhone', 'compEmail',
-    'compInvPrefix', 'compInvPad', 'compInvNextSeq', 'compTaxRate', 'compInvFooter', 'compCurrency', 'compTimeLockDate',
+    'compInvPrefix', 'compInvPad', 'compInvNextSeq', 'compTaxRate', 'compInvFooter', 'compCurrency', 'compTimeLockDate', 'compRequireApproval',
 ];
 const ALLOWED_FIELDS_UPDATE = ALLOWED_FIELDS_CREATE;
 

--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -351,11 +351,23 @@ exports.rollup = async (req, res) => {
         return res.status(500).json({ message: "Error!" });
     }
 
-    const { lines, subtotal: timeSubtotal, skipped } = buildRollup(entries);
+    // Opt-in billing gate (#7): when the customer's company requires approval,
+    // only approved time bills — the rest is reported back in skipped.notApproved.
+    let requireApproval;
+    try {
+        const comp = await db.Company.findByPk(custCompanyId, { attributes: ['compRequireApproval'] });
+        requireApproval = !!(comp && comp.compRequireApproval);
+    } catch (error) {
+        log.error({ err: error }, 'rollup: company config load failed');
+        return res.status(500).json({ message: "Error!" });
+    }
+
+    const { lines, subtotal: timeSubtotal, skipped } = buildRollup(entries, { requireApproval });
     const skippedCounts = {
         nonBillable: skipped.nonBillable.length,
         noJob: skipped.noJob.length,
         unresolvedRate: skipped.unresolvedRate.length,
+        notApproved: skipped.notApproved.length,
     };
 
     // Optionally roll the customer's billable, un-invoiced expenses in too

--- a/app/migrations/20260706060000-company-require-approval.js
+++ b/app/migrations/20260706060000-company-require-approval.js
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Opt-in approval billing gate (audit item #7). compRequireApproval, when
+// true, makes the invoice rollup bill ONLY approved time (non-approved
+// billable time is reported back as skipped). NOT NULL default false —
+// existing companies keep the current behavior (approval is a workflow, not a
+// billing gate). setup/*.sql untouched.
+
+'use strict';
+
+const SCHEMA = 'dbo';
+const TABLE = { tableName: 'Company', schema: SCHEMA };
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn(
+            TABLE, 'compRequireApproval',
+            { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn(TABLE, 'compRequireApproval');
+    },
+};

--- a/app/models/company.model.js
+++ b/app/models/company.model.js
@@ -60,6 +60,14 @@ module.exports = (sequelize, Sequelize) => {
             allowNull: false,
             defaultValue: 'USD',
         },
+        compRequireApproval: {
+            field: 'compRequireApproval',
+            // Opt-in billing gate (#7): when true, only approved time rolls
+            // up into invoices. Default false = approval is a workflow only.
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+        },
         compTimeLockDate: {
             field: 'compTimeLockDate',
             // Locked-period cutoff (#441); time on/before this is frozen.

--- a/app/schemas/company.schema.js
+++ b/app/schemas/company.schema.js
@@ -18,8 +18,11 @@ const invNumberingFields = {
     compInvFooter: z.string().max(2000).optional(),
     compCurrency: z.string().regex(/^[A-Z]{3}$/, { message: 'Must be a 3-letter uppercase ISO 4217 code.' }).optional(),
     compTimeLockDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'Must be an ISO 8601 date (YYYY-MM-DD).' }).nullable().optional(),
+    // Opt-in billing gate (#7): when true, only approved time rolls up into
+    // invoices. Strict boolean — no "true"/"false" string coercion.
+    compRequireApproval: z.boolean().optional(),
 };
-const NUMBERING_WHITELIST = ', compInvPrefix, compInvPad, compInvNextSeq, compTaxRate, compInvFooter, compCurrency, compTimeLockDate';
+const NUMBERING_WHITELIST = ', compInvPrefix, compInvPad, compInvNextSeq, compTaxRate, compInvFooter, compCurrency, compTimeLockDate, compRequireApproval';
 
 const createCompanyBody = z.object({
     compName: z.string().min(1).max(255),

--- a/app/services/invoice-rollup.js
+++ b/app/services/invoice-rollup.js
@@ -22,17 +22,23 @@ const rate = require('./rate.js');
 
 /**
  * @param {Array} entries time-entry rows with { teId, teBillable,
- *   teJobId, teMinutes } and eager-loaded rate associations.
+ *   teJobId, teMinutes, teApprovalStatus } and eager-loaded rate associations.
+ * @param {{ requireApproval?: boolean }} [opts] when `requireApproval` is set
+ *   (the company's opt-in billing gate, #7), a billable entry that is not
+ *   `approved` is reported as `skipped.notApproved` instead of being billed.
  * @returns {{ lines: Array<{jobId:number, amount:number, entryIds:number[]}>,
- *   subtotal:number, skipped:{ nonBillable:number[], noJob:number[], unresolvedRate:number[] } }}
+ *   subtotal:number, skipped:{ nonBillable:number[], noJob:number[], unresolvedRate:number[], notApproved:number[] } }}
  */
-function buildRollup(entries) {
+function buildRollup(entries, opts = {}) {
+    const requireApproval = !!(opts && opts.requireApproval);
     const byJob = new Map(); // jobId -> { amounts:[], entryIds:[] }
-    const skipped = { nonBillable: [], noJob: [], unresolvedRate: [] };
+    const skipped = { nonBillable: [], noJob: [], unresolvedRate: [], notApproved: [] };
 
     for (const e of entries || []) {
         if (!e.teBillable) { skipped.nonBillable.push(e.teId); continue; }
         if (e.teJobId == null) { skipped.noJob.push(e.teId); continue; }
+        // Opt-in billing gate: only approved time bills when it's enabled.
+        if (requireApproval && e.teApprovalStatus !== 'approved') { skipped.notApproved.push(e.teId); continue; }
         const amount = rate.billableAmount(e);
         if (amount == null) { skipped.unresolvedRate.push(e.teId); continue; }
         const group = byJob.get(e.teJobId) || { amounts: [], entryIds: [] };

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -171,12 +171,13 @@ deliberately **not** implemented autonomously.
    authority (one approve → approved, chain marked cleared); a company with
    no active chain is unchanged. The company's active chain (lowest `apchId`
    if several) governs.
-7. **Should approval gate billing?** After the rejected-exclusion fix,
-   `open` / `submitted` time still rolls into invoices — correct for
-   companies that don't use the approval feature, but a company that
-   *requires* approval before billing has no such gate. Requiring
-   `approved` would break the default (approval-less) flow, so which
-   policy applies is a per-tenant product decision.
+7. **Approval billing gate — RESOLVED (#595).** The per-tenant decision is
+   now an **opt-in** company flag, `compRequireApproval` (default **false**,
+   so the approval-less flow is unchanged). When a company sets it, the invoice
+   rollup bills only `approved` time — `open` / `submitted` / `rejected`
+   billable time is reported back in `skipped.notApproved` rather than billed.
+   Implemented in the pure `buildRollup(entries, { requireApproval })` so it's
+   exhaustively unit-tested, and surfaced on `PATCH /v1/company/:id`.
 8. **Approver authorization — RESOLVED (#585, #586).** The approval action
    enforces a `time:approve` permission (granted to **manager and up**) for a
    signed-in-user (JWT) actor, scoped to the actor's own company (secure-404),

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -352,6 +352,19 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('Company.compRequireApproval column exists, boolean default false (billing gate #7)', async () => {
+        if (!connected) return;
+        const rows = await db.sequelize.query(
+            `SELECT data_type, column_default
+               FROM information_schema.columns
+              WHERE table_schema = 'dbo' AND table_name = 'Company' AND column_name = 'compRequireApproval'`,
+            { type: db.Sequelize.QueryTypes.SELECT },
+        );
+        expect(rows.length).toBe(1);
+        expect(rows[0].data_type).toBe('boolean');
+        expect(String(rows[0].column_default)).toContain('false');
+    });
+
     test('TimeEntry.teApprovalLevel column exists with default 0 (approval-chain enforcement)', async () => {
         if (!connected) return;
         const rows = await db.sequelize.query(

--- a/tests/unit/invoice-rollup.test.js
+++ b/tests/unit/invoice-rollup.test.js
@@ -59,7 +59,20 @@ describe('invoice-rollup.buildRollup', () => {
     test('empty / all-skipped input yields no lines and a zero subtotal', () => {
         expect(buildRollup([])).toEqual({
             lines: [], subtotal: 0,
-            skipped: { nonBillable: [], noJob: [], unresolvedRate: [] },
+            skipped: { nonBillable: [], noJob: [], unresolvedRate: [], notApproved: [] },
         });
+    });
+
+    test('requireApproval gate: only approved time bills; the rest is notApproved (#7)', () => {
+        const e = (id, status) => ({ teId: id, teBillable: true, teJobId: 1, teMinutes: 60, teApprovalStatus: status, billingType: { btHourlyRate: 100 } });
+        const entries = [e(1, 'approved'), e(2, 'submitted'), e(3, 'open'), e(4, 'rejected')];
+        // Gate OFF (default): approval status is ignored → all four bill.
+        const off = buildRollup(entries);
+        expect(off.lines[0].entryIds.sort()).toEqual([1, 2, 3, 4]);
+        expect(off.skipped.notApproved).toEqual([]);
+        // Gate ON: only the approved entry bills; the other three are notApproved.
+        const on = buildRollup(entries, { requireApproval: true });
+        expect(on.lines[0].entryIds).toEqual([1]);
+        expect(on.skipped.notApproved.sort()).toEqual([2, 3, 4]);
     });
 });


### PR DESCRIPTION
## Summary

After the rejected-exclusion fix, `open`/`submitted` time still rolled into invoices — right for companies that don't use approvals, but a company that **requires** approval before billing had no gate. Making approval a hard gate would break the default flow, so it's now an **opt-in per-tenant flag** (review-log item 7).

- New **`Company.compRequireApproval`** (migration + model, `BOOLEAN NOT NULL default false`). Default `false` → existing behavior unchanged.
- **`buildRollup(entries, { requireApproval })`**: when set, a billable entry whose `teApprovalStatus !== 'approved'` is reported as **`skipped.notApproved`** instead of billed. Pure → exhaustively unit-tested.
- The rollup handler loads the customer company's flag and passes it in; `skippedCounts` gains a `notApproved` count.
- `compRequireApproval` is settable via **`PATCH /v1/company/:id`** (schema whitelist as a strict boolean + controller `ALLOWED_FIELDS`).

## Verification

- `buildRollup` gate **off** (all four approval statuses bill) vs **on** (only `approved` bills; the rest are `notApproved`).
- The empty-input shape test updated for the new `skipped` key.
- Integration test pins the boolean column + `default false` against real Postgres.
- `npm test` → **1797 passing**; `npm run lint` clean (CI-style, `--max-warnings 0`). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/