### PR TITLE
security(idempotency): harden the claim state machine (#588 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Idempotency claim hardening (#588 follow-up).** An adversarial review of
+  the pre-handler claim surfaced three low-severity / latent missing-guard
+  cases, now closed: (1) `completeClaim` gains an `ikResponseStatus IS NULL`
+  ownership guard so a handler that overran `PENDING_TTL` can no longer
+  overwrite a row another request already re-claimed and completed; (2) a
+  successful **non-JSON** 2xx response now *completes* the claim (null body)
+  instead of releasing it, so a future non-`res.json` POST can't be
+  re-executed by a retry; (3) `res.json(undefined)` on a 2xx caches JSON
+  `null` instead of throwing on the bound `:body` replacement and wedging the
+  key as pending. The atomic-claim state machine itself was verified correct
+  against real Sequelize.
+
 ### Added
 - **Opt-in approval billing gate (#595).** A new company flag
   `compRequireApproval` (default `false`) makes the invoice rollup bill **only

--- a/app/middleware/idempotency.js
+++ b/app/middleware/idempotency.js
@@ -296,13 +296,17 @@ async function idempotency(req, res, next) {
                 SET "ikResponseStatus" = :status,
                     "ikResponseBody" = :body::jsonb,
                     "ikExpiresAt" = :expiresAt
-              WHERE "ikScope" = :scope AND "ikKey" = :key`,
+              WHERE "ikScope" = :scope AND "ikKey" = :key
+                AND "ikResponseStatus" IS NULL`,
             {
                 replacements: {
                     scope,
                     key: rawKey,
                     status,
-                    body: JSON.stringify(body),
+                    // A bound `undefined` replacement throws in Sequelize, which
+                    // would leave the row stuck pending; cache JSON `null` so a
+                    // no-body 2xx still completes (and replays as null).
+                    body: body === undefined ? 'null' : JSON.stringify(body),
                     expiresAt: new Date(Date.now() + TTL_MS),
                 },
             },
@@ -331,9 +335,17 @@ async function idempotency(req, res, next) {
         return originalJson(body);
     };
     // If the response finishes WITHOUT going through res.json (a non-JSON
-    // send, a dropped connection, or an error that bypasses res.json),
-    // release the pending claim so the key isn't stuck until PENDING_TTL.
-    res.on('finish', () => { if (!settled) releaseClaim(); });
+    // send, or an error that bypasses res.json), decide by status: a 2xx/4xx
+    // still SUCCEEDED, so COMPLETE with a null body — that prevents a retry
+    // from re-executing the side effect (we just can't replay the exact body).
+    // Only a 5xx releases the claim so a genuine retry re-runs. (An aborted
+    // connection never fires `finish`; that pending row clears at PENDING_TTL.)
+    res.on('finish', () => {
+        if (settled) return;
+        const status = res.statusCode || 0;
+        if (status >= 200 && status < 500) completeClaim(status, null);
+        else releaseClaim();
+    });
 
     return next();
 }

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -143,7 +143,11 @@ behavior, with the rationale recorded). Nothing in this list remains open.
    same key+body gets `409 idempotency_in_progress` while the holder is live,
    replays once it completes, or `409 idempotency_key_reused` on a body
    mismatch. Nullable `ikResponseStatus`/`ikResponseBody` migration backs the
-   pending state.
+   pending state. A later adversarial review verified the atomic-claim machine
+   correct against real Sequelize and hardened three low/latent missing-guard
+   cases (#597): an `ikResponseStatus IS NULL` ownership guard on complete, a
+   non-JSON 2xx completing rather than releasing, and an `undefined` body
+   caching as JSON null.
 3. **Streamed GDPR export — RESOLVED (#589).** `exportCustomer` previously
    issued seven un-`limit`ed parallel `findAll`s and buffered the lot — an
    OOM/DoS vector for a very large customer. It now **streams** the same JSON

--- a/tests/api/idempotency.test.js
+++ b/tests/api/idempotency.test.js
@@ -14,7 +14,7 @@
 // Full first-write-then-replay coverage requires a real DB and lives
 // in the integration suite (gated behind P5-M).
 
-import { describe, test, expect, vi, beforeAll } from 'vitest';
+import { describe, test, expect, vi, beforeAll, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
@@ -320,5 +320,87 @@ describe('Idempotency middleware: bounded canonicalJson (DoS defense)', () => {
         // Don't assert on body.code — the controller emits whatever
         // it emits; we only care the depth check stayed silent.
         expect(res.body && res.body.code).not.toBe('body_too_deep');
+    });
+});
+
+// Hardening from the adversarial review of #588. Drives the middleware over a
+// tiny app so the non-JSON / undefined-body / 5xx exit paths are reachable
+// (the real routers all reply via res.json). The stub's UPDATE honors the new
+// `ikResponseStatus IS NULL` ownership guard, and DELETE the release guard.
+describe('Idempotency claim guards (#588 hardening)', () => {
+    const idem = require('../../app/middleware/idempotency.js');
+    function claimStub() {
+        const store = new Map();
+        const seenSql = [];
+        const kf = (r) => `${r.scope}::${r.key}`;
+        return {
+            store, seenSql,
+            sequelize: {
+                query: vi.fn(async (sql, opts) => {
+                    seenSql.push(sql);
+                    const r = (opts && opts.replacements) || {};
+                    if (/^INSERT/.test(sql)) {
+                        const k = kf(r); const cur = store.get(k); const now = Date.now();
+                        const pend = r.pendingExpiry && r.pendingExpiry.getTime ? r.pendingExpiry.getTime() : now + 300000;
+                        if (!cur || cur.expiresAt < now) { store.set(k, { requestHash: r.requestHash, status: null, body: null, expiresAt: pend }); return [[{ ikId: 1 }]]; }
+                        return [[]];
+                    }
+                    if (/^SELECT/.test(sql)) { const cur = store.get(kf(r)); return cur && cur.expiresAt >= Date.now() ? [cur] : []; }
+                    if (/^UPDATE/.test(sql)) {
+                        const cur = store.get(kf(r));
+                        // Ownership guard: only complete a row we still hold as pending.
+                        if (cur && cur.status == null) { cur.status = r.status; cur.body = JSON.parse(r.body); cur.expiresAt = Date.now() + 86400000; }
+                        return [[], {}];
+                    }
+                    if (/^DELETE/.test(sql)) {
+                        if (/ikResponseStatus" IS NULL/.test(sql)) { const cur = store.get(kf(r)); if (cur && cur.status == null) store.delete(kf(r)); }
+                        return [[], {}];
+                    }
+                    return [[], {}];
+                }),
+            },
+            Sequelize: { QueryTypes: { SELECT: 'SELECT' } },
+        };
+    }
+    function miniApp(handler) {
+        const a = express();
+        a.use(express.json());
+        a.post('/x', idem.idempotency, handler);
+        return a;
+    }
+    afterEach(() => idem._setDbForTesting(null));
+
+    test('the completeClaim UPDATE carries the ownership guard (ikResponseStatus IS NULL)', async () => {
+        const stub = claimStub(); idem._setDbForTesting(stub);
+        await request(miniApp((req, res) => res.status(201).json({ ok: 1 })))
+            .post('/x').set('authKey', 'k').set('Idempotency-Key', 'k-guard').send({ a: 1 });
+        const upd = stub.seenSql.find((s) => /^UPDATE/.test(s));
+        expect(upd).toMatch(/"ikResponseStatus" IS NULL/);
+    });
+
+    test('res.json(undefined) on a 2xx completes the claim as null (not stuck pending)', async () => {
+        const stub = claimStub(); idem._setDbForTesting(stub);
+        const res = await request(miniApp((req, res2) => res2.status(200).json(undefined)))
+            .post('/x').set('authKey', 'k').set('Idempotency-Key', 'k-undef').send({ a: 1 });
+        expect(res.status).toBe(200);
+        const row = [...stub.store.values()][0];
+        expect(row.status).toBe(200);
+        expect(row.body).toBeNull(); // cached as JSON null, not stuck at null-status
+    });
+
+    test('a non-JSON 2xx (res.end) completes the claim so a retry cannot re-execute', async () => {
+        const stub = claimStub(); idem._setDbForTesting(stub);
+        await request(miniApp((req, res) => res.status(200).end('OK')))
+            .post('/x').set('authKey', 'k').set('Idempotency-Key', 'k-nonjson').send({ a: 1 });
+        const row = [...stub.store.values()][0];
+        expect(row).toBeTruthy();     // NOT released
+        expect(row.status).toBe(200); // completed by the finish handler
+    });
+
+    test('a 5xx with no JSON releases the claim so a retry re-runs', async () => {
+        const stub = claimStub(); idem._setDbForTesting(stub);
+        await request(miniApp((req, res) => res.status(500).end('boom')))
+            .post('/x').set('authKey', 'k').set('Idempotency-Key', 'k-5xx').send({ a: 1 });
+        expect(stub.store.size).toBe(0); // released
     });
 });


### PR DESCRIPTION
## Summary

An **adversarial review** of the pre-handler idempotency claim (#588) verified the atomic-claim machine **correct** against real Sequelize (raw `INSERT…RETURNING` returns `[rows, count]`, so claim detection is sound; replay / 409 branches / re-claim-past-TTL / `settled` guard / parameterization / depth guard all correct). It surfaced **three low-severity / latent missing-guard cases**, now fixed:

1. **`completeClaim` gains `AND "ikResponseStatus" IS NULL`** — a handler that overran `PENDING_TTL` (>5 min) could otherwise overwrite a row a second request had already re-claimed and completed, with stale data.
2. **A successful non-JSON 2xx response now COMPLETES the claim** (null body) via the finish handler instead of releasing it, so a future non-`res.json` POST can't be re-executed by a retry. 5xx still releases.
3. **`res.json(undefined)` on a 2xx caches JSON `null`** instead of passing `undefined` to the bound `:body` replacement (which throws in Sequelize and left the key wedged pending until TTL).

All three are **latent** in the current codebase (every POST controller replies via `res.json` with an object; the sole `res.write` path is a GET the middleware skips), so **no behavior change for existing routes** — this is defense-in-depth for the payment-critical path.

## Verification

- The UPDATE carries the ownership guard; `res.json(undefined)` completes as null; a non-JSON 2xx completes (not released); a 5xx releases. Driven over a tiny Express app so the non-`res.json` exit paths are reachable.
- `npm test` → **1801 passing**; `npm run lint` clean (CI-style). Lone failure is the pre-existing `Sequelize authenticates` check.

Part of the post-arc adversarial review (RBAC/auth, approval+rate, share/GDPR/gate all came back clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/