### PR TITLE
fix(money): convert polPrice DOUBLE→NUMERIC(14,2) + guard against float money

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is unchanged.
 
 ### Fixed
+- **`polPrice` is now exact-decimal money (#587 follow-up).** The
+  purchase-order-line unit price (a money value; negative lines are inline
+  credits) was left as `DOUBLE` when its sibling money columns (`cpayAmount`,
+  `injbAmount`) were converted — a **convention-guard audit** surfaced it.
+  Converted to `NUMERIC(14,2)` with a Number getter and a magnitude bound on
+  the schema. A new model guard (`money-column-types.test.js`) fails if any
+  column uses float storage except the two allowlisted fractional quantities
+  (`invitQty`, `polQty`), so this can't recur.
 - **Idempotency claim hardening (#588 follow-up).** An adversarial review of
   the pre-handler claim surfaced three low-severity / latent missing-guard
   cases, now closed: (1) `completeClaim` gains an `ikResponseStatus IS NULL`

--- a/app/migrations/20260706070000-po-line-price-numeric.js
+++ b/app/migrations/20260706070000-po-line-price-numeric.js
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Storage consistency (follow-up to #587). polPrice is a per-unit money value
+// (a PurchaseOrderLine price; negative lines are inline credits) that was left
+// as DOUBLE when its sibling money columns — cpayAmount, injbAmount — were
+// converted to NUMERIC(14,2). Bring it in line so every money column is
+// exact-decimal at rest. Behaviour-preserving (no rollup computes with it yet;
+// the schema bounds the magnitude). setup/*.sql untouched.
+//
+// polQty (PurchaseOrderLines) and invitQty (InventoryItem) stay DOUBLE on
+// purpose: they are fractional QUANTITIES, not money.
+
+'use strict';
+
+const TABLE = '"dbo"."PurchaseOrderLines"';
+
+module.exports = {
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async up(queryInterface) {
+        await queryInterface.sequelize.query(
+            `ALTER TABLE ${TABLE} ALTER COLUMN "polPrice" TYPE numeric(14,2) USING "polPrice"::numeric(14,2);`,
+        );
+    },
+
+    /** @param {import('sequelize').QueryInterface} queryInterface */
+    async down(queryInterface) {
+        await queryInterface.sequelize.query(
+            `ALTER TABLE ${TABLE} ALTER COLUMN "polPrice" TYPE double precision USING "polPrice"::double precision;`,
+        );
+    },
+};

--- a/app/models/purchaseorderline.model.js
+++ b/app/models/purchaseorderline.model.js
@@ -23,7 +23,19 @@ module.exports = (sequelize, Sequelize) => {
         polpoh:       { field: 'polpoh',      type: Sequelize.INTEGER, allowNull: false },
         polItemDesc:  { field: 'polItemDesc', type: Sequelize.TEXT, allowNull: false },
         polQty:       { field: 'polQty',      type: Sequelize.DOUBLE, allowNull: false },
-        polPrice:     { field: 'polPrice',    type: Sequelize.DOUBLE, allowNull: false },
+        polPrice: {
+            field: 'polPrice',
+            // Per-unit money value (negative = inline credit). NUMERIC(14,2)
+            // with a Number getter, matching every other money column —
+            // exact-decimal at rest. polQty (below) stays DOUBLE: it's a
+            // fractional quantity, not money.
+            type: Sequelize.DECIMAL(14, 2),
+            allowNull: false,
+            get() {
+                const v = this.getDataValue('polPrice');
+                return v == null ? null : Number(v);
+            },
+        },
         polInvtId:    { field: 'polInvtId',   type: Sequelize.INTEGER, allowNull: false },
         polArch:      { field: 'polArch',     type: Sequelize.BOOLEAN, defaultValue: false },
     }, {

--- a/app/schemas/purchaseorderline.schema.js
+++ b/app/schemas/purchaseorderline.schema.js
@@ -25,7 +25,8 @@ const polQtyField = z.coerce.number().finite({
 });
 const polPriceField = z.coerce.number().finite({
     message: 'polPrice must be a finite number.',
-});
+}).min(-999999999.99, { message: 'polPrice is out of range.' })
+    .max(999999999.99, { message: 'polPrice is out of range.' });
 
 const createBody = z.object({
     polpoh: z.coerce.number().int().positive(),

--- a/docs/SECURITY-REVIEW-LOG.md
+++ b/docs/SECURITY-REVIEW-LOG.md
@@ -232,8 +232,10 @@ behavior, with the rationale recorded). Nothing in this list remains open.
     NO resolvable tier is reported in `skipped.unresolvedRate` at rollup, never
     silently dropped. (The
     `DOUBLE`-vs-`NUMERIC` storage inconsistency — `btHourlyRate`, `cpayAmount`,
-    `injbAmount` — was **resolved in #587**: all three are now `NUMERIC(14,2)`
-    with a Number getter, so every money column is exact-decimal at rest.
+    `injbAmount` — was **resolved in #587** (and the missed sibling `polPrice`
+    in the #602 follow-up, found by a convention-guard audit): all money
+    columns are now `NUMERIC(14,2)` with a Number getter — exact-decimal at
+    rest, enforced by `money-column-types.test.js`.
     Remaining minor: `$0` is only settable at the BillingType tier — a
     validation-symmetry choice.)
 12. **Team utilization can exceed 100% — DECIDED (keep, by design).** Team

--- a/tests/integration/db-roundtrip.test.js
+++ b/tests/integration/db-roundtrip.test.js
@@ -352,6 +352,20 @@ describe.skipIf(!HAS_DB)('integration: real PG round-trip', () => {
         }
     });
 
+    test('PurchaseOrderLines.polPrice is NUMERIC(14,2) — money is exact-decimal', async () => {
+        if (!connected) return;
+        const rows = await db.sequelize.query(
+            `SELECT data_type, numeric_precision, numeric_scale
+               FROM information_schema.columns
+              WHERE table_schema = 'dbo' AND table_name = 'PurchaseOrderLines' AND column_name = 'polPrice'`,
+            { type: db.Sequelize.QueryTypes.SELECT },
+        );
+        expect(rows.length).toBe(1);
+        expect(rows[0].data_type).toBe('numeric');
+        expect(Number(rows[0].numeric_precision)).toBe(14);
+        expect(Number(rows[0].numeric_scale)).toBe(2);
+    });
+
     test('Company.compRequireApproval column exists, boolean default false (billing gate #7)', async () => {
         if (!connected) return;
         const rows = await db.sequelize.query(

--- a/tests/unit/money-column-types.test.js
+++ b/tests/unit/money-column-types.test.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Aaron K. Clark
+//
+// Convention guard: money is stored exact-decimal, never as a float. Every
+// money column is DECIMAL/NUMERIC; the ONLY columns permitted to use a
+// floating-point type are fractional QUANTITIES (which are not money). This
+// prevents re-introducing the float-storage precision bug fixed in #587 / the
+// polPrice follow-up.
+
+import { describe, test, expect } from 'vitest';
+
+const db = require('../../app/config/db.config.js');
+
+describe('money columns are exact-decimal (no float storage)', () => {
+    // The only floating-point columns allowed. Both are fractional quantities,
+    // not money. Adding an entry here is a conscious "this is a non-money
+    // quantity" decision — which is the point: a new float column must be
+    // classified, not slip in silently.
+    const ALLOWED_FLOAT = new Set([
+        'InventoryItem.invitQty',      // stock quantity
+        'PurchaseOrderLine.polQty',    // order-line quantity
+    ]);
+
+    function typeKey(attr) {
+        return String((attr.type && attr.type.key) || (attr.type && attr.type.constructor && attr.type.constructor.key) || attr.type);
+    }
+
+    test('no model column uses DOUBLE/FLOAT/REAL except the allowlisted quantities', () => {
+        const offenders = [];
+        for (const name of Object.keys(db)) {
+            const model = db[name];
+            if (!model || !model.rawAttributes) continue;
+            for (const col of Object.keys(model.rawAttributes)) {
+                const t = typeKey(model.rawAttributes[col]);
+                if (/FLOAT|DOUBLE|REAL/i.test(t) && !ALLOWED_FLOAT.has(`${name}.${col}`)) {
+                    offenders.push(`${name}.${col} :: ${t}`);
+                }
+            }
+        }
+        // If this fails, a column uses float storage. Money MUST be DECIMAL(14,2)
+        // (see app/services/money.js + the migration convention); a genuinely
+        // fractional non-money quantity may be added to ALLOWED_FLOAT above.
+        expect(offenders).toEqual([]);
+    });
+
+    test('known money columns are DECIMAL', () => {
+        const money = [
+            ['BillingType', 'btHourlyRate'], ['Job', 'jobFlatRate'], ['Customer', 'custDefaultRate'],
+            ['Role', 'roleRate'], ['Task', 'taskRate'], ['CustomerPayment', 'cpayAmount'],
+            ['InvoiceJob', 'injbAmount'], ['Expense', 'expAmount'], ['PurchaseOrderLine', 'polPrice'],
+            ['Invoice', 'invSubtotal'], ['Invoice', 'invTotal'], ['Retainer', 'retAmount'],
+        ];
+        for (const [model, col] of money) {
+            expect(typeKey(db[model].rawAttributes[col])).toBe('DECIMAL');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Writing a **convention guard** (a test that every money column is exact-decimal) surfaced a **real miss**: `PurchaseOrderLine.polPrice` — a per-unit money value (negative lines are inline credits) — was still `DOUBLE`, left behind when its sibling money columns `cpayAmount` / `injbAmount` were converted to `NUMERIC(14,2)` in #587. No rollup computes with it *yet*, so nothing was corrupted, but a price stored as float can round-trip imprecisely and breaks the money convention.

- **Migration**: `PurchaseOrderLines.polPrice` `DOUBLE → numeric(14,2)` (`USING` cast; `down` reverts). `setup/*.sql` untouched.
- **Model**: `DECIMAL(14,2)` + a Number getter, matching every other money column.
- **Schema**: bounds `polPrice` to ±`999,999,999.99` (allowing negative credits) so it can't overflow `money.toCents` if a total is ever computed.
- **New guard** `tests/unit/money-column-types.test.js`: **fails** if any model column uses `DOUBLE/FLOAT/REAL` except the two allowlisted fractional **quantities** (`InventoryItem.invitQty`, `PurchaseOrderLine.polQty`), and pins the known money columns as `DECIMAL`. This is why the miss can't recur.

`polQty` / `invitQty` stay `DOUBLE` on purpose — they're quantities, not money.

## Verification

- Guard passes (only the 2 quantities are float; all money is `DECIMAL`); an integration test asserts `polPrice` is `numeric(14,2)` via `information_schema`; PO suites green.
- `npm test` → **1810 passing**; `npm run lint` clean (CI-style). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/