### PR TITLE
docs(schemas): fix stale "DOUBLE column" comments after the NUMERIC migrations

### DIFF
--- a/app/schemas/billingtype.schema.js
+++ b/app/schemas/billingtype.schema.js
@@ -8,12 +8,12 @@ const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
 });
 
-// `btHourlyRate` is a Sequelize DOUBLE column for the hourly rate
-// charged against a BillingType. `.nonnegative()` blocks negatives
+// `btHourlyRate` is the hourly rate charged against a BillingType (a
+// NUMERIC(14,2) money column). `.nonnegative()` blocks negatives
 // (a -$50/hr rate is operator error) but DOES NOT block `Infinity`
 // — `Infinity >= 0` is true. The coerce path also turns the string
 // `"Infinity"` into the float, so JSON without an Infinity literal
-// can still land `inf` in the column and contaminate downstream
+// can still reach money.multiply as `inf` and contaminate downstream
 // invoice/time-entry totals.
 //
 // Chain `.finite()` ahead of `.nonnegative()` to reject the

--- a/app/schemas/customerpayment.schema.js
+++ b/app/schemas/customerpayment.schema.js
@@ -16,7 +16,8 @@ const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
 // error (recording a "$0 payment" against a customer ledger has no
 // business meaning); Infinity/-Infinity is data-quality error from
 // pathological clients — `z.number()` rejects NaN but allows the
-// infinities by default, and a DOUBLE column will happily store them.
+// infinities by default, and they overflow money.toCents() (and the
+// NUMERIC(14,2) column errors on them) downstream.
 // Negative values pass — some operators model refunds that way.
 // Bound the magnitude (negatives allowed — a reversal/credit): an unbounded
 // but finite value (e.g. 1e308) survives `.finite()` and later overflows

--- a/app/schemas/invoicejob.schema.js
+++ b/app/schemas/invoicejob.schema.js
@@ -10,8 +10,8 @@ const intIdParam = z.object({
 
 // `injbAmount` is the per-line monetary value on an invoice. zod's
 // `.number()` rejects NaN by default but allows Infinity / -Infinity
-// through, and the column is a Sequelize DOUBLE — `inf` lands in the
-// database fine and contaminates any consumer doing arithmetic
+// through, and although the column is now NUMERIC(14,2), an `inf`
+// still overflows money.toCents() and contaminates any consumer doing arithmetic
 // (invoice totals, aging buckets, CSV exports). Pin to finite real
 // numbers at the boundary. Zero and negative values still pass (a
 // $0 reference line and a credit/discount line are both real

--- a/app/schemas/purchaseorderline.schema.js
+++ b/app/schemas/purchaseorderline.schema.js
@@ -8,8 +8,8 @@ const intIdParam = z.object({
     id: z.coerce.number().int().positive(),
 });
 
-// PO-line quantity + per-unit price. Both are stored as Sequelize
-// DOUBLE columns. zod's `.number()` rejects NaN by default but lets
+// PO-line quantity + per-unit price. `polQty` is a DOUBLE quantity;
+// `polPrice` is a NUMERIC(14,2) money column. zod's `.number()` rejects NaN but lets
 // `Infinity` / `-Infinity` slip through — and the coerce path turns
 // the string `"Infinity"` into the float. An `inf` in either column
 // would silently corrupt every downstream calculation (PO totals,


### PR DESCRIPTION
## Summary

A systematic money-bound audit (prompted by the retainer fix #608) **confirmed every money field is now bounded** — and turned up stale comments. `cpayAmount`, `btHourlyRate`, `injbAmount`, and `polPrice` were converted `DOUBLE → NUMERIC(14,2)` (#587 / #602), but their schema comments still describe them as *"Sequelize DOUBLE columns"* and reason that `inf` *"lands in the column fine"*. With a `NUMERIC` column an `Infinity` would actually **error at write**; the real still-live rationale for `.finite()` + the magnitude bound is the `money.toCents()` overflow. This corrects the four comments to say `NUMERIC(14,2)` and point at the accurate mechanism.

The remaining `DOUBLE` comments (`invitQty`, `polQty`) are **correct** — those are fractional *quantities* that stay DOUBLE by design.

**Comments-only** — no behavior, schema, or test change. Affected api suites (62 tests) green; `npm run lint` clean (CI-style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFbcRXcdz7L5J2E2BnXJJ

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/