### PR TITLE
test(custom-field): cover the remaining coercion + validation branches

### DIFF
--- a/tests/unit/custom-field.test.js
+++ b/tests/unit/custom-field.test.js
@@ -42,4 +42,25 @@ describe('custom-field (#409)', () => {
     test('optional empty fields are skipped', () => {
         expect(validateAgainstDefs(DEFS, { region: 'X' })).toEqual({ values: { region: 'X' } });
     });
+
+    test('boolean coercion accepts every truthy/falsy spelling', () => {
+        expect(coerceValue('boolean', true)).toEqual({ value: true });   // an actual boolean
+        expect(coerceValue('boolean', false)).toEqual({ value: false });
+        expect(coerceValue('boolean', 1)).toEqual({ value: true });
+        expect(coerceValue('boolean', '1')).toEqual({ value: true });
+        expect(coerceValue('boolean', 'false')).toEqual({ value: false });
+        expect(coerceValue('boolean', '0')).toEqual({ value: false });
+    });
+
+    test('a well-formatted but impossible date is rejected', () => {
+        // Passes the YYYY-MM-DD regex but is not a real calendar date → NaN.
+        expect(coerceValue('date', '2026-13-01').error).toBe('must be a YYYY-MM-DD date');
+    });
+
+    test('validateAgainstDefs tolerates a non-array defs / non-object values', () => {
+        // Non-array defs → treated as no defs → any supplied value is unknown.
+        expect(validateAgainstDefs(null, { region: 'X' }).errors).toMatchObject({ region: 'unknown custom field' });
+        // Non-object values → treated as {} → a required field is still flagged.
+        expect(validateAgainstDefs(DEFS, null).errors).toMatchObject({ region: 'is required' });
+    });
 });


### PR DESCRIPTION
## Summary

Coverage-pass follow-up (#604). `custom-field.js` had untested branches in `coerceValue` + `validateAgainstDefs`. Adds tests for:

- **boolean coercion of every accepted spelling** — an *actual* boolean, `1`, `'1'`, `'false'`, `'0'` (the existing test only hit the `'true'` string + `0`);
- a **well-formatted but impossible date** (`'2026-13-01'`) — passes the `YYYY-MM-DD` regex but isn't a real calendar date (`new Date` → NaN) → rejected;
- `validateAgainstDefs` **tolerating a non-array `defs`** (→ every value is unknown) and a **non-object `values`** (→ a required field is still flagged).

All confirm the pure logic behaves as documented. Test-only, no app change. `npm test` → **1820 passing**; `npm run lint` clean (CI-style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/