### PR TITLE
fix(retainer): bound retainer amounts like every other money field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is unchanged.
 
 ### Fixed
+- **Retainer amounts reject out-of-range values (400, not 500).** `retAmount`
+  and the drawdown `amount` shared a `.finite().positive()` validator with no
+  upper bound, so an absurd value (e.g. `1e12`) overflowed `NUMERIC(14,2)` → a
+  500 instead of a clean 400 — a money-bound the earlier `.max()` sweep applied
+  to `expAmount`/`phaseBudgetAmount` but missed here. Now capped at
+  `999,999,999.99` like every other money field. The drawdown arithmetic
+  itself (positive-amount required, overdraw → 409, exact-cent) was verified
+  sound.
 - **`polPrice` is now exact-decimal money (#587 follow-up).** The
   purchase-order-line unit price (a money value; negative lines are inline
   credits) was left as `DOUBLE` when its sibling money columns (`cpayAmount`,

--- a/app/schemas/retainer.schema.js
+++ b/app/schemas/retainer.schema.js
@@ -8,7 +8,12 @@ const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
 });
 
-const positiveAmount = z.coerce.number().finite().positive();
+// Bounded like every other money field (max 999,999,999.99) so an absurd
+// amount returns a clean 400 instead of overflowing NUMERIC(14,2) → 500, and
+// never overflows money.toCents. Covers both retAmount (create) and the
+// drawdown amount.
+const positiveAmount = z.coerce.number().finite().positive()
+    .max(999999999.99, { message: 'amount is out of range (max 999,999,999.99).' });
 
 /** POST /v1/retainer body. retCustId + retAmount required. */
 const createRetainerBody = z.object({

--- a/tests/api/retainer.test.js
+++ b/tests/api/retainer.test.js
@@ -35,11 +35,17 @@ describe('Retainer auth + schema contract', () => {
     test('POST /v1/retainer 400 on a non-positive retAmount (schema)', async () => {
         expect((await request(app).post('/v1/retainer').set('authKey', 'k').send({ retCustId: 1, retAmount: 0 })).status).toBe(400);
     });
+    test('POST /v1/retainer 400 on an out-of-range retAmount (would overflow NUMERIC(14,2))', async () => {
+        expect((await request(app).post('/v1/retainer').set('authKey', 'k').send({ retCustId: 1, retAmount: 1e12 })).status).toBe(400);
+    });
     test('POST /v1/retainer/:id/drawdown 403 without authKey (valid body)', async () => {
         expect((await request(app).post('/v1/retainer/1/drawdown').send({ amount: 100 })).status).toBe(403);
     });
     test('POST /v1/retainer/:id/drawdown 400 on a non-positive amount (schema)', async () => {
         expect((await request(app).post('/v1/retainer/1/drawdown').set('authKey', 'k').send({ amount: -5 })).status).toBe(400);
+    });
+    test('POST /v1/retainer/:id/drawdown 400 on an out-of-range amount (schema)', async () => {
+        expect((await request(app).post('/v1/retainer/1/drawdown').set('authKey', 'k').send({ amount: 1e12 })).status).toBe(400);
     });
     test('GET /v1/retainer/:id 403 without authKey', async () => {
         expect((await request(app).get('/v1/retainer/1')).status).toBe(403);


### PR DESCRIPTION
## Summary

A correctness re-read of the retainer drawdown found the **arithmetic sound** — positive-amount required (NaN-safe via `!(amount > 0)`), overdraw rejected with **409** so the balance can't go negative, exact-cent via `money.js`. But the shared `positiveAmount` validator (used for `retAmount` on create **and** the drawdown `amount`) was `.finite().positive()` with **no upper bound**.

An absurd value (e.g. `1e12`) therefore passed validation and **overflowed the `NUMERIC(14,2)` column → a 500 instead of a clean 400**. This is the same money-bound the earlier `.max()` sweep added to `expAmount` / `phaseBudgetAmount` but **missed for the retainer fields**.

- Cap `positiveAmount` at **`999,999,999.99`** (matching every other money field), so an out-of-range `retAmount` or drawdown amount returns **400**.
- Tests: `POST /v1/retainer` and the drawdown endpoint 400 on `1e12`.

`npm test` → **1827 passing**; `npm run lint` clean (CI-style). Lone failure is the pre-existing `Sequelize authenticates` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/