### PR TITLE
feat(rbac): accept a JWT actor on the invitation read/remove endpoints (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **JWT-actor RBAC on the invitation read/remove endpoints (#598).**
+  `GET /v1/invitation/bycompany/:id` (needs `user:read`) and
+  `DELETE /v1/invitation/:id` (needs `user:write`) now accept a signed-in user
+  as well as an API key, scoped to the actor's own company (403 / secure-404) —
+  matching the fully JWT-aware user-management surface. Closes the
+  over-restrictive gap the post-arc adversarial review flagged. The API-key
+  path is unchanged.
+
 ### Fixed
 - **Idempotency claim hardening (#588 follow-up).** An adversarial review of
   the pre-handler claim surfaced three low-severity / latent missing-guard

--- a/app/controllers/invitationcontroller.js
+++ b/app/controllers/invitationcontroller.js
@@ -180,9 +180,8 @@ exports.accept = async (req, res) => {
 
 /** GET /v1/invitation/bycompany/:id — list a company's invitations (no token hash). */
 exports.listByCompany = async (req, res) => {
-    const authKey = req.get('authKey');
-    if (!authKey) {
-        return res.status(403).json({ message: "Authorization key not sent." });
+    if (!req.user && !req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization required." });
     }
 
     const targetCompanyId = Number(req.params.id);
@@ -190,11 +189,18 @@ exports.listByCompany = async (req, res) => {
         return res.status(400).json({ message: "Invalid company id." });
     }
 
-    const isMaster = await MasterFromReq(req, authKey);
-    if (!isMaster) {
-        const companyId = await CompanyIdFromReq(req, authKey);
-        if (companyId === -1 || companyId !== targetCompanyId) {
+    if (req.user) {
+        // Signed-in user: needs read permission + can only list its OWN company.
+        if (!rbac.canReadUsers(req.user.userRole) || targetCompanyId !== req.user.userCompId) {
             return res.status(403).json({ message: "Invalid Authorization Key." });
+        }
+    } else {
+        const isMaster = await MasterFromReq(req, req.get('authKey'));
+        if (!isMaster) {
+            const companyId = await CompanyIdFromReq(req, req.get('authKey'));
+            if (companyId === -1 || companyId !== targetCompanyId) {
+                return res.status(403).json({ message: "Invalid Authorization Key." });
+            }
         }
     }
 
@@ -222,8 +228,8 @@ exports.listByCompany = async (req, res) => {
 
 /** DELETE /v1/invitation/:id — revoke (soft-delete). Company-scoped, secure-404. */
 exports.remove = async (req, res) => {
-    if (!req.get('authKey')) {
-        return res.status(403).json({ message: "Authorization key not sent." });
+    if (!req.user && !req.get('authKey')) {
+        return res.status(403).json({ message: "Authorization required." });
     }
 
     let invite;
@@ -236,11 +242,21 @@ exports.remove = async (req, res) => {
     if (!invite || invite.invtArch) {
         return res.status(404).json({ message: "Not found." });
     }
-    const isMaster = await MasterFromReq(req, req.get('authKey'));
-    if (!isMaster) {
-        const companyId = await CompanyIdFromReq(req, req.get('authKey'));
-        if (companyId === -1 || invite.invtCompId !== companyId) {
+    if (req.user) {
+        // Signed-in user: own company (secure-404) + manage-users permission.
+        if (invite.invtCompId !== req.user.userCompId) {
             return res.status(404).json({ message: "Not found." });
+        }
+        if (!rbac.canManageUsers(req.user.userRole)) {
+            return res.status(403).json({ message: "Insufficient role to revoke invitations." });
+        }
+    } else {
+        const isMaster = await MasterFromReq(req, req.get('authKey'));
+        if (!isMaster) {
+            const companyId = await CompanyIdFromReq(req, req.get('authKey'));
+            if (companyId === -1 || invite.invtCompId !== companyId) {
+                return res.status(404).json({ message: "Not found." });
+            }
         }
     }
 

--- a/tests/api/invitation.test.js
+++ b/tests/api/invitation.test.js
@@ -3,7 +3,7 @@
 //
 // HTTP contract tests for /v1/invitation (#458) — auth + schema.
 
-import { describe, test, expect, vi, beforeAll } from 'vitest';
+import { describe, test, expect, vi, beforeAll, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
@@ -48,5 +48,37 @@ describe('Invitation auth + schema contract (#458)', () => {
     });
     test('DELETE /:id 403 without authKey', async () => {
         expect((await request(app).delete('/v1/invitation/1')).status).toBe(403);
+    });
+});
+
+// JWT-actor RBAC on the invitation read/remove endpoints (surface consistency
+// with the user endpoints). canReadUsers = user:read (all roles); canManageUsers
+// = user:write (admin/owner).
+describe('Invitation — RBAC for a JWT actor (#458)', () => {
+    const jwt = require('../../app/services/jwt.js');
+    const db = require('../../app/config/db.config.js');
+    const SECRET = 'test-secret';
+    const ACTOR = 100; const INVITE = 7;
+
+    function token() { process.env.JWT_SECRET = SECRET; return jwt.sign({ sub: ACTOR, userCompId: 1 }, SECRET, 3600); }
+    function mockActor(role) { db.User.findByPk = vi.fn().mockResolvedValue({ userId: ACTOR, userCompId: 1, userRole: role, userArch: false }); }
+    function mockInvite(comp = 1) { db.Invitation.findByPk = vi.fn().mockResolvedValue({ invtId: INVITE, invtCompId: comp, invtArch: false, update: vi.fn().mockResolvedValue(undefined) }); }
+    afterEach(() => { delete process.env.JWT_SECRET; });
+    const bearer = () => ({ authorization: `Bearer ${token()}` });
+
+    test('listByCompany: own company 200 (a member may read), other company 403', async () => {
+        mockActor('member');
+        db.Invitation.findAndCountAll = vi.fn().mockResolvedValue({ count: 0, rows: [] });
+        expect((await request(app).get('/v1/invitation/bycompany/1').set(bearer())).status).toBe(200);
+        expect((await request(app).get('/v1/invitation/bycompany/2').set(bearer())).status).toBe(403);
+    });
+
+    test('remove: an admin revokes (200); a member cannot (403); cross-company is secure-404', async () => {
+        mockActor('admin'); mockInvite(1);
+        expect((await request(app).delete(`/v1/invitation/${INVITE}`).set(bearer())).status).toBe(200);
+        mockActor('member'); mockInvite(1); // user:write is admin/owner only
+        expect((await request(app).delete(`/v1/invitation/${INVITE}`).set(bearer())).status).toBe(403);
+        mockActor('admin'); mockInvite(2);  // invite in another company
+        expect((await request(app).delete(`/v1/invitation/${INVITE}`).set(bearer())).status).toBe(404);
     });
 });


### PR DESCRIPTION
## Summary

The post-arc adversarial review noted the invitation `listByCompany`/`remove` endpoints were **over-restrictive**: unlike the fully JWT-aware user surface (#584), they accepted API keys only, so a signed-in user (Bearer JWT) always got 403. This extends them to match, using the same `attachUser` + `rbac` mechanism.

- **`GET /v1/invitation/bycompany/:id`**: a JWT actor needs `user:read` (`canReadUsers`, all roles) and can only list its **own** company (else 403).
- **`DELETE /v1/invitation/:id`**: a JWT actor needs `user:write` (`canManageUsers`, admin/owner) and its own company (**secure-404** cross-company).
- The **API-key path (full authority) is unchanged**; `create` already had a JWT branch (#583).

Not a security hole (the old behavior was strictly *more* restrictive) — a surface-consistency fix so a signed-in admin can manage invitations the same way it manages users. The `invtRole` data-quality note from the same review is already covered: `invitation.schema` enforces `invtRole: z.enum(ROLES)` at the validation boundary, so an invalid role 400s before the controller.

## Verification

- `listByCompany` own-company 200 (a member may read) / other-company 403; `remove` admin 200 / member 403 / cross-company secure-404.
- `npm test` → **1803 passing**; `npm run lint` clean (CI-style). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/