### PR TITLE
refactor(invoice): extract composeTotals + pin the discount/tax/total order

### DIFF
--- a/app/controllers/invoicecontroller.js
+++ b/app/controllers/invoicecontroller.js
@@ -422,14 +422,8 @@ exports.rollup = async (req, res) => {
             return res.status(500).json({ message: "Error!" });
         }
     }
-    // Discount applies to the subtotal before tax; clamp to [0, subtotal].
-    let discount = Number(req.body.discount);
-    if (!Number.isFinite(discount) || discount < 0) discount = 0;
-    if (money.subtract(subtotal, discount) < 0) discount = subtotal;
-    discount = money.round(discount);
-    const taxableBase = money.subtract(subtotal, discount);
-    const tax = invoiceTax.computeTax(taxableBase, taxRate);
-    const total = money.add(taxableBase, tax);
+    // Discount → tax-on-discounted-base → total (see invoiceTax.composeTotals).
+    const { discount, tax, total } = invoiceTax.composeTotals(subtotal, req.body.discount, taxRate);
 
     let result;
     try {
@@ -846,13 +840,8 @@ exports.fromPhase = async (req, res) => {
         }
     }
 
-    let discount = Number(body.discount);
-    if (!Number.isFinite(discount) || discount < 0) discount = 0;
-    if (money.subtract(subtotal, discount) < 0) discount = subtotal;
-    discount = money.round(discount);
-    const taxableBase = money.subtract(subtotal, discount);
-    const tax = invoiceTax.computeTax(taxableBase, taxRate);
-    const total = money.add(taxableBase, tax);
+    // Discount → tax-on-discounted-base → total (see invoiceTax.composeTotals).
+    const { discount, tax, total } = invoiceTax.composeTotals(subtotal, body.discount, taxRate);
 
     const invDate = body.invDate || todayISO();
     const invDueDate = body.invDueDate || addDaysISO(invDate, 30);

--- a/app/services/invoice-tax.js
+++ b/app/services/invoice-tax.js
@@ -37,4 +37,32 @@ function resolveRate({ override, companyDefault }) {
     return 0;
 }
 
-module.exports = { normalizeRate, computeTax, resolveRate };
+/**
+ * Compose an invoice's discount / tax / total from a subtotal, a raw discount
+ * request, and a resolved tax rate. The ORDER OF OPERATIONS is the invariant
+ * this pins (it's what makes the numbers right, and is easy to get wrong):
+ *
+ *   1. discount is clamped to [0, subtotal]  (a bad/negative one → 0; one
+ *      larger than the subtotal → the subtotal, so total never goes negative);
+ *   2. tax is computed on the POST-discount taxable base — NOT the raw
+ *      subtotal — so a discount reduces the tax too;
+ *   3. total = taxableBase + tax.
+ *
+ * Write-off is deliberately NOT part of the total: it settles the outstanding
+ * balance like a payment (see invoice-status.js), it doesn't reduce the bill.
+ *
+ * PURE. @returns { discount, taxableBase, tax, total } — all cent-rounded.
+ */
+function composeTotals(subtotal, rawDiscount, taxRate) {
+    const sub = subtotal == null ? 0 : subtotal;
+    let discount = Number(rawDiscount);
+    if (!Number.isFinite(discount) || discount < 0) discount = 0;
+    if (money.subtract(sub, discount) < 0) discount = sub;
+    discount = money.round(discount);
+    const taxableBase = money.subtract(sub, discount);
+    const tax = computeTax(taxableBase, taxRate);
+    const total = money.add(taxableBase, tax);
+    return { discount, taxableBase, tax, total };
+}
+
+module.exports = { normalizeRate, computeTax, resolveRate, composeTotals };

--- a/tests/unit/invoice-tax.test.js
+++ b/tests/unit/invoice-tax.test.js
@@ -5,7 +5,7 @@
 
 import { describe, test, expect } from 'vitest';
 
-const { normalizeRate, computeTax, resolveRate } = require('../../app/services/invoice-tax.js');
+const { normalizeRate, computeTax, resolveRate, composeTotals } = require('../../app/services/invoice-tax.js');
 
 describe('invoice-tax.normalizeRate', () => {
     test('passes fractions through, clamps out-of-range, zeroes junk', () => {
@@ -34,5 +34,31 @@ describe('invoice-tax.resolveRate', () => {
         expect(resolveRate({ override: null, companyDefault: 0.0725 })).toBe(0.0725);
         expect(resolveRate({ override: null, companyDefault: null })).toBe(0);
         expect(resolveRate({ override: 0 })).toBe(0); // explicit zero override is honored
+    });
+});
+
+describe('invoice-tax.composeTotals — the discount→tax→total order of operations', () => {
+    test('tax is charged on the POST-discount base, not the raw subtotal', () => {
+        // 1000 − 200 discount = 800 taxable; 10% → 80 tax (NOT 100 on the 1000).
+        expect(composeTotals(1000, 200, 0.1)).toEqual({ discount: 200, taxableBase: 800, tax: 80, total: 880 });
+    });
+
+    test('no discount → tax on the full subtotal', () => {
+        expect(composeTotals(1000, 0, 0.1)).toEqual({ discount: 0, taxableBase: 1000, tax: 100, total: 1100 });
+        // A missing/undefined discount behaves as 0.
+        expect(composeTotals(1000, undefined, 0.1)).toEqual({ discount: 0, taxableBase: 1000, tax: 100, total: 1100 });
+    });
+
+    test('a discount larger than the subtotal is clamped so the total never goes negative', () => {
+        expect(composeTotals(500, 900, 0.1)).toEqual({ discount: 500, taxableBase: 0, tax: 0, total: 0 });
+    });
+
+    test('a negative / junk discount is treated as 0', () => {
+        expect(composeTotals(1000, -50, 0.2)).toEqual({ discount: 0, taxableBase: 1000, tax: 200, total: 1200 });
+        expect(composeTotals(1000, 'nope', 0)).toEqual({ discount: 0, taxableBase: 1000, tax: 0, total: 1000 });
+    });
+
+    test('a null subtotal composes to all zeros', () => {
+        expect(composeTotals(null, 100, 0.1)).toEqual({ discount: 0, taxableBase: 0, tax: 0, total: 0 });
     });
 });


### PR DESCRIPTION
## Summary

A correctness re-read of the invoice money math confirmed the order of operations is **right** — discount clamped to `[0, subtotal]` → tax on the **post-discount** taxable base → `total = base + tax`; write-off settles the *balance* separately (not the total). But the exact block was **duplicated inline in two handlers** (rollup + create-from-phase) and wasn't unit-tested in isolation, so nothing *pinned* the invariant.

- Extract **`invoiceTax.composeTotals(subtotal, rawDiscount, taxRate)` → `{ discount, taxableBase, tax, total }`** — the single source of truth for the ordering. Both controller sites call it now (de-dupes ~7 identical lines each). **Behavior-preserving**: `composeTotals(1000, 200, 0.1)` = tax **80** on the discounted 800, total **880** — identical to the old inline math.
- **Unit tests pin the invariant** that would be easy to regress: tax on the post-discount base (80, not 100), the no-discount case, discount clamped to subtotal (no negative total), negative/junk discount → 0, null subtotal → 0.

## Verification

`npm test` → **1825 passing** (invoice rollup / from-phase / tax suites stay green); `npm run lint` clean (CI-style). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/